### PR TITLE
[fix] #162 - 공연 삭제 로직 변경

### DIFF
--- a/src/main/java/com/beat/domain/booking/api/TicketController.java
+++ b/src/main/java/com/beat/domain/booking/api/TicketController.java
@@ -32,7 +32,7 @@ public class TicketController {
     }
 
     @Operation(summary = "예매자 입금여부 수정 및 웹발신 API", description = "메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정한 뒤 예매확정 웹발신을 보내는 PUT API입니다.")
-    @PutMapping("/{performanceId}")
+    @PutMapping("/{performanceId}") // 이 부분 body로 performanceId를 넘기기에 수정 필요!!
     public ResponseEntity<SuccessResponse<Void>> updateTickets(
             @CurrentMember Long memberId,
             @PathVariable Long performanceId,
@@ -42,12 +42,11 @@ public class TicketController {
     }
 
     @Operation(summary = "예매자 삭제 API", description = "메이커가 자신의 공연에 대한 예매자의 정보를 삭제하는 DELETE API입니다.")
-    @DeleteMapping("/{performanceId}")
+    @DeleteMapping
     public ResponseEntity<SuccessResponse<Void>> deleteTickets(
             @CurrentMember Long memberId,
-            @PathVariable Long performanceId,
-            @RequestBody TicketDeleteRequest request) {
-        ticketService.deleteTickets(memberId, request);
-        return ResponseEntity.ok(SuccessResponse.of(BookingSuccessCode.TICKET_DELETE_SUCCESS, null));
+            @RequestBody TicketDeleteRequest ticketDeleteRequest) {
+        ticketService.deleteTickets(memberId, ticketDeleteRequest);
+        return ResponseEntity.ok(SuccessResponse.from(BookingSuccessCode.TICKET_DELETE_SUCCESS));
     }
 }

--- a/src/main/java/com/beat/domain/booking/application/TicketService.java
+++ b/src/main/java/com/beat/domain/booking/application/TicketService.java
@@ -11,6 +11,7 @@ import com.beat.domain.performance.domain.Performance;
 import com.beat.domain.performance.exception.PerformanceErrorCode;
 import com.beat.domain.schedule.domain.ScheduleNumber;
 import com.beat.domain.booking.exception.BookingErrorCode;
+import com.beat.global.common.exception.ForbiddenException;
 import com.beat.global.common.exception.NotFoundException;
 import com.beat.domain.user.dao.UserRepository;
 import com.beat.domain.user.domain.Users;
@@ -107,17 +108,20 @@ public class TicketService {
     }
 
     @Transactional
-    public void deleteTickets(Long memberId, TicketDeleteRequest request) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+    public void deleteTickets(Long memberId, TicketDeleteRequest ticketDeleteRequest) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        Users user = userRepository.findById(member.getUser().getId()).orElseThrow(
-                () -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+        Long userId = member.getUser().getId();
 
-        Performance performance = performanceRepository.findById(request.performanceId())
+        Performance performance = performanceRepository.findById(ticketDeleteRequest.performanceId())
                 .orElseThrow(() -> new NotFoundException(BookingErrorCode.NO_PERFORMANCE_FOUND));
 
-        for (Long bookingId : request.bookingList()) {
+        if (!performance.getUsers().getId().equals(userId)) {
+            throw new ForbiddenException(PerformanceErrorCode.NOT_PERFORMANCE_OWNER);
+        }
+
+        for (Long bookingId : ticketDeleteRequest.bookingList()) {
             Booking booking = ticketRepository.findById(bookingId)
                     .orElseThrow(() -> new NotFoundException(BookingErrorCode.NO_BOOKING_FOUND));
 

--- a/src/main/java/com/beat/domain/booking/dao/BookingRepository.java
+++ b/src/main/java/com/beat/domain/booking/dao/BookingRepository.java
@@ -32,5 +32,6 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
 
     List<Booking> findByUsersId(Long userId);
 
-    boolean existsBySchedulePerformanceId(Long performanceId);
+    @Query("SELECT COUNT(b) > 0 FROM Booking b WHERE b.schedule.id IN :scheduleIds")
+    boolean existsByScheduleIdIn(@Param("scheduleIds") List<Long> scheduleIds);
 }

--- a/src/main/java/com/beat/domain/performance/api/PerformanceController.java
+++ b/src/main/java/com/beat/domain/performance/api/PerformanceController.java
@@ -94,6 +94,6 @@ public class PerformanceController {
             @CurrentMember Long memberId,
             @PathVariable Long performanceId) {
         performanceManagementService.deletePerformance(memberId, performanceId);
-        return ResponseEntity.ok(SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_DELETE_SUCCESS, null));
+        return ResponseEntity.ok(SuccessResponse.from(PerformanceSuccessCode.PERFORMANCE_DELETE_SUCCESS));
     }
 }

--- a/src/main/java/com/beat/domain/performance/domain/Performance.java
+++ b/src/main/java/com/beat/domain/performance/domain/Performance.java
@@ -1,6 +1,7 @@
 package com.beat.domain.performance.domain;
 
 import com.beat.domain.BaseTimeEntity;
