### PR TITLE
[refactor] #142-  castImages, staffImages의 파라미터 value를 주지않아도 posterImages에 대한 presigned-url만 발급할 수 있도록 변경

### DIFF
--- a/src/main/java/com/beat/global/external/s3/controller/FileController.java
+++ b/src/main/java/com/beat/global/external/s3/controller/FileController.java
@@ -23,9 +23,14 @@ public class FileController {
     @GetMapping("/presigned-url")
     public ResponseEntity<Map<String, Map<String, String>>> getPresignedUrls(
             @RequestParam String posterImage,
-            @RequestParam List<String> castImages,
-            @RequestParam List<String> staffImages) {
-
+            @RequestParam(required = false) List<String> castImages,
+            @RequestParam(required = false) List<String> staffImages) {
+        if (castImages == null) {
+            castImages = List.of();
+        }
+        if (staffImages == null) {
+            staffImages = List.of();
+        }
         Map<String, Map<String, String>> response = fileService.getPresignedUrls(posterImage, castImages, staffImages);
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #142

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- castImages, staffImages를 사용자가 업로드하는 것은 선택사항입니다. 따라서 해당 부분을 파라미터로 주지 않을 수도 있다는 것을 프론트와 소통 끝에 알게되었습니다.
- castImages, staffImages의 파라미터 value를 주지않아도 빈리스트로 서버단에서 저장하고 빈 리스트를 리턴하여 posterImages에 대한 presigned-url만 발급할 수 있도록 변경했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### castImages, staffImages의 파라미터 value을 주지 않아도 posterImages에 대한 presigned-url만 발급 가능
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/2c439e2d-5783-4e15-81ca-c43b4615e338">


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
