### PR TITLE
[fix] #196 - promotion 조회 로직 수정

### DIFF
--- a/src/main/java/com/beat/domain/performance/application/PerformanceService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceService.java
@@ -219,13 +219,19 @@ public class PerformanceService {
     private List<HomePromotionDetail> getPromotions() {
         List<Promotion> promotionList = promotionRepository.findAll();
         return promotionList.stream()
-                .map(promotion -> HomePromotionDetail.of(
-                        promotion.getId(),
-                        promotion.getPromotionPhoto(),
-                        promotion.getPerformance().getId(),
-                        promotion.getRedirectUrl(),
-                        promotion.isExternal()
-                ))
+                .map(promotion -> {
+                    Long performanceId = null;
+                    if (promotion.getPerformance() != null) {
+                        performanceId = promotion.getPerformance().getId();
+                    }
+                    return HomePromotionDetail.of(
+                            promotion.getId(),
+                            promotion.getPromotionPhoto(),
+                            performanceId,
+                            promotion.getRedirectUrl(),
+                            promotion.isExternal()
+                    );
+                })
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION

## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #196 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
performanceId가 null인 promotion이 db에 삽입됐을 때 홈페이지 조회가 안되는 이슈가 있었습니다.
PerformanceService의 getPromotions 로직에서 performanceId가 null인 경우를 고려하지 않아 발생한 이슈였기 때문에 performanceId가 null이 아닌 경우에만 promotion.getPerformance().getId()로 performanceId를 조회하는 로직으로 수정했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/a1a8ab11-2134-48e8-8fbc-9f2a163bacff)
performanceId가 null인 promotionId 9번의 promotion을 포함한 promotionList가 정상적으로 조회되며, performanceList도 같이 잘 조회되는 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