+import com.beat.domain.promotion.domain.Promotion;
 import com.beat.domain.user.domain.Users;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -65,6 +69,9 @@ public class Performance extends BaseTimeEntity {
 
     @Column(nullable = false)
     private int totalScheduleCount;
+
+    @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Promotion> promotions = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -12,7 +12,8 @@ public enum PerformanceErrorCode implements BaseErrorCode {
     INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
     INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
     NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
-    PERFORMANCE_DELETE_FAILED(400, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
+    PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
+    NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.")
     ;
 

--- a/src/main/java/com/beat/domain/schedule/dao/ScheduleRepository.java
+++ b/src/main/java/com/beat/domain/schedule/dao/ScheduleRepository.java
@@ -20,4 +20,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findAllByPerformanceId(Long performanceId);
 
-}
+    @Query("SELECT s.id FROM Schedule s WHERE s.performance.id = :performanceId")
+    List<Long> findIdsByPerformanceId(@Param("performanceId") Long performanceId);}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #162

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 공연 삭제 로직 - 기존
```java
boolean hasBookings = bookingRepository.existsBySchedulePerformanceId(performanceId);
```
- Booking과 Schedule을 조인하여, Schedule이 참조하는 Performance의 ID가 주어진 performanceId와 일치하는지를 검사합니다.

### 공연 삭제 로직 - 변경
```java
@Query("SELECT COUNT(b) > 0 FROM Booking b WHERE b.schedule.id IN :scheduleIds")
boolean existsByScheduleIdIn(@Param("scheduleIds") List<Long> scheduleIds);
```
- Booking 테이블에서 주어진 scheduleIds 리스트 중 하나라도 존재하는지를 확인합니다.

### 변경 사유
- 변경 전 로직도 공연 삭제가 가능한 로직이라고 판단되고, 실제로 로컬에서 돌렸을 때 공연 삭제가 잘 되었습니다.
- 다만 Client 측에서 테스트를 했을 때 공연 삭제가 안되는 문제가 발생했고, 자동으로 생성된 쿼리가 예기치 못한 문제를 일으킬 수도 있다고 생각이 들었습니다.
- 따라서 JPQL을 사용해 명시적으로 쿼리를 작성하므로서 쿼리의 명확성을 높이고, performanceId 대신 List<Long> scheduleIds를 줘 불필요한 조인을 하지 않고 삭제가 가능하도록 변경했습니다.

### promotion 양방향 매핑
- promotion은 performanceId를 외래키로 가지며, performance가 삭제되면 이론상 해당 performance의 id를 외래키로 가지고 있는 promotion의 튜플을 삭제하도록 구현했어야 했습니다.
- 하지만 구현이 안된 것을 확인하였고, @onDelete로 단방향 방식을 적용하고 싶었으나 ddl-auto를 create 옵션으로 해서 테이블을 초기화 시켜야 했기에 기존 데이터를 백업하고 재배포 하는 방식보다 양방향 매핑을 하는 것이 시간 리소스가 덜 할거라고 판단되어서 양방향 매핑으로 진행을 하게 되었습니다.

### 불필요한 pathVariable 어노테이션 제거
- 예매자 삭제시 performanceId를 requestBody로 받고 있는데, performanceId가 pathVariable로도 받도록 구현이 되어있었습니다.
- 따라서 해당 부분을 삭제하고 api 경로를 /api/tickets/{performanceId} -> /api/tickets로 수정하였습니다.


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 해당 공연의 메이커가 아닌 경우 수정 페이지 공연 조회 불가
![image](https://github.com/user-attachments/assets/520ce521-5b3a-497c-8594-5019efef2302)

### 예매자가 하나도 없는 경우 isBookerExist : false 확인
![image](https://github.com/user-attachments/assets/05b5eb76-3c54-4af9-b147-6471f418753d)

### 1회차 예매 진행 ->  isBookerExist : true 확인 따라서 해당 jpql로 지어진 메서드가 잘 작동되는지 확인 완료
![image](https://github.com/user-attachments/assets/75654242-5408-4577-a745-e767018b17c6)

### 1회차 예매 진행한 공연의 경우 삭제가 되지 않는거 확인 완료
![image](https://github.com/user-attachments/assets/fbcb2158-af0d-4148-ad94-8c1dc3e52d27)

### 예매가 없는 공연의 경우 삭제가 되는거 확인 완료
![image](https://github.com/user-attachments/assets/9181800c-f524-4981-97a0-51847670e9a4)

### 해당 공연의 메이커가 아니면 예매자를 삭제할 수 없도록 변경
![image](https://github.com/user-attachments/assets/c9d5dd18-cfb3-4601-8197-01bb87ef8144)

### 정상적으로 예매자 삭제 완료 및 DB에서도 확인 완료
![image](https://github.com/user-attachments/assets/2b51c43f-dda5-4506-84fd-c41359dececf)

### 다시 11번째 공연을 조회하면 isBookerExist가 false로 변경된거 확인 가능
![image](https://github.com/user-attachments/assets/9776ca8f-601c-4e2d-8fc5-36ec50fc8934)

### 공연 삭제 가능 및 cascade로 performanceId=11을 가지고 있는 테이블(schedule, promotion, cast, staff) 튜플 삭제 확인
![image](https://github.com/user-attachments/assets/68488d65-c5a7-4af2-8ba6-8d9acd9ff060)


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- 불필요한 pathVariable을 삭제하고 예매자 삭제 api의 경로명을 /api/tickets/{performanceId} -> /api/tickets로 수정하였습니다.
- 주석을 달아 놓았지만 TicketController에서 예매자 입금여부 수정 및 웹발신 API도 마찬가지로 /api/tickets/{performanceId} -> /api/tickets로 수정해야 합니다. 이 부분은 혜린님꼐서 잘 아시는 코드라 수정하지 않고 남겨두었으니 수정 부탁드립니다!
