### PR TITLE
[feat] #49 - 예매자 관리 API 구현

### DIFF
--- a/src/main/java/com/beat/domain/booking/api/TicketController.java
+++ b/src/main/java/com/beat/domain/booking/api/TicketController.java
@@ -1,0 +1,53 @@
+package com.beat.domain.booking.api;
+
+import com.beat.domain.booking.application.TicketService;
+import com.beat.domain.booking.application.dto.TicketDeleteRequest;
+import com.beat.domain.booking.application.dto.TicketRetrieveResponse;
+import com.beat.domain.booking.application.dto.TicketUpdateRequest;
+import com.beat.domain.booking.exception.BookingSuccessCode;
+import com.beat.global.auth.annotation.CurrentMember;
+import com.beat.global.common.dto.SuccessResponse;
+import com.beat.domain.schedule.domain.ScheduleNumber;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/tickets")
+@RequiredArgsConstructor
+public class TicketController {
+
+    private final TicketService ticketService;
+
+    @Operation(summary = "예매자 목록 조회 API", description = "메이커가 자신의 공연에 대한 예매자 목록을 조회하는 GET API입니다.")
+    @GetMapping("/{performanceId}")
+    public ResponseEntity<SuccessResponse<TicketRetrieveResponse>> getTickets(
+            @CurrentMember Long memberId,
+            @PathVariable Long performanceId,
+            @RequestParam(required = false) ScheduleNumber scheduleNumber,
+            @RequestParam(required = false) Boolean isPaymentCompleted) {
+        TicketRetrieveResponse response = ticketService.getTickets(memberId, performanceId, scheduleNumber, isPaymentCompleted);
+        return ResponseEntity.ok(SuccessResponse.of(BookingSuccessCode.TICKET_RETRIEVE_SUCCESS, response));
+    }
+
+    @Operation(summary = "예매자 입금여부 수정 API", description = "메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정하는 PUT API입니다.")
+    @PutMapping("/{performanceId}")
+    public ResponseEntity<SuccessResponse<Void>> updateTickets(
+            @CurrentMember Long memberId,
+            @PathVariable Long performanceId,
+            @RequestBody TicketUpdateRequest request) {
+        ticketService.updateTickets(memberId, request);
+        return ResponseEntity.ok(SuccessResponse.of(BookingSuccessCode.TICKET_UPDATE_SUCCESS, null));
+    }
+
+    @Operation(summary = "예매자 삭제 API", description = "메이커가 자신의 공연에 대한 예매자의 정보를 삭제하는 DELETE API입니다.")
+    @DeleteMapping("/{performanceId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteTickets(
+            @CurrentMember Long memberId,
+            @PathVariable Long performanceId,
+            @RequestBody TicketDeleteRequest request) {
+        ticketService.deleteTickets(memberId, request);
+        return ResponseEntity.ok(SuccessResponse.of(BookingSuccessCode.TICKET_DELETE_SUCCESS, null));
+    }
+}

--- a/src/main/java/com/beat/domain/booking/application/dto/TicketDeleteRequest.java
+++ b/src/main/java/com/beat/domain/booking/application/dto/TicketDeleteRequest.java
@@ -1,0 +1,12 @@
+package com.beat.domain.booking.application.dto;
+
+import java.util.List;
+
+public record TicketDeleteRequest(
+        Long performanceId,
+        List<Long> bookingList
+) {
+    public static TicketDeleteRequest of(Long performanceId, List<Long> bookingList) {
+        return new TicketDeleteRequest(performanceId, bookingList);
+    }
+}

--- a/src/main/java/com/beat/domain/booking/application/dto/TicketDetail.java
+++ b/src/main/java/com/beat/domain/booking/application/dto/TicketDetail.java
@@ -1,0 +1,26 @@
+package com.beat.domain.booking.application.dto;
+
+import java.time.LocalDateTime;
+
+public record TicketDetail(
+        Long bookingId,
+        String bookerName,
+        String bookerPhoneNumber,
+        Long scheduleId,
+        int purchaseTicketCount,
+        LocalDateTime createdAt,
+        boolean isPaymentCompleted,
+        String scheduleNumber
+) {
+    public static TicketDetail of(
+            Long bookingId,
+            String bookerName,
+            String bookerPhoneNumber,
+            Long scheduleId,
+            int purchaseTicketCount,
+            LocalDateTime createdAt,
+            boolean isPaymentCompleted,
+            String scheduleNumber) {
+        return new TicketDetail(bookingId, bookerName, bookerPhoneNumber, scheduleId, purchaseTicketCount, createdAt, isPaymentCompleted, scheduleNumber);
+    }
+}

