### PR TITLE
[feat] #40 - 소개 관련 공연 정보 조회 GET API 구현

### DIFF
--- a/src/main/java/com/beat/domain/cast/dao/CastRepository.java
+++ b/src/main/java/com/beat/domain/cast/dao/CastRepository.java
@@ -1,0 +1,10 @@
+package com.beat.domain.cast.dao;
+
+import com.beat.domain.cast.domain.Cast;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CastRepository extends JpaRepository<Cast, Long> {
+    List<Cast> findByPerformanceId(Long performanceId);
+}

--- a/src/main/java/com/beat/domain/performance/api/PerformanceController.java
+++ b/src/main/java/com/beat/domain/performance/api/PerformanceController.java
@@ -1,0 +1,2 @@
+package com.beat.domain.performance.api;public class PerformanceController {
+}

--- a/src/main/java/com/beat/domain/performance/api/PerformanceController.java
+++ b/src/main/java/com/beat/domain/performance/api/PerformanceController.java
@@ -1,2 +1,27 @@
-package com.beat.domain.performance.api;public class PerformanceController {
+package com.beat.domain.performance.api;
+
+import com.beat.domain.performance.application.dto.PerformanceDetailResponse;
+import com.beat.domain.performance.exception.PerformanceSuccessCode;
+import com.beat.domain.performance.application.PerformanceService;
+import com.beat.global.common.dto.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/performances")
+@RequiredArgsConstructor
+public class PerformanceController {
+
+    private final PerformanceService performanceService;
+
+    @GetMapping("/detail/{performanceId}")
+    public ResponseEntity<SuccessResponse<PerformanceDetailResponse>> getPerformanceDetail(
+            @PathVariable Long performanceId) {
+        PerformanceDetailResponse performanceDetail = performanceService.getPerformanceDetail(performanceId);
+        return ResponseEntity.ok(SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_RETRIEVE_SUCCESS, performanceDetail));
+    }
 }

--- a/src/main/java/com/beat/domain/performance/application/PerformanceService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceService.java
@@ -1,2 +1,73 @@
-package com.beat.domain.performance.application;public class PerformanceService {
+package com.beat.domain.performance.application;
+
+import com.beat.domain.performance.application.dto.PerformanceDetailResponse;
+import com.beat.domain.performance.dao.PerformanceRepository;
+import com.beat.domain.performance.domain.Performance;
+import com.beat.domain.performance.exception.PerformanceErrorCode;
+import com.beat.domain.schedule.dao.ScheduleRepository;
+import com.beat.domain.cast.dao.CastRepository;
+import com.beat.domain.staff.dao.StaffRepository;
+import com.beat.global.common.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceService {
+
+    private final PerformanceRepository performanceRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final CastRepository castRepository;
+    private final StaffRepository staffRepository;
+
+    @Transactional(readOnly = true)
+    public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {
+        Performance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(() -> new NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND));
+
+        List<PerformanceDetailResponse.ScheduleDetail> scheduleList = scheduleRepository.findByPerformanceId(performanceId).stream()
+                .map(schedule -> PerformanceDetailResponse.ScheduleDetail.of(
+                        schedule.getId(),
+                        schedule.getPerformanceDate(),
+                        schedule.getScheduleNumber().name()
+                )).collect(Collectors.toList());
+
+        List<PerformanceDetailResponse.CastDetail> castList = castRepository.findByPerformanceId(performanceId).stream()
+                .map(cast -> PerformanceDetailResponse.CastDetail.of(
+                        cast.getId(),
+                        cast.getCastName(),
+                        cast.getCastRole(),
+                        cast.getCastPhoto()
+                )).collect(Collectors.toList());
+
+        List<PerformanceDetailResponse.StaffDetail> staffList = staffRepository.findByPerformanceId(performanceId).stream()
+                .map(staff -> PerformanceDetailResponse.StaffDetail.of(
+                        staff.getId(),
+                        staff.getStaffName(),
+                        staff.getStaffRole(),
+                        staff.getStaffPhoto()
+                )).collect(Collectors.toList());
+
+        return PerformanceDetailResponse.of(
+                performance.getId(),
+                performance.getPerformanceTitle(),
+                performance.getPerformancePeriod(),
+                scheduleList,
+                performance.getTicketPrice(),
+                performance.getGenre().name(),
+                performance.getPosterImage(),
+                performance.getRunningTime(),
+                performance.getPerformanceVenue(),
+                performance.getPerformanceDescription(),
+                performance.getPerformanceAttentionNote(),
+                performance.getPerformanceContact(),
+                performance.getPerformanceTeamName(),
+                castList,
+                staffList
+        );
+    }
 }

