### PR TITLE
[feat] #183 - 공연 등록 시 공연상세이미지 추가 및 상세페이지, 수정페이지에서의 조회 기능 구현과 웹발신 문자내용 수정

### DIFF
--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -53,6 +53,8 @@ jobs:
           DEV_COOLSMS_KEY: ${{ secrets.DEV_COOLSMS_KEY }}
           DEV_COOLSMS_NUMBER: ${{ secrets.DEV_COOLSMS_NUMBER }}
           DEV_COOLSMS_SECRET: ${{ secrets.DEV_COOLSMS_SECRET }}
+          DEV_ACCESS_TOKEN_EXPIRE_TIME: ${{ secrets.DEV_ACCESS_TOKEN_EXPIRE_TIME }}
+          DEV_REFRESH_TOKEN_EXPIRE_TIME: ${{ secrets.DEV_REFRESH_TOKEN_EXPIRE_TIME }}
         run: |
           cd ./src/main/resources
           envsubst < application-dev.yml > application-dev.tmp.yml && mv application-dev.tmp.yml application-dev.yml

--- a/.github/workflows/prod-CI.yml
+++ b/.github/workflows/prod-CI.yml
@@ -53,6 +53,8 @@ jobs:
           PROD_COOLSMS_KEY: ${{ secrets.PROD_COOLSMS_KEY }}
           PROD_COOLSMS_NUMBER: ${{ secrets.PROD_COOLSMS_NUMBER }}
           PROD_COOLSMS_SECRET: ${{ secrets.PROD_COOLSMS_SECRET }}
+          PROD_ACCESS_TOKEN_EXPIRE_TIME: ${{ secrets.PROD_ACCESS_TOKEN_EXPIRE_TIME }}
+          PROD_REFRESH_TOKEN_EXPIRE_TIME: ${{ secrets.PROD_REFRESH_TOKEN_EXPIRE_TIME }}
         run: |
           cd ./src/main/resources
           envsubst < application-prod.yml > application-prod.tmp.yml && mv application-prod.tmp.yml application-prod.yml

