### PR TITLE
[#180] refactor - isBooking 로직 조건 개선

### DIFF
--- a/src/main/java/com/beat/domain/performance/application/PerformanceService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceService.java
@@ -61,11 +61,13 @@ public class PerformanceService {
         List<PerformanceDetailSchedule> scheduleList = scheduleRepository.findByPerformanceId(performanceId).stream()
                 .map(schedule -> {
                     int dueDate = scheduleService.calculateDueDate(schedule);
+                    scheduleService.updateBookingStatus(schedule);
                     return PerformanceDetailSchedule.of(
                             schedule.getId(),
                             schedule.getPerformanceDate(),
                             schedule.getScheduleNumber().name(),
-                            dueDate
+                            dueDate,
+                            schedule.isBooking()
                     );
                 }).collect(Collectors.toList());
 

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailSchedule.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailSchedule.java
@@ -6,9 +6,10 @@ public record PerformanceDetailSchedule(
         Long scheduleId,
         LocalDateTime performanceDate,
         String scheduleNumber,
-        int dueDate
+        int dueDate,
+        boolean isBooking
 ) {
-    public static PerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber, int dueDate) {
-        return new PerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber, dueDate);
+    public static PerformanceDetailSchedule of(Long scheduleId, LocalDateTime performanceDate, String scheduleNumber, int dueDate, boolean isBooking) {
+        return new PerformanceDetailSchedule(scheduleId, performanceDate, scheduleNumber, dueDate, isBooking);
     }
 }

--- a/src/main/java/com/beat/domain/schedule/application/ScheduleService.java
+++ b/src/main/java/com/beat/domain/schedule/application/ScheduleService.java
@@ -60,7 +60,8 @@ public class ScheduleService {
 
     public boolean isBookingAvailable(Schedule schedule) {
         int availableTicketCount = getAvailableTicketCount(schedule);
-        return schedule.isBooking() && availableTicketCount > 0 && schedule.getPerformanceDate().isAfter(LocalDateTime.now());
+        LocalDateTime performanceEndTime = schedule.getPerformanceDate().plusMinutes(schedule.getPerformance().getRunningTime());
+        return schedule.isBooking() && availableTicketCount > 0 && LocalDateTime.now().isBefore(performanceEndTime);
     }
 
     @Transactional


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #180 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 예매가능 여부를 의미하는 isBooking 판단 기준 중 날짜 기준을 공연종료시간 기준으로 변경
- 공연 상세페이지의 response에 schedule별 isBooking 추가

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
![스크린샷 2024-08-20 오후 12 56 07](https://github.com/user-attachments/assets/fc2d3af4-6043-425c-8adc-beac8b781637)
공연시작시간 24-08-20 10:57, 러닝타임 120분인 schedule 3을 12시 56분에 조회했을 때 isBooking true

![스크린샷 2024-08-20 오후 12 57 17](https://github.com/user-attachments/assets/c726e97a-faad-4e1f-a6fb-945d45b3d0dc)
공연 종료시간인 12시57분0초 이후 12시 57분에 조회했을 때 isBooking false로 update 됐습니다.

![스크린샷 2024-08-20 오후 1 03 42](https://github.com/user-attachments/assets/b491902c-a637-424e-8260-c8c819a184b2)
공연 상세정보 조회 시 schedule별 isBooking 필드가 같이 조회됩니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
