### PR TITLE
[refactor] #192 - 공연소개 & 유의사항 최대 글자수 500자로 구현

### DIFF
--- a/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
@@ -17,6 +17,7 @@ import com.beat.domain.schedule.domain.Schedule;
 import com.beat.domain.staff.dao.StaffRepository;
 import com.beat.domain.staff.domain.Staff;
 import com.beat.domain.user.domain.Users;
+import com.beat.global.common.exception.BadRequestException;
 import com.beat.global.common.exception.ForbiddenException;
 import com.beat.global.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,14 @@ public class PerformanceManagementService {
                 .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Users user = member.getUser();
+
+        if (request.performanceDescription().length() > 500) {
+            throw new BadRequestException(PerformanceErrorCode.INVALID_PERFORMANCE_DESCRIPTION_LENGTH);
+        }
+
+        if (request.performanceAttentionNote().length() > 500) {
+            throw new BadRequestException(PerformanceErrorCode.INVALID_ATTENTION_NOTE_LENGTH);
+        }
 
         Performance performance = Performance.create(
                 request.performanceTitle(),

--- a/src/main/java/com/beat/domain/performance/domain/Performance.java
+++ b/src/main/java/com/beat/domain/performance/domain/Performance.java
@@ -35,10 +35,10 @@ public class Performance extends BaseTimeEntity {
     @Column(nullable = false)
     private int runningTime;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 500)
     private String performanceDescription;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 500)
     private String performanceAttentionNote;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -17,6 +17,8 @@ public enum PerformanceErrorCode implements BaseErrorCode {
     PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
     NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
     MAX_SCHEDULE_LIMIT_EXCEEDED(400, "공연 회차는 최대 3개까지 추가할 수 있습니다."),
+    INVALID_PERFORMANCE_DESCRIPTION_LENGTH(400, "공연 소개 글자수가 500자를 초과했습니다."),
+    INVALID_ATTENTION_NOTE_LENGTH(400, "공연 유의사항 글자수가 500자를 초과했습니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.")
     ;
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #192 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 공연소개 & 유의사항 최대 글자수를 @Column 어노테이션의 length 옵션으로 500자로 변경하겼습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### @Column(length=500)
![image](https://github.com/user-attachments/assets/d3769efd-17b8-442a-9d6a-b237882c8608)

- length 옵션으로 500자로 설정하고, Datagrip의 SQL Generator를 확인했을 때 VARCHAR(500)으로 변경된 점을 확인했습니다.

### 500자로 공연 생성 
![image](https://github.com/user-attachments/assets/9b5622b8-da3d-45e0-a474-82bd991087db)

- 공연 소개 & 유의사항의 글자수를 500자로 설정하고 요청을 보냈을 때 공연이 성공적으로 생성됨을 확인했습니다.

### 500자 초과 에러처리
![image](https://github.com/user-attachments/assets/1b065889-2c3a-4742-87b1-855e3ea4e577)

- 공연 소개 글자수가 500자 초과시 에러처리가 됨을 확인했습니다.

![image](https://github.com/user-attachments/assets/8b935819-be64-465b-a32d-6e303aaa9be8)

- 공연 유의사항 글자수가 500자 초과시 에러처리가 됨음 확인했습니다,.

![image](https://github.com/user-attachments/assets/3a7b5351-4f60-4a31-9755-ada0bee40ea7)

- 둘 다 글자수 500자 초과시 공연 소개 글자수 에러를 먼저 잡기에 공연 소개 글자수 에러처리가 먼저 잡아짐을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- dev는 ddl-auto 옵션이 update라 자동으로 VARCHAR(500)이 반영이 되지만, prod는 ddl-auto 옵션이 none이기에 수동으로 VARCHAR(500)으로 업데이트를 해줘야 할 것 같습니다.
- DB 변동사항에 해당사항 명시에 놓겠습니다!!
