### PR TITLE
[feat] #42 - 예매 관련 공연 정보 GET API 구현

### DIFF
--- a/src/main/java/com/beat/domain/performance/api/PerformanceController.java
+++ b/src/main/java/com/beat/domain/performance/api/PerformanceController.java
@@ -1,5 +1,6 @@
 package com.beat.domain.performance.api;
 
+import com.beat.domain.performance.application.dto.BookingPerformanceDetailResponse;
 import com.beat.domain.performance.application.dto.PerformanceDetailResponse;
 import com.beat.domain.performance.exception.PerformanceSuccessCode;
 import com.beat.domain.performance.application.PerformanceService;
@@ -23,5 +24,12 @@ public class PerformanceController {
             @PathVariable Long performanceId) {
         PerformanceDetailResponse performanceDetail = performanceService.getPerformanceDetail(performanceId);
         return ResponseEntity.ok(SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_RETRIEVE_SUCCESS, performanceDetail));
+    }
+
+    @GetMapping("/booking/{performanceId}")
+    public ResponseEntity<SuccessResponse<BookingPerformanceDetailResponse>> getBookingPerformanceDetail(
+            @PathVariable Long performanceId) {
+        BookingPerformanceDetailResponse bookingPerformanceDetail = performanceService.getBookingPerformanceDetail(performanceId);
+        return ResponseEntity.ok(SuccessResponse.of(PerformanceSuccessCode.BOOKING_PERFORMANCE_RETRIEVE_SUCCESS, bookingPerformanceDetail));
     }
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/BookingPerformanceDetailResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/BookingPerformanceDetailResponse.java
@@ -1,0 +1,30 @@
+package com.beat.domain.performance.application.dto;
+
+import java.util.List;
+
+public record BookingPerformanceDetailResponse(
+        Long performanceId,
+        String performanceTitle,
+        String performancePeriod,
+        List<BookingPerformanceDetailSchedule> scheduleList,
+        int ticketPrice,
+        String genre,
+        String posterImage,
+        String performanceVenue,
+        String performanceTeamName
+) {
+    public static BookingPerformanceDetailResponse of(
+            Long performanceId,
+            String performanceTitle,
+            String performancePeriod,
+            List<BookingPerformanceDetailSchedule> scheduleList,
+            int ticketPrice,
+            String genre,
+            String posterImage,
+            String performanceVenue,
+            String performanceTeamName
+    ) {
+        return new BookingPerformanceDetailResponse(performanceId, performanceTitle, performancePeriod, scheduleList, ticketPrice, genre, posterImage, performanceVenue, performanceTeamName);
+    }
+
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/BookingPerformanceDetailSchedule.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/BookingPerformanceDetailSchedule.java
@@ -1,0 +1,16 @@
+package com.beat.domain.performance.application.dto;
+
+import java.time.LocalDateTime;
+
+public record BookingPerformanceDetailSchedule(
+        Long scheduleId,
+        LocalDateTime performanceDate,
+        String scheduleNumber,
+        int availableTicketCount,
+        boolean isBooking
+) {
+    public static BookingPerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber, int availableTicketCount, boolean isBooking) {
+        return new BookingPerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber, availableTicketCount, isBooking);
+    }
+
+}

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PerformanceSuccessCode implements BaseSuccessCode {
-    PERFORMANCE_RETRIEVE_SUCCESS(200, "공연 상세 정보 조회가 성공적으로 완료되었습니다.");
+    PERFORMANCE_RETRIEVE_SUCCESS(200, "공연 상세 정보 조회가 성공적으로 완료되었습니다."),
+    BOOKING_PERFORMANCE_RETRIEVE_SUCCESS(200, "예매 관련 공연 정보 조회가 성공적으로 완료되었습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/beat/domain/schedule/application/ScheduleService.java
+++ b/src/main/java/com/beat/domain/schedule/application/ScheduleService.java
@@ -27,7 +27,7 @@ public class ScheduleService {
                 () -> new NotFoundException(ScheduleErrorCode.NO_SCHEDULE_FOUND)
         );
 
-        int availableTicketCount = schedule.getTotalTicketCount() - schedule.getSoldTicketCount();
+        int availableTicketCount = getAvailableTicketCount(schedule);
         boolean isAvailable = availableTicketCount >= ticketAvailabilityRequest.purchaseTicketCount();
 
         if (!isAvailable) {

--- a/src/main/java/com/beat/domain/schedule/application/ScheduleService.java
+++ b/src/main/java/com/beat/domain/schedule/application/ScheduleService.java
@@ -10,6 +10,9 @@ import com.beat.global.common.exception.ConflictException;
 import com.beat.global.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -45,6 +48,24 @@ public class ScheduleService {
     private void validateRequest(Long scheduleId, TicketAvailabilityRequest ticketAvailabilityRequest) {
         if (ticketAvailabilityRequest.purchaseTicketCount() <= 0 || scheduleId <= 0) {
             throw new BadRequestException(ScheduleErrorCode.INVALID_DATA_FORMAT);
+        }
+    }
+
+    public int getAvailableTicketCount(Schedule schedule) {
+        return schedule.getTotalTicketCount() - schedule.getSoldTicketCount();
+    }
+
+    public boolean isBookingAvailable(Schedule schedule) {
+        int availableTicketCount = getAvailableTicketCount(schedule);
+        return schedule.isBooking() && availableTicketCount > 0 && schedule.getPerformanceDate().isAfter(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void updateBookingStatus(Schedule schedule) {
+        boolean isBookingAvailable = isBookingAvailable(schedule);
+        if (schedule.isBooking() != isBookingAvailable) {
+            schedule.setBooking(isBookingAvailable);
+            scheduleRepository.save(schedule);
         }
     }
 }

--- a/src/main/java/com/beat/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/beat/global/common/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
             "/api/v1/v3/api-docs/**",
             "/api/v1/swagger-ui/**",
             "/api/v1/swagger-resources/**",
-            "/api/performances/detail/**"
+            "/api/performances/detail/**",
+            "/api/performances/booking/**",
 //            "/login/oauth2/code/kakao",
 //            "/kakao/callback"
     };


### PR DESCRIPTION
## Related issue 🛠

- closes #42 

## Work Description ✏️

- 예매하기 페이지에 접속했을 때 보여질 예매 관련 공연 정보 조회 GET API 구현
- 예매하기 페이지에 접속했을 때 당시의 잔여 티켓 수 확인하는 로직 구현
- 예매 가능 여부를 확인하는 로직 구현
- 예매 가능 여부가 바뀌었을 때 db에 반영하는 로직 구현

## Trouble Shooting ⚽️


## Related ScreenShot 📷

- 예매하기에 필요한 공연 상세정보 조회 성공
<img width="717" alt="image" src="https://github.com/user-attachments/assets/b2195bb4-bcea-4ec2-b477-05057b74de6b">
isBooking default인 true가 위 조회 이후 아래처럼 db에 false로 업데이트 됨
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/0c44342b-86a4-4ea3-a261-4f21e56a4eab">


- 없는 공연 조회 시도 했을 때의 실패
<img width="716" alt="image" src="https://github.com/user-attachments/assets/8e99b0de-eb1e-45cb-b0a9-ada6e86e5228">

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
ScheduleService에 만들어둔 잔여티켓 계산 로직인 getAvailableTicketCount는 위에 findTicketAvailability에서도 사용하면 좋을 것 같습니다!