### PR TITLE
[fix] #170 - 예매자 삭제 시 판매 티켓 수에 반영하는 로직 구현

### DIFF
--- a/src/main/java/com/beat/domain/booking/application/TicketService.java
+++ b/src/main/java/com/beat/domain/booking/application/TicketService.java
@@ -9,6 +9,8 @@ import com.beat.domain.member.exception.MemberErrorCode;
 import com.beat.domain.performance.dao.PerformanceRepository;
 import com.beat.domain.performance.domain.Performance;
 import com.beat.domain.performance.exception.PerformanceErrorCode;
+import com.beat.domain.schedule.dao.ScheduleRepository;
+import com.beat.domain.schedule.domain.Schedule;
 import com.beat.domain.schedule.domain.ScheduleNumber;
 import com.beat.domain.booking.exception.BookingErrorCode;
 import com.beat.global.common.exception.ForbiddenException;
@@ -32,6 +34,7 @@ public class TicketService {
     private final PerformanceRepository performanceRepository;
     private final MemberRepository memberRepository;
     private final UserRepository userRepository;
+    private final ScheduleRepository scheduleRepository;
     private final CoolSmsService coolSmsService;
 
     public TicketRetrieveResponse getTickets(Long memberId, Long performanceId, ScheduleNumber scheduleNumber, Boolean isPaymentCompleted) {
@@ -125,6 +128,13 @@ public class TicketService {
                     .orElseThrow(() -> new NotFoundException(BookingErrorCode.NO_BOOKING_FOUND));
 
             ticketRepository.delete(booking);
+
+            Schedule schedule = booking.getSchedule();
+
+            ticketRepository.delete(booking);
+
+            schedule.decreaseSoldTicketCount(booking.getPurchaseTicketCount());
+            scheduleRepository.save(schedule);
         }
     }
 }

--- a/src/main/java/com/beat/domain/schedule/domain/Schedule.java
+++ b/src/main/java/com/beat/domain/schedule/domain/Schedule.java
@@ -78,4 +78,13 @@ public class Schedule {
         this.totalTicketCount = totalTicketCount;
         this.scheduleNumber = scheduleNumber;
     }
+
+    public void decreaseSoldTicketCount(int count) {
+        if (this.soldTicketCount >= count) {
+            this.soldTicketCount -= count;
+        } else {
+            throw new IllegalArgumentException("Sold ticket count cannot be less than zero.");
+        }
+    }
+
 }

--- a/src/main/java/com/beat/domain/schedule/domain/Schedule.java
+++ b/src/main/java/com/beat/domain/schedule/domain/Schedule.java
@@ -1,6 +1,8 @@
 package com.beat.domain.schedule.domain;
 
 import com.beat.domain.performance.domain.Performance;
+import com.beat.domain.schedule.exception.ScheduleErrorCode;
+import com.beat.global.common.exception.ConflictException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -83,7 +85,7 @@ public class Schedule {
         if (this.soldTicketCount >= count) {
             this.soldTicketCount -= count;
         } else {
-            throw new IllegalArgumentException("Sold ticket count cannot be less than zero.");
+            throw new ConflictException(ScheduleErrorCode.EXCESS_TICKET_DELETE);
         }
     }
 

--- a/src/main/java/com/beat/domain/schedule/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/beat/domain/schedule/exception/ScheduleErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum ScheduleErrorCode implements BaseErrorCode {
     INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
     NO_SCHEDULE_FOUND(404, "해당 회차를 찾을 수 없습니다."),
-    INSUFFICIENT_TICKETS(409, "요청한 티켓 수량이 잔여 티켓 수를 초과했습니다. 다른 수량을 선택해 주세요.")
+    INSUFFICIENT_TICKETS(409, "요청한 티켓 수량이 잔여 티켓 수를 초과했습니다. 다른 수량을 선택해 주세요."),
+    EXCESS_TICKET_DELETE(409, "예매된 티켓 수 이상을 삭제할 수 없습니다.")
     ;
 
     private final int status;


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #170 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
예매자 삭제 시 판매 티켓 수에 반영하는 로직 구현

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
기존 티켓 판매 수
<img width="1392" alt="스크린샷 2024-08-13 오후 4 45 42" src="https://github.com/user-attachments/assets/b2314442-416b-4a16-8a70-9e359ffcd850">

기존 예매자 조회
<img width="1292" alt="스크린샷 2024-08-13 오후 4 46 07" src="https://github.com/user-attachments/assets/e205c1ae-0382-4764-b922-6caa004883fe">

예매id 2번 삭제
<img width="1294" alt="스크린샷 2024-08-13 오후 4 53 04" src="https://github.com/user-attachments/assets/9289e3b6-91f5-4e31-9946-50f5674d1e9c">

schedule 1번의 soldTicketCount 7매 줄어든 것 확인
<img width="1390" alt="스크린샷 2024-08-13 오후 4 53 12" src="https://github.com/user-attachments/assets/04b1b30a-b9ab-4fe5-8181-f5a253176b9f">

예매자 목록 조회에서 예매id 2번 삭제된 것 확인
<img width="1297" alt="스크린샷 2024-08-13 오후 4 53 34" src="https://github.com/user-attachments/assets/81872058-b866-43b5-8df2-313b97bd4c9e">
<img width="1293" alt="스크린샷 2024-08-13 오후 4 54 39" src="https://github.com/user-attachments/assets/52689875-2e86-43e0-b6d6-c68c2e2571bc">

schedule 2번, 3번을 각각 예매한 예매id 7,6번 동시 삭제
<img width="1305" alt="스크린샷 2024-08-13 오후 4 55 00" src="https://github.com/user-attachments/assets/fc32474f-3bd4-499f-aab1-622e88649e74">

schedule 2번, 3번의 soldTicketCount 감소 확인
<img width="1390" alt="스크린샷 2024-08-13 오후 4 55 18" src="https://github.com/user-attachments/assets/4b5c3d30-8e16-482d-90c5-e0236fda2506">


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