--- a/src/main/java/com/beat/domain/performance/application/PerformanceService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceService.java
@@ -1,6 +1,9 @@
 package com.beat.domain.performance.application;
 
+import com.beat.domain.performance.application.dto.PerformanceDetailCast;
 import com.beat.domain.performance.application.dto.PerformanceDetailResponse;
+import com.beat.domain.performance.application.dto.PerformanceDetailSchedule;
+import com.beat.domain.performance.application.dto.PerformanceDetailStaff;
 import com.beat.domain.performance.dao.PerformanceRepository;
 import com.beat.domain.performance.domain.Performance;
 import com.beat.domain.performance.exception.PerformanceErrorCode;
@@ -29,23 +32,23 @@ public class PerformanceService {
         Performance performance = performanceRepository.findById(performanceId)
                 .orElseThrow(() -> new NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND));
 
-        List<PerformanceDetailResponse.ScheduleDetail> scheduleList = scheduleRepository.findByPerformanceId(performanceId).stream()
-                .map(schedule -> PerformanceDetailResponse.ScheduleDetail.of(
+        List<PerformanceDetailSchedule> scheduleList = scheduleRepository.findByPerformanceId(performanceId).stream()
+                .map(schedule -> PerformanceDetailSchedule.of(
                         schedule.getId(),
                         schedule.getPerformanceDate(),
                         schedule.getScheduleNumber().name()
                 )).collect(Collectors.toList());
 
-        List<PerformanceDetailResponse.CastDetail> castList = castRepository.findByPerformanceId(performanceId).stream()
-                .map(cast -> PerformanceDetailResponse.CastDetail.of(
+        List<PerformanceDetailCast> castList = castRepository.findByPerformanceId(performanceId).stream()
+                .map(cast -> PerformanceDetailCast.of(
                         cast.getId(),
                         cast.getCastName(),
                         cast.getCastRole(),
                         cast.getCastPhoto()
                 )).collect(Collectors.toList());
 
-        List<PerformanceDetailResponse.StaffDetail> staffList = staffRepository.findByPerformanceId(performanceId).stream()
-                .map(staff -> PerformanceDetailResponse.StaffDetail.of(
+        List<PerformanceDetailStaff> staffList = staffRepository.findByPerformanceId(performanceId).stream()
+                .map(staff -> PerformanceDetailStaff.of(
                         staff.getId(),
                         staff.getStaffName(),
                         staff.getStaffRole(),

--- a/src/main/java/com/beat/domain/performance/application/PerformanceService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceService.java
@@ -1,0 +1,2 @@
+package com.beat.domain.performance.application;public class PerformanceService {
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailCast.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailCast.java
@@ -1,0 +1,12 @@
+package com.beat.domain.performance.application.dto;
+
+public record PerformanceDetailCast(
+        Long castId,
+        String castName,
+        String castRole,
+        String castPhoto
+) {
+    public static PerformanceDetailCast of(Long castId, String castName, String castRole, String castPhoto) {
+        return new PerformanceDetailCast(castId, castName, castRole, castPhoto);
+    }
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
@@ -1,2 +1,74 @@
-package com.beat.domain.performance.application.dto;public class PerformanceDetailResponse {
+package com.beat.domain.performance.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PerformanceDetailResponse(
+        Long performanceId,
+        String performanceTitle,
+        String performancePeriod,
+        List<ScheduleDetail> scheduleList,
+        int ticketPrice,
+        String genre,
+        String posterImage,
+        int runningTime,
+        String performanceVenue,
+        String performanceDescription,
+        String performanceAttentionNote,
+        String performanceContact,
+        String performanceTeamName,
+        List<CastDetail> castList,
+        List<StaffDetail> staffList
+) {
+    public static PerformanceDetailResponse of(
+            Long performanceId,
+            String performanceTitle,
+            String performancePeriod,
+            List<ScheduleDetail> scheduleList,
+            int ticketPrice,
+            String genre,
+            String posterImage,
+            int runningTime,
+            String performanceVenue,
+            String performanceDescription,
+            String performanceAttentionNote,
+            String performanceContact,
+            String performanceTeamName,
+            List<CastDetail> castList,
+            List<StaffDetail> staffList
+    ) {
+        return new PerformanceDetailResponse(performanceId, performanceTitle, performancePeriod, scheduleList, ticketPrice, genre, posterImage, runningTime, performanceVenue, performanceDescription, performanceAttentionNote, performanceContact, performanceTeamName, castList, staffList);
+    }
+
+    public record ScheduleDetail(
+            Long scheduleId,
+            LocalDateTime performanceDate,
+            String scheduleNumber
+    ) {
+        public static ScheduleDetail of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber) {
+            return new ScheduleDetail(scheduleId, performanceDate, scheduleNumber);
+        }
+    }
+
+    public record CastDetail(
+            Long castId,
+            String castName,
+            String castRole,
+            String castPhoto
+    ) {
+        public static CastDetail of(Long castId, String castName, String castRole, String castPhoto) {
+            return new CastDetail(castId, castName, castRole, castPhoto);
+        }
+    }
+
+    public record StaffDetail(
+            Long staffId,
+            String staffName,
+            String staffRole,
+            String staffPhoto
+    ) {
+        public static StaffDetail of(Long staffId, String staffName, String staffRole, String staffPhoto) {
+            return new StaffDetail(staffId, staffName, staffRole, staffPhoto);
+        }
+    }
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
@@ -1,13 +1,12 @@
 package com.beat.domain.performance.application.dto;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record PerformanceDetailResponse(
         Long performanceId,
         String performanceTitle,
         String performancePeriod,
-        List<ScheduleDetail> scheduleList,
+        List<PerformanceDetailSchedule> scheduleList,
         int ticketPrice,
         String genre,
         String posterImage,
@@ -17,14 +16,14 @@ public record PerformanceDetailResponse(
         String performanceAttentionNote,
         String performanceContact,
         String performanceTeamName,
-        List<CastDetail> castList,
-        List<StaffDetail> staffList
+        List<PerformanceDetailCast> castList,
+        List<PerformanceDetailStaff> staffList
 ) {
     public static PerformanceDetailResponse of(
             Long performanceId,
             String performanceTitle,
             String performancePeriod,
-            List<ScheduleDetail> scheduleList,
+            List<PerformanceDetailSchedule> scheduleList,
             int ticketPrice,
             String genre,
             String posterImage,
@@ -34,41 +33,11 @@ public record PerformanceDetailResponse(
             String performanceAttentionNote,
             String performanceContact,
             String performanceTeamName,
-            List<CastDetail> castList,
-            List<StaffDetail> staffList
+            List<PerformanceDetailCast> castList,
+            List<PerformanceDetailStaff> staffList
     ) {
         return new PerformanceDetailResponse(performanceId, performanceTitle, performancePeriod, scheduleList, ticketPrice, genre, posterImage, runningTime, performanceVenue, performanceDescription, performanceAttentionNote, performanceContact, performanceTeamName, castList, staffList);
     }
 
-    public record ScheduleDetail(
-            Long scheduleId,
-            LocalDateTime performanceDate,
-            String scheduleNumber
-    ) {
-        public static ScheduleDetail of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber) {
-            return new ScheduleDetail(scheduleId, performanceDate, scheduleNumber);
-        }
-    }
 
-    public record CastDetail(
-            Long castId,
-            String castName,
-            String castRole,
-            String castPhoto
-    ) {
-        public static CastDetail of(Long castId, String castName, String castRole, String castPhoto) {
-            return new CastDetail(castId, castName, castRole, castPhoto);
-        }
-    }
-
-    public record StaffDetail(
-            Long staffId,
-            String staffName,
-            String staffRole,
-            String staffPhoto
-    ) {
-        public static StaffDetail of(Long staffId, String staffName, String staffRole, String staffPhoto) {
-            return new StaffDetail(staffId, staffName, staffRole, staffPhoto);
-        }
-    }
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
@@ -1,0 +1,2 @@
+package com.beat.domain.performance.application.dto;public class PerformanceDetailResponse {
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailSchedule.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailSchedule.java
@@ -1,0 +1,13 @@
+package com.beat.domain.performance.application.dto;
+
+import java.time.LocalDateTime;
+
+public record PerformanceDetailSchedule(
+        Long scheduleId,
+        LocalDateTime performanceDate,
+        String scheduleNumber
+) {
+    public static PerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber) {
+        return new PerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber);
+    }
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailStaff.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailStaff.java
@@ -1,0 +1,12 @@
+package com.beat.domain.performance.application.dto;
+
+public record PerformanceDetailStaff(
+        Long staffId,
+        String staffName,
+        String staffRole,
+        String staffPhoto
+) {
+    public static PerformanceDetailStaff of(Long staffId, String staffName, String staffRole, String staffPhoto) {
+        return new PerformanceDetailStaff(staffId, staffName, staffRole, staffPhoto);
+    }
+}

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -1,2 +1,14 @@
-package com.beat.domain.performance.exception;public enum PerformanceErrorCode {
+package com.beat.domain.performance.exception;
+
+import com.beat.global.common.exception.base.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PerformanceErrorCode implements BaseErrorCode {
+    PERFORMANCE_NOT_FOUND(404, "해당 공연 정보를 찾을 수 없습니다.");
+
+    private final int status;
+    private final String message;
 }

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -1,0 +1,2 @@
+package com.beat.domain.performance.exception;public enum PerformanceErrorCode {
+}

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
@@ -1,0 +1,2 @@
+package com.beat.domain.performance.exception;public class PerformanceSuccessCode {
+}

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
@@ -1,2 +1,14 @@
-package com.beat.domain.performance.exception;public class PerformanceSuccessCode {
+package com.beat.domain.performance.exception;
+
+import com.beat.global.common.exception.base.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PerformanceSuccessCode implements BaseSuccessCode {
+    PERFORMANCE_RETRIEVE_SUCCESS(200, "공연 상세 정보 조회가 성공적으로 완료되었습니다.");
+
+    private final int status;
+    private final String message;
 }

--- a/src/main/java/com/beat/domain/schedule/dao/ScheduleRepository.java
+++ b/src/main/java/com/beat/domain/schedule/dao/ScheduleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -14,4 +15,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM Schedule s WHERE s.id = :id")
     Optional<Schedule> lockById(@Param("id") Long id);
+
+    List<Schedule> findByPerformanceId(Long performanceId);
 }

--- a/src/main/java/com/beat/domain/staff/dao/StaffRepository.java
+++ b/src/main/java/com/beat/domain/staff/dao/StaffRepository.java
@@ -1,0 +1,10 @@
+package com.beat.domain.staff.dao;
+
+import com.beat.domain.staff.domain.Staff;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StaffRepository extends JpaRepository<Staff, Long> {
+    List<Staff> findByPerformanceId(Long performanceId);
+}

--- a/src/main/java/com/beat/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/beat/global/common/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.beat.global.auth.security.CustomJwtAuthenticationEntryPoint;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -31,6 +32,7 @@ public class SecurityConfig {
             "/api/v1/v3/api-docs/**",
             "/api/v1/swagger-ui/**",
             "/api/v1/swagger-resources/**",
+            "/api/performances/detail/**"
 //            "/login/oauth2/code/kakao",
 //            "/kakao/callback"
     };


### PR DESCRIPTION
## Related issue 🛠

- closes #40 

## Work Description ✏️

공연 상세 페이지에 들어갈 소개 관련 공연 정보 조회 GET API 구현

## Trouble Shooting ⚽️

소소하지만 토큰 검증 필요 없는 경로는 AUTH_WHITELIST에 추가해야한다는 점을 재확인했습니다.

## Related ScreenShot 📷

### 존재하는 공연의 상세 정보 조회할 때
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/9b2f7026-4296-47c6-ae3d-6f153f532b47">

### 존재하지 않는 공연의 상세 정보 조회할 때
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/7446d828-b757-44c5-85b1-037f1ee3f712">

## Uncompleted Tasks 😅

x

## To Reviewers 📢

x