--- a/src/main/java/com/beat/domain/booking/application/dto/TicketRetrieveResponse.java
+++ b/src/main/java/com/beat/domain/booking/application/dto/TicketRetrieveResponse.java
@@ -1,2 +1,16 @@
-package com.beat.domain.booking.application.dto;public record TicketRetrieveResponse() {
+package com.beat.domain.booking.application.dto;
+
+import java.util.List;
+
+public record TicketRetrieveResponse(
+        String performanceTitle,
+        int totalScheduleCount,
+        List<TicketDetail> bookingList
+) {
+    public static TicketRetrieveResponse of(
+            String performanceTitle,
+            int totalScheduleCount,
+            List<TicketDetail> bookingList) {
+        return new TicketRetrieveResponse(performanceTitle, totalScheduleCount, bookingList);
+    }
 }

--- a/src/main/java/com/beat/domain/booking/application/dto/TicketUpdateDetail.java
+++ b/src/main/java/com/beat/domain/booking/application/dto/TicketUpdateDetail.java
@@ -1,0 +1,26 @@
+package com.beat.domain.booking.application.dto;
+
+import java.time.LocalDateTime;
+
+public record TicketUpdateDetail(
+        Long bookingId,
+        String bookerName,
+        String bookerPhoneNumber,
+        Long scheduleId,
+        int purchaseTicketCount,
+        LocalDateTime createdAt,
+        boolean isPaymentCompleted,
+        String scheduleNumber
+) {
+    public static TicketUpdateDetail of(
+            Long bookingId,
+            String bookerName,
+            String bookerPhoneNumber,
+            Long scheduleId,
+            int purchaseTicketCount,
+            LocalDateTime createdAt,
+            boolean isPaymentCompleted,
+            String scheduleNumber) {
+        return new TicketUpdateDetail(bookingId, bookerName, bookerPhoneNumber, scheduleId, purchaseTicketCount, createdAt, isPaymentCompleted, scheduleNumber);
+    }
+}

--- a/src/main/java/com/beat/domain/booking/application/dto/TicketUpdateRequest.java
+++ b/src/main/java/com/beat/domain/booking/application/dto/TicketUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.beat.domain.booking.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TicketUpdateRequest(
+        Long performanceId,
+        String performanceTitle,
+        int totalScheduleCount,
+        List<TicketUpdateDetail> bookingList
+) {
+    public static TicketUpdateRequest of(
+            Long performanceId,
+            String performanceTitle,
+            int totalScheduleCount,
+            List<TicketUpdateDetail> bookingList) {
+        return new TicketUpdateRequest(performanceId, performanceTitle, totalScheduleCount, bookingList);
+    }
+}

--- a/src/main/java/com/beat/domain/booking/dao/TicketRepository.java
+++ b/src/main/java/com/beat/domain/booking/dao/TicketRepository.java
@@ -1,2 +1,17 @@
-package com.beat.domain.booking.dao;public interface TicketRepository {
+package com.beat.domain.booking.dao;
+
+import com.beat.domain.booking.domain.Booking;
+import com.beat.domain.schedule.domain.ScheduleNumber;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TicketRepository extends JpaRepository<Booking, Long> {
+    List<Booking> findBySchedulePerformanceId(Long performanceId);
+
+    List<Booking> findBySchedulePerformanceIdAndScheduleScheduleNumber(Long performanceId, ScheduleNumber scheduleNumber);
+
+    List<Booking> findBySchedulePerformanceIdAndIsPaymentCompleted(Long performanceId, boolean isPaymentCompleted);
+
+    List<Booking> findBySchedulePerformanceIdAndScheduleScheduleNumberAndIsPaymentCompleted(Long performanceId, ScheduleNumber scheduleNumber, boolean isPaymentCompleted);
 }

--- a/src/main/java/com/beat/domain/booking/domain/Booking.java
+++ b/src/main/java/com/beat/domain/booking/domain/Booking.java
@@ -83,4 +83,9 @@ public class Booking {
                 .users(users)
                 .build();
     }
+
+    public void setIsPaymentCompleted(boolean isPaymentCompleted) {
+        this.isPaymentCompleted = isPaymentCompleted;
+    }
+
 }

--- a/src/main/java/com/beat/domain/booking/exception/BookingErrorCode.java
+++ b/src/main/java/com/beat/domain/booking/exception/BookingErrorCode.java
@@ -10,7 +10,10 @@ public enum BookingErrorCode implements BaseErrorCode {
     REQUIRED_DATA_MISSING(400, "필수 데이터가 누락되었습니다."),
     INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
     INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
-    NO_BOOKING_FOUND(404, "입력하신 정보와 일치하는 예매 내역이 없습니다. 확인 후 다시 조회해주세요.")
+    NO_BOOKING_FOUND(404, "입력하신 정보와 일치하는 예매 내역이 없습니다. 확인 후 다시 조회해주세요."),
+    NO_TICKETS_FOUND(404, "입력하신 정보와 일치하는 예매자 목록이 없습니다."),
+    NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
+    NO_SCHEDULE_FOUND(404, "회차를 찾을 수 없습니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/beat/domain/booking/exception/BookingSuccessCode.java
+++ b/src/main/java/com/beat/domain/booking/exception/BookingSuccessCode.java
@@ -10,7 +10,10 @@ public enum BookingSuccessCode implements BaseSuccessCode {
     MEMBER_BOOKING_SUCCESS(201, "회원 예매가 성공적으로 완료되었습니다"),
     GUEST_BOOKING_SUCCESS(201, "비회원 예매가 성공적으로 완료되었습니다"),
     MEMBER_BOOKING_RETRIEVE_SUCCESS(200, "회원 예매 조회가 성공적으로 완료되었습니다."),
-    GUEST_BOOKING_RETRIEVE_SUCCESS(200, "비회원 예매 조회가 성공적으로 완료되었습니다.")
+    GUEST_BOOKING_RETRIEVE_SUCCESS(200, "비회원 예매 조회가 성공적으로 완료되었습니다."),
+    TICKET_RETRIEVE_SUCCESS(200, "예매자 목록 조회가 성공적으로 완료되었습니다."),
+    TICKET_UPDATE_SUCCESS(200, "예매자 입금여부 수정이 성공적으로 완료되었습니다."),
+    TICKET_DELETE_SUCCESS(200, "예매자 삭제 요청이 성공했습니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/beat/domain/member/api/MemberController.java
+++ b/src/main/java/com/beat/domain/member/api/MemberController.java
@@ -6,6 +6,7 @@ import com.beat.domain.member.exception.MemberSuccessCode;
 import com.beat.global.auth.client.dto.MemberLoginRequest;
 import com.beat.global.auth.jwt.application.TokenService;
 import com.beat.global.common.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,7 @@ public class MemberController {
     private final static int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
     private final static String REFRESH_TOKEN = "refreshToken";
 
+    @Operation(summary = "로그인/회원가입 API", description = "로그인/회원가입하는 POST API입니다.")
     @PostMapping("/sign-up")
     public ResponseEntity<SuccessResponse<LoginSuccessResponse>> signUp(
             @RequestParam final String authorizationCode,
@@ -43,6 +45,7 @@ public class MemberController {
                 .body(SuccessResponse.of(MemberSuccessCode.SIGN_UP_SUCCESS, LoginSuccessResponse.of(loginSuccessResponse.accessToken(), null, loginSuccessResponse.nickname())));
     }
 
+    @Operation(summary = "access token 재발급 API", description = "refresh token으로 access token을 재발급하는 GET API입니다.")
     @GetMapping("/refresh-token")
     public ResponseEntity<SuccessResponse<AccessTokenGetSuccess>> refreshToken(
             @RequestParam final String refreshToken
@@ -52,6 +55,7 @@ public class MemberController {
                 .body(SuccessResponse.of(MemberSuccessCode.ISSUE_REFRESH_TOKEN_SUCCESS, accessTokenGetSuccess));
     }
 
+    @Operation(summary = "로그아웃 API", description = "로그아웃하는 POST API입니다.")
     @PostMapping("/sign-out")
     public ResponseEntity<SuccessResponse<Void>> signOut(
             final Principal principal

--- a/src/main/java/com/beat/domain/performance/api/HomeController.java
+++ b/src/main/java/com/beat/domain/performance/api/HomeController.java
@@ -6,6 +6,7 @@ import com.beat.domain.performance.application.dto.HomeResponse;
 import com.beat.domain.performance.domain.Genre;
 import com.beat.domain.performance.exception.PerformanceSuccessCode;
 import com.beat.global.common.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,7 @@ public class HomeController {
 
     private final PerformanceService performanceService;
 
+    @Operation(summary = "전체공연목록, 홍보목록 조회 API", description = "홈화면에서 전체공연목록, 홍보목록을 조회하는 GET API입니다.")
     @GetMapping
     public ResponseEntity<SuccessResponse<HomeResponse>> getHomePerformanceList(@RequestParam(required = false) String genre) {
         HomeRequest homeRequest;

--- a/src/main/java/com/beat/domain/performance/api/PerformanceController.java
+++ b/src/main/java/com/beat/domain/performance/api/PerformanceController.java
@@ -5,6 +5,7 @@ import com.beat.domain.performance.application.dto.PerformanceDetailResponse;
 import com.beat.domain.performance.exception.PerformanceSuccessCode;
 import com.beat.domain.performance.application.PerformanceService;
 import com.beat.global.common.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +20,7 @@ public class PerformanceController {
 
     private final PerformanceService performanceService;
 
+    @Operation(summary = "공연 상세정보 조회 API", description = "공연 상세페이지의 공연 상세정보를 조회하는 GET API입니다.")
     @GetMapping("/detail/{performanceId}")
     public ResponseEntity<SuccessResponse<PerformanceDetailResponse>> getPerformanceDetail(
             @PathVariable Long performanceId) {
@@ -26,6 +28,7 @@ public class PerformanceController {
         return ResponseEntity.ok(SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_RETRIEVE_SUCCESS, performanceDetail));
     }
 
+    @Operation(summary = "예매하기 관련 공연 정보 조회 API", description = "예매하기 페이지에서 필요한 예매 관련 공연 정보를 조회하는 GET API입니다.")
     @GetMapping("/booking/{performanceId}")
     public ResponseEntity<SuccessResponse<BookingPerformanceDetailResponse>> getBookingPerformanceDetail(
             @PathVariable Long performanceId) {

--- a/src/main/java/com/beat/global/auth/client/kakao/KakaoApiClient.java
+++ b/src/main/java/com/beat/global/auth/client/kakao/KakaoApiClient.java
@@ -1,6 +1,7 @@
 package com.beat.global.auth.client.kakao;
 
 import com.beat.global.auth.client.kakao.response.KakaoUserResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @FeignClient(name = "kakaoApiClient", url = "https://kapi.kakao.com")
 public interface KakaoApiClient {
 
+    @Operation(summary = "카카오 개인정보 조회 API", description = "카카오로그인 결과 카카오 개인정보를 조회하는 GET API입니다.")
     @GetMapping(value = "/v2/user/me")
     KakaoUserResponse getUserInformation(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken);
 }

--- a/src/main/java/com/beat/global/auth/client/kakao/KakaoAuthApiClient.java
+++ b/src/main/java/com/beat/global/auth/client/kakao/KakaoAuthApiClient.java
@@ -1,6 +1,7 @@
 package com.beat.global.auth.client.kakao;
 
 import com.beat.global.auth.client.kakao.response.KakaoAccessTokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "kakaoAuthApiClient", url = "https://kauth.kakao.com")
 public interface KakaoAuthApiClient {
+
+    @Operation(summary = "authorization code 발급 API", description = "토큰 발급에 필요한 authorization code를 발급하는 POST API입니다.")
     @PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     KakaoAccessTokenResponse getOAuth2AccessToken(
             @RequestParam("grant_type") String grantType,


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #49 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
 - 메이커(회원)가 메이커의 공연을 예매한 예매자 목록을 조회하는 GET API 구현하기
 - 예매자 중 일부의 입금여부 정보를 수정하는 PUT API 구현
 - 예매자 중 일부를 삭제하는 DELETE API 구현

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 예매자 목록 조회 GET
- 예매자 전체 목록 조회
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/c189b79e-39f0-4ae1-9a6a-194f6d501c8d">
- 1회차 예매자 목록 조회
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/3c36dae0-68fd-414e-8ad9-5b03d49e8a85">
- 입금여부 false인 예매자 목록조회
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/da49e85a-1cdd-4cdf-be94-f2541defe52b">
- 2회차를 예매했고 입금여부 false인 예매자 목록조회
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/75838db3-0a4a-40c3-a258-d5ef25b52a9d">

### 예매자 입금여부 수정
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/e3fbd952-96b4-41c2-9da4-ae6dd011d945">

### 예매자 삭제
<img width="1296" alt="image" src="https://github.com/user-attachments/assets/b0e49eac-650a-4f42-b7bb-fee9b7ff0435">

<img width="1419" alt="image" src="https://github.com/user-attachments/assets/f664a8f1-f08a-4cf9-a852-2f0c9883673e">
2, 3번 예매자 삭제 확인

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
