### PR TITLE
[feat] #172 - promotion 필드 추가 및 지난 공연 캐러샐 자동 삭제 구현, response에 dueDate 추가

### DIFF
--- a/src/main/java/com/beat/BeatApplication.java
+++ b/src/main/java/com/beat/BeatApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 @ImportAutoConfiguration({FeignAutoConfiguration.class})
 public class BeatApplication {
 

--- a/src/main/java/com/beat/domain/performance/application/dto/BookingPerformanceDetailSchedule.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/BookingPerformanceDetailSchedule.java
@@ -7,10 +7,11 @@ public record BookingPerformanceDetailSchedule(
         LocalDateTime performanceDate,
         String scheduleNumber,
         int availableTicketCount,
-        boolean isBooking
+        boolean isBooking,
+        int dueDate
 ) {
-    public static BookingPerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber, int availableTicketCount, boolean isBooking) {
-        return new BookingPerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber, availableTicketCount, isBooking);
+    public static BookingPerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber, int availableTicketCount, boolean isBooking, int dueDate) {
+        return new BookingPerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber, availableTicketCount, isBooking, dueDate);
     }
 
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/MakerPerformanceDetail.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/MakerPerformanceDetail.java
@@ -5,14 +5,16 @@ public record MakerPerformanceDetail(
         String genre,
         String performanceTitle,
         String posterImage,
-        String performancePeriod
+        String performancePeriod,
+        int minDueDate
 ) {
     public static MakerPerformanceDetail of(
             Long performanceId,
             String genre,
             String performanceTitle,
             String posterImage,
-            String performancePeriod) {
-        return new MakerPerformanceDetail(performanceId, genre, performanceTitle, posterImage, performancePeriod);
+            String performancePeriod,
+            int minDueDate) {  // minDueDate 매개변수 추가
+        return new MakerPerformanceDetail(performanceId, genre, performanceTitle, posterImage, performancePeriod, minDueDate);
     }
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
@@ -17,7 +17,8 @@ public record PerformanceDetailResponse(
         String performanceContact,
         String performanceTeamName,
         List<PerformanceDetailCast> castList,
-        List<PerformanceDetailStaff> staffList
+        List<PerformanceDetailStaff> staffList,
+        int minDueDate
 ) {
     public static PerformanceDetailResponse of(
             Long performanceId,
@@ -34,10 +35,26 @@ public record PerformanceDetailResponse(
             String performanceContact,
             String performanceTeamName,
             List<PerformanceDetailCast> castList,
-            List<PerformanceDetailStaff> staffList
+            List<PerformanceDetailStaff> staffList,
+            int minDueDate
     ) {
-        return new PerformanceDetailResponse(performanceId, performanceTitle, performancePeriod, scheduleList, ticketPrice, genre, posterImage, runningTime, performanceVenue, performanceDescription, performanceAttentionNote, performanceContact, performanceTeamName, castList, staffList);
+        return new PerformanceDetailResponse(
+                performanceId,
+                performanceTitle,
+                performancePeriod,
+                scheduleList,
+                ticketPrice,
+                genre,
+                posterImage,
+                runningTime,
+                performanceVenue,
+                performanceDescription,
+                performanceAttentionNote,
+                performanceContact,
+                performanceTeamName,
+                castList,
+                staffList,
+                minDueDate
+        );
     }
-
-
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailSchedule.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailSchedule.java
@@ -5,9 +5,10 @@ import java.time.LocalDateTime;
 public record PerformanceDetailSchedule(
         Long scheduleId,
         LocalDateTime performanceDate,
-        String scheduleNumber
+        String scheduleNumber,
+        int dueDate
 ) {
-    public static PerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber) {
-        return new PerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber);
+    public static PerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber, int dueDate) {
+        return new PerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber, dueDate);
     }
 }

