### PR TITLE
[feat] #200 - 공연회차 등록 10회까지 가능하도록 수정

### DIFF
--- a/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
@@ -195,7 +195,7 @@ public class PerformanceModifyService {
 
         long existingSchedulesCount = scheduleRepository.countByPerformanceId(performance.getId());
 
-        if ((existingSchedulesCount + 1) > 3) {
+        if ((existingSchedulesCount + 1) > 10) {
             throw new BadRequestException(PerformanceErrorCode.MAX_SCHEDULE_LIMIT_EXCEEDED);
         }
 

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -16,7 +16,7 @@ public enum PerformanceErrorCode implements BaseErrorCode {
     NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
     PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
     NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
-    MAX_SCHEDULE_LIMIT_EXCEEDED(400, "공연 회차는 최대 3개까지 추가할 수 있습니다."),
+    MAX_SCHEDULE_LIMIT_EXCEEDED(400, "공연 회차는 최대 10개까지 추가할 수 있습니다."),
     INVALID_PERFORMANCE_DESCRIPTION_LENGTH(400, "공연 소개 글자수가 500자를 초과했습니다."),
     INVALID_ATTENTION_NOTE_LENGTH(400, "공연 유의사항 글자수가 500자를 초과했습니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.")

--- a/src/main/java/com/beat/domain/schedule/domain/ScheduleNumber.java
+++ b/src/main/java/com/beat/domain/schedule/domain/ScheduleNumber.java
@@ -8,7 +8,14 @@ import lombok.RequiredArgsConstructor;
 public enum ScheduleNumber {
     FIRST("1회차"),
     SECOND("2회차"),
-    THIRD("3회차");
+    THIRD("3회차"),
+    FOURTH("4회차"),
+    FIFTH("5회차"),
+    SIXTH("6회차"),
+    SEVENTH("7회차"),
+    EIGHTH("8회차"),
+    NINTH("9회차"),
+    TENTH("10회차");
 
     private final String displayName;
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #200 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 공연회차를 10회로 늘렸으며, 공연 수정 중 최대회차 검증 로직도 10회까지 허용하도록 수정했습니다.
- SEVENTH의 경우 기존 ScheduleNumber의 최대 문자열 길이보다 길어 머지 전 db 상 수정이 필요합니다.
```
ALTER TABLE schedule MODIFY COLUMN schedule_number VARCHAR(10);
```
- FE 쪽의 요청에 따라 dev 서버의 accessToken expire time을 수정했습니다.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
10회차 공연 생성 테스트
![image](https://github.com/user-attachments/assets/20406286-09e5-4856-ac01-c4e0a4f46eed)

10회차 공연 상세정보 조회
![image](https://github.com/user-attachments/assets/c08dd16c-0688-46c8-b5ad-f0a312ca3d0c)

등록한 공연 목록 조회
![image](https://github.com/user-attachments/assets/85a19dae-1940-4c19-bbf0-8b1ac60237fe)

비회원 예매 요청 테스트
![image](https://github.com/user-attachments/assets/a98e5bce-b64a-4bb8-8a5d-38ff2ca32bbe)

비회원 예매 확인
![image](https://github.com/user-attachments/assets/28626d01-b279-4bf1-8eb0-ebf4d993d9f0)

회원 예매 요청 테스트
![image](https://github.com/user-attachments/assets/97c03d15-7295-4574-bdc3-cd6b6ec1c55e)

회원 예매 확인
![image](https://github.com/user-attachments/assets/ca2f3e1c-c41b-4223-8671-c01f21f6e2e9)

예매자 목록 조회
![image](https://github.com/user-attachments/assets/c8e4ddae-1329-410a-868a-c9461d0a235a)
전체 예매자 목록 조회가 정상적으로 이루어짐을 확인했습니다.
![image](https://github.com/user-attachments/assets/e2e874c1-8bc4-4bfb-931b-2a98ace1328c)
회차별 예매자 목록 조회가 정상적으로 이루어짐을 확인했습니다.

수정하기에 필요한 공연 상세정보 조회
![image](https://github.com/user-attachments/assets/e331f933-1b15-40d0-b47f-0585064bb403)

10회차 공연 정보 수정 테스트
![image](https://github.com/user-attachments/assets/5c61f471-7097-478b-a6df-98deee70a0a0)
- 6회차를 삭제하고, 5회차 날짜를 수정했습니다.
- 그 결과 총 회차가 9회차가 됐습니다.
- 5회차 날짜를 등록한 회차 중 가장 늦은 날짜로 수정했으므로 기존 5회차는 마지막 회차인 NINTH로 scheduleNumber가 업데이트됐습니다.

예매하기에 필요한 공연 상세정보 조회
![image](https://github.com/user-attachments/assets/bc6128f5-b411-428e-b481-462d4d0949de)

예매자 입금 여부 수정
![image](https://github.com/user-attachments/assets/9d133d47-826a-42fb-902d-d5ea39f6a67d)

예매 취소 요청
![image](https://github.com/user-attachments/assets/9cbe0b92-5433-4155-bff0-21a6d92c71e9)

### 추가 테스트
- 공연 정보 수정 시 request body에 scheduleNumber 미포함해도 수정되는지 확인
![image](https://github.com/user-attachments/assets/234e6222-ee70-4875-a7fb-46f88afdb510)
9회차까지 존재하던 공연에 회차를 하나 추가하는 수정 요청을 보낸 결과 정상적으로 추가됨을 확인했습니다. 이때 기존 dto 양식에 맞게  request body에 scheduleNumber 미포함했습니다.

- 공연 정보 수정 시 회차 추가로 인해 총 회차가 10회를 초과하는 요청을 보낼 때 에러 반환하는지 확인
![image](https://github.com/user-attachments/assets/42c420aa-fe3a-429b-a484-22a00dd53927)
의도한대로 에러를 반환하는 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
 scheduleModifyRequests에 scheduleNumber 포함해서 요청했을 때도 정상 요청으로 인식되고 수정도 성공한 것에 대한 확인을 위해 테스트를 진행했습니다.
- scheduleModifyRequests에 일부만 scheduleNumber 포함해서 요청했을 때 확인
![image](https://github.com/user-attachments/assets/3d41cb5d-91a9-4356-8e4b-21b4bf58c950)
1회차의 티켓 수를 수정하는 요청을 scheduleNumber을 포함해 보내자 정상 요청으로 판단했고 수정도 성공했습니다.
dto와 달리 request body를 작성했음에도 수정에 필요한 필드만 다 확인되면 정상으로 판단한 것으로 보입니다.

![image](https://github.com/user-attachments/assets/1137868b-0822-4ec5-801a-b9fa3ac3ab27)
1회차의 티켓 수를 수정하는 요청을 보내며 이번엔 기존과 다른 scheduleNumber 포함해서 요청하는 테스트를 해봤는데 정상 요청으로 판단했고 티켓 수 수정도 성공했으며, response body에서 scheduleNumber가 duedate에 따라 다시 재부여되여 FIRST로 변경된 것도 확인했습니다.

이 부분에 대해 dto 양식에 대해 재검증하는 로직이 추가로 필요한가에 대한 리뷰어분의 생각이 궁금합니다. 저는 프론트 측에서 요청을 보낼 때 저희가 작성한 api 명세서에 맞춰 scheduleNumber를 포함하지 않고 보낼 것이고 서버에서는 request body로 받은 scheduleNumber 를 이용하지 않고 수정하기 때문에 로직을 추가로 작성하는 것의 필요성은 없다고 생각했지만 또 한편으로 다른 api도 request body에 dto와 다른 추가 필드를 포함했을 때 문제가 발생할 여지가 있는지에 대한 검토는 필요하다고 생각했습니다.
