### PR TITLE
[fix] #212 - 커스텀 어노테이션 CurrentMember 파라미터 옵션 hidden으로 설정

### DIFF
--- a/src/main/java/com/beat/global/auth/annotation/CurrentMember.java
+++ b/src/main/java/com/beat/global/auth/annotation/CurrentMember.java
@@ -6,8 +6,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Parameter(hidden = true)
 public @interface CurrentMember {
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #212 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- @CurrentMember는 컨트롤러 메서드의 파라미터로 선언되지만, 실제로는 클라이언트가 값을 직접 제공하는 것이 아니라, 서버에서 자동으로 해당 값을 추출하여 넣어주는 역할을 합니다.
- 따라서 클라이언트가 API 요청을 보낼 때, @CurrentMember로 지정된 파라미터에 값을 직접 전달하지 않도록 해야합니다.
- 하지만 Swagger에서는 직접 파라미터를 전달하도록 구현이 되어있었고, 클라이언트 측에서 테스트를 할 수 없었습니다.
- 이를 해결하기 위해, Swagger에서 해당 파라미터를 hidden 옵션을 통해 명시하지 않도록 구현했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="1492" alt="image" src="https://github.com/user-attachments/assets/4f529938-656b-4435-9965-b7a24c728a73">

- memberId를 파라미터로 주는 부분이 Swagger에 명시가 되지 않는 것을 확인했습니다.
- 이 밖에 다른 API에서도 모두 확인했습니다!

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