--- a/src/main/java/com/beat/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/beat/domain/promotion/application/PromotionService.java
@@ -27,16 +27,17 @@ public class PromotionService {
         List<Promotion> promotions = promotionRepository.findAll();
 
         for (Promotion promotion : promotions) {
-            if (promotion.getPerformance() != null) {
-                Performance performance = promotion.getPerformance();
+            Performance performance = promotion.getPerformance();
 
-                List<Schedule> schedules = scheduleRepository.findByPerformanceId(performance.getId());
-                int minDueDate = scheduleService.getMinDueDate(schedules);
+            if (performance == null) {
+                return;
+            }
 
-                // MinDueDate가 음수일 경우 Promotion 삭제
-                if (minDueDate < 0) {
-                    promotionRepository.delete(promotion);
-                }
+            List<Schedule> schedules = scheduleRepository.findByPerformanceId(performance.getId());
+            int minDueDate = scheduleService.getMinDueDate(schedules);
+
+            if (minDueDate < 0) {
+                promotionRepository.delete(promotion);
             }
         }
     }

--- a/src/main/java/com/beat/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/beat/domain/promotion/application/PromotionService.java
@@ -1,0 +1,43 @@
+package com.beat.domain.promotion.application;
+
+import com.beat.domain.performance.domain.Performance;
+import com.beat.domain.promotion.dao.PromotionRepository;
+import com.beat.domain.promotion.domain.Promotion;
+import com.beat.domain.schedule.application.ScheduleService;
+import com.beat.domain.schedule.dao.ScheduleRepository;
+import com.beat.domain.schedule.domain.Schedule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionService {
+
+    private final PromotionRepository promotionRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleService scheduleService;
+
+    @Scheduled(cron = "1 0 0 * * ?")
+    @Transactional
+    public void checkAndDeleteInvalidPromotions() {
+        List<Promotion> promotions = promotionRepository.findAll();
+
+        for (Promotion promotion : promotions) {
+            if (promotion.getPerformance() != null) {
+                Performance performance = promotion.getPerformance();
+
+                List<Schedule> schedules = scheduleRepository.findByPerformanceId(performance.getId());
+                int minDueDate = scheduleService.getMinDueDate(schedules);
+
+                // MinDueDate가 음수일 경우 Promotion 삭제
+                if (minDueDate < 0) {
+                    promotionRepository.delete(promotion);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/beat/domain/promotion/domain/Promotion.java
+++ b/src/main/java/com/beat/domain/promotion/domain/Promotion.java
@@ -20,19 +20,29 @@ public class Promotion {
     private String promotionPhoto;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "performance_id", nullable = false)
+    @JoinColumn(name = "performance_id", nullable = true)
     private Performance performance;
 
+    @Column(nullable = true)
+    private String redirectUrl;
+
+    @Column(nullable = false)
+    private boolean isExternal;
+
     @Builder
-    public Promotion(String promotionPhoto, Performance performance) {
+    public Promotion(String promotionPhoto, Performance performance, String redirectUrl, boolean isExternal) {
         this.promotionPhoto = promotionPhoto;
         this.performance = performance;
+        this.redirectUrl = redirectUrl;
+        this.isExternal = isExternal;
     }
 
-    public static Promotion create(String promotionPhoto, Performance performance) {
+    public static Promotion create(String promotionPhoto, Performance performance, String redirectUrl, boolean isExternal) {
         return Promotion.builder()
                 .promotionPhoto(promotionPhoto)
                 .performance(performance)
+                .redirectUrl(redirectUrl)
+                .isExternal(isExternal)
                 .build();
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #172 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- promotion에 필요 필드(redirectUrl, isExternal) 추가
- 지난 공연 캐러샐 자동 삭제 구현 - cron을 이용해 매일 0시0분1초에 캐러셀에 올라간 공연이 지나간 공연일 경우 삭제되도록 구현함
- 공연 관리페이지 조회 시 공연 리스트에 minDueDate 같이 반환 및 minDueDate 기준 정렬
- 공연상세페이지 조회 시 minDueDate, 스케쥴 별 duedate 같이 반환
- 공연 예매하기 시 필요한 상세정보 조회에서 스케쥴 별 duedate 반환

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

- 기존 promotion에 지나간 공연 3개가 등록돼있었으며, test를 위해 23시 18분 1초에 지나간 공연 캐러셀을 삭제하는 로직 구현
<img width="1361" alt="스크린샷 2024-08-13 오후 11 16 47" src="https://github.com/user-attachments/assets/cef200ce-ed49-4661-a51d-a02e5de54efc">

- 23시 19분에 삭제된 것 확인
<img width="1364" alt="스크린샷 2024-08-13 오후 11 19 06" src="https://github.com/user-attachments/assets/6707639a-f9d5-496b-9281-55d710d1e241">
<img width="1030" alt="스크린샷 2024-08-13 오후 11 19 51" src="https://github.com/user-attachments/assets/1c1d33cb-a77e-453a-9bcb-8d9b6fddf0de">

- 공연 관리페이지 조회 시 공연 리스트에 minDueDate 같이 반환 및 minDueDate 기준 정렬
<img width="1300" alt="스크린샷 2024-08-14 오전 12 11 21" src="https://github.com/user-attachments/assets/757407c7-4478-44e0-8962-46c23ce8503b">
지나간 공연이 아닌 경우(duedate 양수) duedate가 작은 순으로 정렬, 지난 공연인 경우(duedate 음수) duedate가 큰 순으로 정렬(최근에 끝난 공연순)되도록 구현함.

- 공연상세페이지 조회 시 minDueDate, 스케쥴 별 duedate 같이 반환
<img width="1298" alt="스크린샷 2024-08-13 오후 11 40 00" src="https://github.com/user-attachments/assets/c751c535-8985-4a75-8972-593beabffd1e">

- 공연 예매하기 시 필요한 상세정보 조회에서 스케쥴 별 duedate 반환
<img width="1286" alt="스크린샷 2024-08-13 오후 11 45 06" src="https://github.com/user-attachments/assets/5a9f45b1-cd1d-459b-9179-2878e1bf5c8c">

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
