### PR TITLE
[feat] #166 - 사용하지 않는 도커이미지를 서버에서 삭제하도록 Jenkinsfile에 스크립트 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,12 @@ pipeline {
                             ' -e "SPRING_PROFILES_ACTIVE=' + OPERATION_ENV + '"' +
                             ' ' + DOCKER_IMAGE_NAME + ':latest'
                         )
+
+                        // Docker dangling 이미지 정리
+                        sshCommand remote: remote, command: '''
+                            docker images -f "dangling=true" -q | \
+                            xargs -r docker rmi
+                        '''
                     }
                 }
             }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #166 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### What
- 사용하지 않는 도커이미지를 서버에서 삭제하도록 Jenkinsfile에 스크립트를 추가하였습니다.

### Why
- 불필요한 이미지가 서버 디스크에 쌓이게 되어 공간을 차지하는 상황을 자동화를 통해 방지하기 위함입니다.

### Result
- latest 이미지를 제외한 none 태그 이미지를 전부 삭제하는거 확인 완료 -2024.08.09-

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- ddl-auto dev서버는 update로, prod서버는 none으로 설정했습니다!