--- a/src/main/java/com/beat/domain/booking/application/TicketService.java
+++ b/src/main/java/com/beat/domain/booking/application/TicketService.java
@@ -99,7 +99,7 @@ public class TicketService {
             ticketRepository.save(booking);
 
             if (!wasPaymentCompleted && detail.isPaymentCompleted()) {
-                String message = String.format("%s님, BEAT에서의 %s의 예매가 확정되었습니다.", detail.bookerName(), request.performanceTitle());
+                String message = String.format("[BEAT] %s님 %s 예매 확정되었습니다.", detail.bookerName(), request.performanceTitle());
                 try {
                     coolSmsService.sendSms(detail.bookerPhoneNumber(), message);
                 } catch (CoolsmsException e) {

--- a/src/main/java/com/beat/domain/performance/application/PerformanceService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceService.java
@@ -6,14 +6,17 @@ import com.beat.domain.member.domain.Member;
 import com.beat.domain.member.exception.MemberErrorCode;
 import com.beat.domain.performance.application.dto.*;
 import com.beat.domain.performance.application.dto.create.CastResponse;
+import com.beat.domain.performance.application.dto.create.PerformanceImageResponse;
 import com.beat.domain.performance.application.dto.create.ScheduleResponse;
 import com.beat.domain.performance.application.dto.create.StaffResponse;
 import com.beat.domain.performance.application.dto.home.HomePerformanceDetail;
 import com.beat.domain.performance.application.dto.home.HomePromotionDetail;
 import com.beat.domain.performance.application.dto.home.HomeRequest;
 import com.beat.domain.performance.application.dto.home.HomeResponse;
+import com.beat.domain.performance.dao.PerformanceImageRepository;
 import com.beat.domain.performance.dao.PerformanceRepository;
 import com.beat.domain.performance.domain.Performance;
+import com.beat.domain.performance.domain.PerformanceImage;
 import com.beat.domain.performance.exception.PerformanceErrorCode;
 import com.beat.domain.promotion.dao.PromotionRepository;
 import com.beat.domain.promotion.domain.Promotion;
@@ -52,6 +55,7 @@ public class PerformanceService {
     private final MemberRepository memberRepository;
     private final UserRepository userRepository;
     private final BookingRepository bookingRepository;
+    private final PerformanceImageRepository performanceImageRepository;
 
     @Transactional(readOnly = true)
     public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {
@@ -89,6 +93,13 @@ public class PerformanceService {
                         staff.getStaffPhoto()
                 )).collect(Collectors.toList());
 
+        List<PerformanceDetailImage> performanceImageList = performanceImageRepository.findAllByPerformanceId(performanceId).stream()
+                .map(image -> PerformanceDetailImage.of(
+                        image.getId(),
+                        image.getPerformanceImage()
+                ))
+                .collect(Collectors.toList());
+
         return PerformanceDetailResponse.of(
                 performance.getId(),
                 performance.getPerformanceTitle(),
@@ -105,7 +116,8 @@ public class PerformanceService {
                 performance.getPerformanceTeamName(),
                 castList,
                 staffList,
-                minDueDate
+                minDueDate,
+                performanceImageList
         );
     }
 
@@ -275,11 +287,12 @@ public class PerformanceService {
         List<Schedule> schedules = scheduleRepository.findAllByPerformanceId(performanceId);
         List<Cast> casts = castRepository.findAllByPerformanceId(performanceId);
         List<Staff> staffs = staffRepository.findAllByPerformanceId(performanceId);
+        List<PerformanceImage> performanceImages = performanceImageRepository.findAllByPerformanceId(performanceId);
 
-        return mapToPerformanceEditResponse(performance, schedules, casts, staffs, isBookerExist);
+        return mapToPerformanceEditResponse(performance, schedules, casts, staffs, performanceImages, isBookerExist);
     }
 
-    private PerformanceEditResponse mapToPerformanceEditResponse(Performance performance, List<Schedule> schedules, List<Cast> casts, List<Staff> staffs, boolean isBookerExist) {
+    private PerformanceEditResponse mapToPerformanceEditResponse(Performance performance, List<Schedule> schedules, List<Cast> casts, List<Staff> staffs, List<PerformanceImage> performanceImages, boolean isBookerExist) {
         List<ScheduleResponse> scheduleResponses = schedules.stream()
                 .map(schedule -> ScheduleResponse.of(
                         schedule.getId(),
@@ -308,6 +321,13 @@ public class PerformanceService {
                 ))
                 .collect(Collectors.toList());
 
+        List<PerformanceImageResponse> performanceImageResponses = performanceImages.stream()
+                .map(performanceImage -> PerformanceImageResponse.of(
+                        performanceImage.getId(),
+                        performanceImage.getPerformanceImage()
+                ))
+                .collect(Collectors.toList());
+
         return PerformanceEditResponse.of(
                 performance.getUsers().getId(),
                 performance.getId(),
@@ -329,7 +349,8 @@ public class PerformanceService {
                 isBookerExist,
                 scheduleResponses,
                 castResponses,
-                staffResponses
+                staffResponses,
+                performanceImageResponses
         );
     }
 

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailImage.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailImage.java
@@ -1,0 +1,10 @@
+package com.beat.domain.performance.application.dto;
+
+public record PerformanceDetailImage(
+        Long performanceImageId,
+        String performanceImage
+) {
+    public static PerformanceDetailImage of(Long performanceImageId, String performanceImage) {
+        return new PerformanceDetailImage(performanceImageId, performanceImage);
+    }
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceDetailResponse.java
@@ -18,7 +18,8 @@ public record PerformanceDetailResponse(
         String performanceTeamName,
         List<PerformanceDetailCast> castList,
         List<PerformanceDetailStaff> staffList,
-        int minDueDate
+        int minDueDate,
+        List<PerformanceDetailImage> performanceImageList
 ) {
     public static PerformanceDetailResponse of(
             Long performanceId,
@@ -36,7 +37,8 @@ public record PerformanceDetailResponse(
             String performanceTeamName,
             List<PerformanceDetailCast> castList,
             List<PerformanceDetailStaff> staffList,
-            int minDueDate
+            int minDueDate,
+            List<PerformanceDetailImage> performanceImageList
     ) {
         return new PerformanceDetailResponse(
                 performanceId,
@@ -54,7 +56,8 @@ public record PerformanceDetailResponse(
                 performanceTeamName,
                 castList,
                 staffList,
-                minDueDate
+                minDueDate,
+                performanceImageList
         );
     }
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/PerformanceEditResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/PerformanceEditResponse.java
@@ -1,6 +1,7 @@
 package com.beat.domain.performance.application.dto;
 
 import com.beat.domain.performance.application.dto.create.CastResponse;
+import com.beat.domain.performance.application.dto.create.PerformanceImageResponse;
 import com.beat.domain.performance.application.dto.create.ScheduleResponse;
 import com.beat.domain.performance.application.dto.create.StaffResponse;
 import com.beat.domain.performance.domain.BankName;
@@ -29,7 +30,8 @@ public record PerformanceEditResponse(
         boolean isBookerExist,
         List<ScheduleResponse> scheduleList,
         List<CastResponse> castList,
-        List<StaffResponse> staffList
+        List<StaffResponse> staffList,
+        List<PerformanceImageResponse> performanceImageList
 ) {
     public static PerformanceEditResponse of(
             Long userId,
@@ -52,7 +54,8 @@ public record PerformanceEditResponse(
             boolean isBookerExist,
             List<ScheduleResponse> scheduleList,
             List<CastResponse> castList,
-            List<StaffResponse> staffList
+            List<StaffResponse> staffList,
+            List<PerformanceImageResponse> performanceImageList
     ) {
         return new PerformanceEditResponse(
                 userId,
@@ -75,7 +78,8 @@ public record PerformanceEditResponse(
                 isBookerExist,
                 scheduleList,
                 castList,
-                staffList
+                staffList,
+                performanceImageList
         );
     }
 }

--- a/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceImageRequest.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceImageRequest.java
@@ -1,0 +1,6 @@
+package com.beat.domain.performance.application.dto.create;
+
+public record PerformanceImageRequest(
+        String performanceImage
+) {
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceImageResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceImageResponse.java
@@ -1,0 +1,16 @@
+package com.beat.domain.performance.application.dto.create;
+
+public record PerformanceImageResponse(
+        Long imageId,
+        String imageUrl
+) {
+    public static PerformanceImageResponse of(
+            Long imageId,
+            String imageUrl
+    ) {
+        return new PerformanceImageResponse(
+                imageId,
+                imageUrl
+        );
+    }
+}

--- a/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceRequest.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceRequest.java
@@ -23,5 +23,6 @@ public record PerformanceRequest(
         int totalScheduleCount,
         List<ScheduleRequest> scheduleList,
         List<CastRequest> castList,
-        List<StaffRequest> staffList
+        List<StaffRequest> staffList,
+        List<PerformanceImageRequest> performanceImageList
 ) {}

--- a/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceResponse.java
+++ b/src/main/java/com/beat/domain/performance/application/dto/create/PerformanceResponse.java
@@ -25,7 +25,8 @@ public record PerformanceResponse(
         int totalScheduleCount,
         List<ScheduleResponse> scheduleList,
         List<CastResponse> castList,
-        List<StaffResponse> staffList
+        List<StaffResponse> staffList,
+        List<PerformanceImageResponse> performanceImageList
 ) {
     public static PerformanceResponse of(
             Long userId,
@@ -47,7 +48,8 @@ public record PerformanceResponse(
             int totalScheduleCount,
             List<ScheduleResponse> scheduleList,
             List<CastResponse> castList,
-            List<StaffResponse> staffList
+            List<StaffResponse> staffList,
+            List<PerformanceImageResponse> performanceImageList
     ) {
         return new PerformanceResponse(
                 userId,
@@ -69,7 +71,8 @@ public record PerformanceResponse(
                 totalScheduleCount,
                 scheduleList,
                 castList,
-                staffList
+                staffList,
+                performanceImageList
         );
     }
 }

--- a/src/main/java/com/beat/domain/performance/dao/PerformanceImageRepository.java
+++ b/src/main/java/com/beat/domain/performance/dao/PerformanceImageRepository.java
@@ -1,0 +1,10 @@
+package com.beat.domain.performance.dao;
+
+import com.beat.domain.performance.domain.PerformanceImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PerformanceImageRepository extends JpaRepository<PerformanceImage, Long> {
+    List<PerformanceImage> findAllByPerformanceId(Long performanceId);
+}

--- a/src/main/java/com/beat/domain/performance/domain/Performance.java
+++ b/src/main/java/com/beat/domain/performance/domain/Performance.java
@@ -78,6 +78,9 @@ public class Performance extends BaseTimeEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Users users;
 
+    @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PerformanceImage> performanceImageList = new ArrayList<>();
+
     @Builder
     public Performance(String performanceTitle, Genre genre, int runningTime, String performanceDescription, String performanceAttentionNote,
                        BankName bankName, String accountNumber, String accountHolder, String posterImage, String performanceTeamName, String performanceVenue, String performanceContact,

--- a/src/main/java/com/beat/domain/performance/domain/Performance.java
+++ b/src/main/java/com/beat/domain/performance/domain/Performance.java
@@ -1,8 +1,10 @@
 package com.beat.domain.performance.domain;
 
 import com.beat.domain.BaseTimeEntity;
+import com.beat.domain.performance.exception.PerformanceErrorCode;
 import com.beat.domain.promotion.domain.Promotion;
 import com.beat.domain.user.domain.Users;
+import com.beat.global.common.exception.BadRequestException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -145,5 +147,12 @@ public class Performance extends BaseTimeEntity {
         this.performanceContact = performanceContact;
         this.performancePeriod = performancePeriod;
         this.totalScheduleCount = totalScheduleCount;
+    }
+
+    public void updateTicketPrice(int newTicketPrice) {
+        if (newTicketPrice < 0) {
+            throw new BadRequestException(PerformanceErrorCode.NEGATIVE_TICKET_PRICE);
+        }
+        this.ticketPrice = newTicketPrice;
     }
 }

--- a/src/main/java/com/beat/domain/performance/domain/PerformanceImage.java
+++ b/src/main/java/com/beat/domain/performance/domain/PerformanceImage.java
@@ -1,0 +1,37 @@
+package com.beat.domain.performance.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PerformanceImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String performanceImage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+
+    @Builder
+    public PerformanceImage(String performanceImage, Performance performance) {
+        this.performanceImage = performanceImage;
+        this.performance = performance;
+    }
+
+    public static PerformanceImage create(String imageUrl, Performance performance) {
+        return PerformanceImage.builder()
+                .performanceImage(imageUrl)
+                .performance(performance)
+                .build();
+    }
+}

--- a/src/main/java/com/beat/global/external/s3/controller/FileController.java
+++ b/src/main/java/com/beat/global/external/s3/controller/FileController.java
@@ -24,14 +24,20 @@ public class FileController {
     public ResponseEntity<Map<String, Map<String, String>>> getPresignedUrls(
             @RequestParam String posterImage,
             @RequestParam(required = false) List<String> castImages,
-            @RequestParam(required = false) List<String> staffImages) {
+            @RequestParam(required = false) List<String> staffImages,
+            @RequestParam(required = false) List<String> performanceImages
+    )
+    {
         if (castImages == null) {
             castImages = List.of();
         }
         if (staffImages == null) {
             staffImages = List.of();
         }
-        Map<String, Map<String, String>> response = fileService.getPresignedUrls(posterImage, castImages, staffImages);
+        if (performanceImages == null) {
+            performanceImages = List.of();
+        }
+        Map<String, Map<String, String>> response = fileService.getPresignedUrls(posterImage, castImages, staffImages, performanceImages);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/beat/global/external/s3/service/FileService.java
+++ b/src/main/java/com/beat/global/external/s3/service/FileService.java
@@ -23,7 +23,7 @@ public class FileService {
 
     private final AmazonS3 amazonS3;
 
-    public Map<String, Map<String, String>> getPresignedUrls(String posterImage, List<String> castImages, List<String> staffImages) {
+    public Map<String, Map<String, String>> getPresignedUrls(String posterImage, List<String> castImages, List<String> staffImages, List<String> performanceImages) {
         Map<String, Map<String, String>> presignedUrls = new HashMap<>();
 
         // Poster Image URL
@@ -50,6 +50,15 @@ public class FileService {
             staffUrls.put(staffImage, staffPresignedUrl.toString());
         }
         presignedUrls.put("staff", staffUrls);
+
+        // Performance Images URLs
+        Map<String, String> performanceImageUrls = new HashMap<>();
+        for (String performanceImage : performanceImages) {
+            String performanceImageFilePath = createPath("performance", performanceImage);
+            URL performanceImagePresignedUrl = amazonS3.generatePresignedUrl(getGeneratePresignedUrlRequest(bucket, performanceImageFilePath));
+            performanceImageUrls.put(performanceImage, performanceImagePresignedUrl.toString());
+        }
+        presignedUrls.put("performance", performanceImageUrls);
 
         return presignedUrls;
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -57,8 +57,8 @@ spring:
 
 jwt:
   secret: ${DEV_JWT_SECRET}
-  access-token-expire-time: 31536000000 # 365일 (1년) 밀리초
-  refresh-token-expire-time: 1209600000 # 14일 밀리초
+  access-token-expire-time: ${DEV_ACCESS_TOKEN_EXPIRE_TIME}
+  refresh-token-expire-time: ${DEV_REFRESH_TOKEN_EXPIRE_TIME}
 
 cloud:
   aws:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -57,8 +57,8 @@ spring:
 
 jwt:
   secret: ${PROD_JWT_SECRET}
-  access-token-expire-time: 31536000000 # 365일 (1년) 밀리초
-  refresh-token-expire-time: 1209600000 # 14일 밀리초
+  access-token-expire-time: ${PROD_ACCESS_TOKEN_EXPIRE_TIME}
+  refresh-token-expire-time: ${PROD_REFRESH_TOKEN_EXPIRE_TIME}
 
 cloud:
   aws:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #183 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 공연상세이미지 presignedUrl로 등록
- 공연 등록 시 공연상세이미지 추가 가능하도록 변경
- 공연상세페이지의 공연정보 조회에 상세 이미지 포함
- 수정페이지에서의 공연정보 조회에 상세 이미지 포함
- 웹발신 문자 내용 수정
- dev, prod 토큰 관련 환경변수 설정

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
공연상세이미지가 여러장인 공연 생성할 경우
![image](https://github.com/user-attachments/assets/7afc252b-079c-4dc7-b2fd-12d03b0a0f66)
해당 공연 상세페이지 조회
![image](https://github.com/user-attachments/assets/d99efadc-f715-4fca-b6cb-5d190366e6e6)
수정하기에 필요한 공연 상세정보 조회
![image](https://github.com/user-attachments/assets/42f66758-5e44-4393-941d-322873b6064d)

공연상세이미지가 없는 공연 생성할 경우 아래처럼 빈리스트로 요청 보내면 됩니다.
![image](https://github.com/user-attachments/assets/15dfce49-7695-42bf-b8d1-48728a474952)

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
