### PR TITLE
[fix] #204 - SuccessReponse 메서드 타입 수정 및 회원 예매 조회 타입 일치 완료

### DIFF
--- a/src/main/java/com/beat/domain/booking/api/BookingController.java
+++ b/src/main/java/com/beat/domain/booking/api/BookingController.java
@@ -47,7 +47,7 @@ public class BookingController {
 
     @Operation(summary = "회원 예매 조회 API", description = "회원이 예매를 조회하는 GET API입니다.")
     @GetMapping("/member/retrieve")
-    public ResponseEntity<SuccessResponse<MemberBookingRetrieveResponse>> getMemberBookings(
+    public ResponseEntity<SuccessResponse<List<MemberBookingRetrieveResponse>>> getMemberBookings(
             @CurrentMember Long memberId) {
         List<MemberBookingRetrieveResponse> response = memberBookingRetrieveService.findMemberBookings(memberId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/beat/global/common/dto/SuccessResponse.java
+++ b/src/main/java/com/beat/global/common/dto/SuccessResponse.java
@@ -7,11 +7,11 @@ public record SuccessResponse<T>(
         String message,
         T data
 ) {
-    public static <T> SuccessResponse of(final BaseSuccessCode baseSuccessCode, final T data) {
-        return new SuccessResponse(baseSuccessCode.getStatus(), baseSuccessCode.getMessage(), data);
+    public static <T> SuccessResponse<T> of(final BaseSuccessCode baseSuccessCode, final T data) {
+        return new SuccessResponse<>(baseSuccessCode.getStatus(), baseSuccessCode.getMessage(), data);
     }
 
-    public static SuccessResponse from(final BaseSuccessCode baseSuccessCode) {
-        return new SuccessResponse(baseSuccessCode.getStatus(), baseSuccessCode.getMessage(), null);
+    public static <T> SuccessResponse<T> from(final BaseSuccessCode baseSuccessCode) {
+        return new SuccessResponse<>(baseSuccessCode.getStatus(), baseSuccessCode.getMessage(), null);
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #204

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 이전에는 SuccessResponse 클래스의 of 메서드에서 제네릭 타입을 명시적으로 지정하지 않았기 때문에, 컴파일러는 제네릭 타입을 원시 타입(Raw Type)으로 취급했습니다. 
- 따라서 원시 타입을 사용할 경우, 컴파일러는 타입 검사를 엄격하게 수행하지 않았고, 발생할 수 있는 타입 불일치에 대해 경고만을 제공했습니다.
- 그러다 이번 기회에 메서드에서 제네릭 타입을 명시적으로 선언하여 컴파일을 해보았고, 다음과 같은 문제점이 있다는 것을 확인했습니다.

### 기존
- List<MemberBookingRetrieveResponse>와 MemberBookingRetrieveResponse 간의 불일치가 있어도 경고만 발생하고 컴파일은 성공하였습니다.
- 이유는 원시 타입으로 사용될 때, 컴파일러는 타입 불일치에 대해 경고를 발생시키지만, 이를 컴파일 오류로 간주하지 않기 때문이였습니다.

### 변경
- SuccessResponse의 메서드에서 제네릭 타입을 명시적으로 선언했습니다. 
- 따라서 컴파일러에게 “이 메서드는 특정 타입을 정확하게 처리해야 한다”는 신호를 주게 되고, 결과적으로 컴파일러는 반환 타입과 실제 전달된 타입 간의 일치 여부를 엄격하게 검사하게 되었습니다.
- 따라서 T가 MemberBookingRetrieveResponse로 선언되었을 때 List<MemberBookingRetrieveResponse>가 전달되면, 컴파일러는 T와 List<T> 간의 불일치를 발견하고 이를 컴파일 오류로 처리하였고 문제점을 발견하여 해결할 수 있었습니다.


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 타입 일치 후 회원 예매 조회 재실행
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/a3990c79-25ec-45f9-acc4-7de26dfd475e">

- 문제없이 get이 되는 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
