### PR TITLE
[fix] #164 - 입금여부수정 api 경로 수정 및 dev db 초기화

### DIFF
--- a/src/main/java/com/beat/domain/booking/api/TicketController.java
+++ b/src/main/java/com/beat/domain/booking/api/TicketController.java
@@ -32,10 +32,9 @@ public class TicketController {
     }
 
     @Operation(summary = "예매자 입금여부 수정 및 웹발신 API", description = "메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정한 뒤 예매확정 웹발신을 보내는 PUT API입니다.")
-    @PutMapping("/{performanceId}") // 이 부분 body로 performanceId를 넘기기에 수정 필요!!
+    @PutMapping
     public ResponseEntity<SuccessResponse<Void>> updateTickets(
             @CurrentMember Long memberId,
-            @PathVariable Long performanceId,
             @RequestBody TicketUpdateRequest request) {
         ticketService.updateTickets(memberId, request);
         return ResponseEntity.ok(SuccessResponse.of(BookingSuccessCode.TICKET_UPDATE_SUCCESS, null));

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #164 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 입금여부수정 api 경로 수정
이미 requestBody에서 performanceId를 받고 있기에 pathVariable에서 제외했습니다.
```
    @Operation(summary = "예매자 입금여부 수정 및 웹발신 API", description = "메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정한 뒤 예매확정 웹발신을 보내는 PUT API입니다.")
    @PutMapping
    public ResponseEntity<SuccessResponse<Void>> updateTickets(
            @CurrentMember Long memberId,
            @RequestBody TicketUpdateRequest request) {
        ticketService.updateTickets(memberId, request);
        return ResponseEntity.ok(SuccessResponse.of(BookingSuccessCode.TICKET_UPDATE_SUCCESS, null));
    }
```

- dev db 초기화
ddl-auto create로 수정해뒀습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="721" alt="image" src="https://github.com/user-attachments/assets/2800a00e-d61b-492c-aee9-7e00943faea7">
정상적으로 입금여부 수정되는 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
