### PR TITLE
[fix] #211 - 스케쥴 날짜 및 티켓수 변경 관련 에러 처리

### DIFF
--- a/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
@@ -1,12 +1,26 @@
 package com.beat.domain.performance.application;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.beat.domain.booking.dao.BookingRepository;
 import com.beat.domain.cast.dao.CastRepository;
 import com.beat.domain.cast.domain.Cast;
 import com.beat.domain.member.dao.MemberRepository;
 import com.beat.domain.member.domain.Member;
 import com.beat.domain.member.exception.MemberErrorCode;
-import com.beat.domain.performance.application.dto.create.*;
+import com.beat.domain.performance.application.dto.create.CastResponse;
+import com.beat.domain.performance.application.dto.create.PerformanceImageResponse;
+import com.beat.domain.performance.application.dto.create.PerformanceRequest;
+import com.beat.domain.performance.application.dto.create.PerformanceResponse;
+import com.beat.domain.performance.application.dto.create.ScheduleResponse;
+import com.beat.domain.performance.application.dto.create.StaffResponse;
 import com.beat.domain.performance.dao.PerformanceImageRepository;
 import com.beat.domain.performance.dao.PerformanceRepository;
 import com.beat.domain.performance.domain.Performance;
@@ -21,201 +35,201 @@ import com.beat.global.common.exception.BadRequestException;
 import com.beat.global.common.exception.ForbiddenException;
 import com.beat.global.common.exception.NotFoundException;
 import com.beat.global.common.scheduler.application.JobSchedulerService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class PerformanceManagementService {
 
-    private final PerformanceRepository performanceRepository;
-    private final ScheduleRepository scheduleRepository;
-    private final CastRepository castRepository;
-    private final StaffRepository staffRepository;
-    private final BookingRepository bookingRepository;
-    private final MemberRepository memberRepository;
-    private final PerformanceImageRepository performanceImageRepository;
-    private final JobSchedulerService jobSchedulerService;
+	private final PerformanceRepository performanceRepository;
+	private final ScheduleRepository scheduleRepository;
+	private final CastRepository castRepository;
+	private final StaffRepository staffRepository;
+	private final BookingRepository bookingRepository;
+	private final MemberRepository memberRepository;
+	private final PerformanceImageRepository performanceImageRepository;
+	private final JobSchedulerService jobSchedulerService;
 
-    @Transactional
-    public PerformanceResponse createPerformance(Long memberId, PerformanceRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+	@Transactional
+	public PerformanceResponse createPerformance(Long memberId, PerformanceRequest request) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        Users user = member.getUser();
+		Users user = member.getUser();
 
-        if (request.performanceDescription().length() > 500) {
-            throw new BadRequestException(PerformanceErrorCode.INVALID_PERFORMANCE_DESCRIPTION_LENGTH);
-        }
+		if (request.performanceDescription().length() > 500) {
+			throw new BadRequestException(PerformanceErrorCode.INVALID_PERFORMANCE_DESCRIPTION_LENGTH);
+		}
 
-        if (request.performanceAttentionNote().length() > 500) {
-            throw new BadRequestException(PerformanceErrorCode.INVALID_ATTENTION_NOTE_LENGTH);
-        }
+		if (request.performanceAttentionNote().length() > 500) {
+			throw new BadRequestException(PerformanceErrorCode.INVALID_ATTENTION_NOTE_LENGTH);
+		}
 
-        Performance performance = Performance.create(
-                request.performanceTitle(),
-                request.genre(),
-                request.runningTime(),
-                request.performanceDescription(),
-                request.performanceAttentionNote(),
-                request.bankName(),
-                request.accountNumber(),
-                request.accountHolder(),
-                request.posterImage(),
-                request.performanceTeamName(),
-                request.performanceVenue(),
-                request.performanceContact(),
-                request.performancePeriod(),
-                request.ticketPrice(),
-                request.totalScheduleCount(),
-                user
-        );
-        performanceRepository.save(performance);
+		Performance performance = Performance.create(
+			request.performanceTitle(),
+			request.genre(),
+			request.runningTime(),
+			request.performanceDescription(),
+			request.performanceAttentionNote(),
+			request.bankName(),
+			request.accountNumber(),
+			request.accountHolder(),
+			request.posterImage(),
+			request.performanceTeamName(),
+			request.performanceVenue(),
+			request.performanceContact(),
+			request.performancePeriod(),
+			request.ticketPrice(),
+			request.totalScheduleCount(),
+			user
+		);
+		performanceRepository.save(performance);
 
-        List<Schedule> schedules = request.scheduleList().stream()
-                .map(scheduleRequest -> Schedule.create(
-                        scheduleRequest.performanceDate(),
-                        scheduleRequest.totalTicketCount(),
-                        0,
-                        true,
-                        scheduleRequest.scheduleNumber(),
-                        performance
-                ))
-                .collect(Collectors.toList());
-        scheduleRepository.saveAll(schedules);
+		List<Schedule> schedules = request.scheduleList().stream()
+			.map(scheduleRequest -> {
+				if (scheduleRequest.performanceDate().isBefore(LocalDateTime.now())) {
+					throw new BadRequestException(PerformanceErrorCode.PAST_SCHEDULE_NOT_ALLOWED);
+				}
+				return Schedule.create(
+					scheduleRequest.performanceDate(),
+					scheduleRequest.totalTicketCount(),
+					0,
+					true,
+					scheduleRequest.scheduleNumber(),
+					performance
+				);
+			})
+			.collect(Collectors.toList());
+		scheduleRepository.saveAll(schedules);
 
-        schedules.forEach(jobSchedulerService::addScheduleIfNotExists);
+		schedules.forEach(jobSchedulerService::addScheduleIfNotExists);
 
-        List<Cast> casts = request.castList().stream()
-                .map(castRequest -> Cast.create(
-                        castRequest.castName(),
-                        castRequest.castRole(),
-                        castRequest.castPhoto(),
-                        performance
-                ))
-                .collect(Collectors.toList());
-        castRepository.saveAll(casts);
+		List<Cast> casts = request.castList().stream()
+			.map(castRequest -> Cast.create(
+				castRequest.castName(),
+				castRequest.castRole(),
+				castRequest.castPhoto(),
+				performance
+			))
+			.collect(Collectors.toList());
+		castRepository.saveAll(casts);
 
-        List<Staff> staffs = request.staffList().stream()
-                .map(staffRequest -> Staff.create(
-                        staffRequest.staffName(),
-                        staffRequest.staffRole(),
-                        staffRequest.staffPhoto(),
-                        performance
-                ))
-                .collect(Collectors.toList());
-        staffRepository.saveAll(staffs);
+		List<Staff> staffs = request.staffList().stream()
+			.map(staffRequest -> Staff.create(
+				staffRequest.staffName(),
+				staffRequest.staffRole(),
+				staffRequest.staffPhoto(),
+				performance
+			))
+			.collect(Collectors.toList());
+		staffRepository.saveAll(staffs);
 
-        List<PerformanceImage> performanceImageList = request.performanceImageList().stream()
-                .map(performanceImageRequest -> PerformanceImage.create(
-                        performanceImageRequest.performanceImage(),
-                        performance
-                ))
-                .collect(Collectors.toList());
-        performanceImageRepository.saveAll(performanceImageList);
+		List<PerformanceImage> performanceImageList = request.performanceImageList().stream()
+			.map(performanceImageRequest -> PerformanceImage.create(
+				performanceImageRequest.performanceImage(),
+				performance
+			))
+			.collect(Collectors.toList());
+		performanceImageRepository.saveAll(performanceImageList);
 
-        return mapToPerformanceResponse(performance, schedules, casts, staffs, performanceImageList);
-    }
+		return mapToPerformanceResponse(performance, schedules, casts, staffs, performanceImageList);
+	}
 
-    private PerformanceResponse mapToPerformanceResponse(Performance performance, List<Schedule> schedules, List<Cast> casts, List<Staff> staffs, List<PerformanceImage> performanceImages) {
-        List<ScheduleResponse> scheduleResponses = schedules.stream()
-                .map(schedule -> ScheduleResponse.of(
-                        schedule.getId(),
-                        schedule.getPerformanceDate(),
-                        schedule.getTotalTicketCount(),
-                        calculateDueDate(schedule.getPerformanceDate().toLocalDate()),
-                        schedule.getScheduleNumber()
-                ))
-                .collect(Collectors.toList());
+	private PerformanceResponse mapToPerformanceResponse(Performance performance, List<Schedule> schedules,
+		List<Cast> casts, List<Staff> staffs, List<PerformanceImage> performanceImages) {
+		List<ScheduleResponse> scheduleResponses = schedules.stream()
+			.map(schedule -> ScheduleResponse.of(
+				schedule.getId(),
+				schedule.getPerformanceDate(),
+				schedule.getTotalTicketCount(),
+				calculateDueDate(schedule.getPerformanceDate().toLocalDate()),
+				schedule.getScheduleNumber()
+			))
+			.collect(Collectors.toList());
 
-        List<CastResponse> castResponses = casts.stream()
-                .map(cast -> CastResponse.of(
-                        cast.getId(),
-                        cast.getCastName(),
-                        cast.getCastRole(),
-                        cast.getCastPhoto()
-                ))
-                .collect(Collectors.toList());
+		List<CastResponse> castResponses = casts.stream()
+			.map(cast -> CastResponse.of(
+				cast.getId(),
+				cast.getCastName(),
+				cast.getCastRole(),
+				cast.getCastPhoto()
+			))
+			.collect(Collectors.toList());
 
-        List<StaffResponse> staffResponses = staffs.stream()
-                .map(staff -> StaffResponse.of(
-                        staff.getId(),
-                        staff.getStaffName(),
-                        staff.getStaffRole(),
-                        staff.getStaffPhoto()
-                ))
-                .collect(Collectors.toList());
+		List<StaffResponse> staffResponses = staffs.stream()
+			.map(staff -> StaffResponse.of(
+				staff.getId(),
+				staff.getStaffName(),
+				staff.getStaffRole(),
+				staff.getStaffPhoto()
+			))
+			.collect(Collectors.toList());
 
-        List<PerformanceImageResponse> performanceImageResponses = performanceImages.stream()
-                .map(image -> PerformanceImageResponse.of(
-                        image.getId(),
-                        image.getPerformanceImage()
-                ))
-                .collect(Collectors.toList());
+		List<PerformanceImageResponse> performanceImageResponses = performanceImages.stream()
+			.map(image -> PerformanceImageResponse.of(
+				image.getId(),
+				image.getPerformanceImage()
+			))
+			.collect(Collectors.toList());
 
-        return PerformanceResponse.of(
-                performance.getUsers().getId(),
-                performance.getId(),
-                performance.getPerformanceTitle(),
-                performance.getGenre(),
-                performance.getRunningTime(),
-                performance.getPerformanceDescription(),
-                performance.getPerformanceAttentionNote(),
-                performance.getBankName(),
-                performance.getAccountNumber(),
-                performance.getAccountHolder(),
-                performance.getPosterImage(),
-                performance.getPerformanceTeamName(),
-                performance.getPerformanceVenue(),
-                performance.getPerformanceContact(),
-                performance.getPerformancePeriod(),
-                performance.getTicketPrice(),
-                performance.getTotalScheduleCount(),
-                scheduleResponses,
-                castResponses,
-                staffResponses,
-                performanceImageResponses
-        );
-    }
+		return PerformanceResponse.of(
+			performance.getUsers().getId(),
+			performance.getId(),
+			performance.getPerformanceTitle(),
+			performance.getGenre(),
+			performance.getRunningTime(),
+			performance.getPerformanceDescription(),
+			performance.getPerformanceAttentionNote(),
+			performance.getBankName(),
+			performance.getAccountNumber(),
+			performance.getAccountHolder(),
+			performance.getPosterImage(),
+			performance.getPerformanceTeamName(),
+			performance.getPerformanceVenue(),
+			performance.getPerformanceContact(),
+			performance.getPerformancePeriod(),
+			performance.getTicketPrice(),
+			performance.getTotalScheduleCount(),
+			scheduleResponses,
+			castResponses,
+			staffResponses,
+			performanceImageResponses
+		);
+	}
 
-    private int calculateDueDate(LocalDate performanceDate) {
-        return (int) ChronoUnit.DAYS.between(LocalDate.now(), performanceDate);
-    }
+	private int calculateDueDate(LocalDate performanceDate) {
+		return (int)ChronoUnit.DAYS.between(LocalDate.now(), performanceDate);
+	}
 
-    @Transactional
-    public void deletePerformance(Long memberId, Long performanceId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+	@Transactional
+	public void deletePerformance(Long memberId, Long performanceId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        Long userId = member.getUser().getId();
+		Long userId = member.getUser().getId();
 
-        Performance performance = performanceRepository.findById(performanceId)
-                .orElseThrow(() -> new NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND));
+		Performance performance = performanceRepository.findById(performanceId)
+			.orElseThrow(() -> new NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND));
 
-        if (!performance.getUsers().getId().equals(userId)) {
-            throw new ForbiddenException(PerformanceErrorCode.NOT_PERFORMANCE_OWNER);
-        }
+		if (!performance.getUsers().getId().equals(userId)) {
+			throw new ForbiddenException(PerformanceErrorCode.NOT_PERFORMANCE_OWNER);
+		}
 
-        List<Long> scheduleIds = scheduleRepository.findIdsByPerformanceId(performanceId);
+		List<Long> scheduleIds = scheduleRepository.findIdsByPerformanceId(performanceId);
 
-        boolean hasBookings = bookingRepository.existsByScheduleIdIn(scheduleIds);
+		boolean hasBookings = bookingRepository.existsByScheduleIdIn(scheduleIds);
 
-        if (hasBookings) {
-            throw new ForbiddenException(PerformanceErrorCode.PERFORMANCE_DELETE_FAILED);
-        }
+		if (hasBookings) {
+			throw new ForbiddenException(PerformanceErrorCode.PERFORMANCE_DELETE_FAILED);
+		}
 
-        // 모든 스케줄에 대해 등록된 TaskScheduler 작업을 취소
-        List<Schedule> schedules = scheduleRepository.findByPerformanceId(performanceId);
-        for (Schedule schedule : schedules) {
-            jobSchedulerService.cancelScheduledTaskForPerformance(schedule);
-        }
+		// 모든 스케줄에 대해 등록된 TaskScheduler 작업을 취소
+		List<Schedule> schedules = scheduleRepository.findByPerformanceId(performanceId);
+		for (Schedule schedule : schedules) {
+			jobSchedulerService.cancelScheduledTaskForPerformance(schedule);
+		}
 
-        performanceRepository.delete(performance);
-    }
+		performanceRepository.delete(performance);
+	}
 }

--- a/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
@@ -1,5 +1,16 @@
 package com.beat.domain.performance.application;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.beat.domain.booking.dao.BookingRepository;
 import com.beat.domain.cast.dao.CastRepository;
 import com.beat.domain.cast.domain.Cast;
@@ -7,7 +18,8 @@ import com.beat.domain.cast.exception.CastErrorCode;
 import com.beat.domain.member.dao.MemberRepository;
 import com.beat.domain.member.domain.Member;
 import com.beat.domain.member.exception.MemberErrorCode;
-import com.beat.domain.performance.application.dto.modify.*;
+import com.beat.domain.performance.application.dto.modify.PerformanceModifyRequest;
+import com.beat.domain.performance.application.dto.modify.PerformanceModifyResponse;
 import com.beat.domain.performance.application.dto.modify.cast.CastModifyRequest;
 import com.beat.domain.performance.application.dto.modify.cast.CastModifyResponse;
 import com.beat.domain.performance.application.dto.modify.performanceImage.PerformanceImageModifyRequest;
@@ -33,518 +45,526 @@ import com.beat.global.common.exception.BadRequestException;
 import com.beat.global.common.exception.ForbiddenException;
 import com.beat.global.common.exception.NotFoundException;
 import com.beat.global.common.scheduler.application.JobSchedulerService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PerformanceModifyService {
-    
-    private final PerformanceRepository performanceRepository;
-    private final ScheduleRepository scheduleRepository;
-    private final MemberRepository memberRepository;
-    private final CastRepository castRepository;
-    private final StaffRepository staffRepository;
-    private final BookingRepository bookingRepository;
-    private final PerformanceImageRepository performanceImageRepository;
-    private final JobSchedulerService jobSchedulerService;
-
-    @Transactional
-    public PerformanceModifyResponse modifyPerformance(Long memberId, PerformanceModifyRequest request) {
-        log.info("Starting updatePerformance for memberId: {}, performanceId: {}", memberId, request.performanceId());
-
-        Member member = validateMember(memberId);
-        Long userId = member.getUser().getId();
-
-        Performance performance = findPerformance(request.performanceId());
-
-        validateOwnership(userId, performance);
-
-        List<Long> scheduleIds = scheduleRepository.findIdsByPerformanceId(request.performanceId());
-        boolean isBookerExist = bookingRepository.existsByScheduleIdIn(scheduleIds);
-
-        if (isBookerExist && request.ticketPrice() != performance.getTicketPrice()) {
-            log.error("Ticket price update failed due to existing bookings for performanceId: {}", performance.getId());
-            throw new BadRequestException(PerformanceErrorCode.PRICE_UPDATE_NOT_ALLOWED);
-        }
-
-        updatePerformanceDetails(performance, request, isBookerExist);
-
-        List<ScheduleModifyResponse> modifiedSchedules = processSchedules(request.scheduleModifyRequests(), performance);
-        List<CastModifyResponse> modifiedCasts = processCasts(request.castModifyRequests(), performance);
-        List<StaffModifyResponse> modifiedStaffs = processStaffs(request.staffModifyRequests(), performance);
-        List<PerformanceImageModifyResponse> modifiedPerformanceImages = processPerformanceImages(request.performanceImageModifyRequests(), performance);
-
-        PerformanceModifyResponse response = completeModifyResponse(performance, modifiedSchedules, modifiedCasts, modifiedStaffs, modifiedPerformanceImages);
-
-        log.info("Successfully completed updatePerformance for performanceId: {}", request.performanceId());
-        return response;
-    }
-
-    private Member validateMember(Long memberId) {
-        log.debug("Validating memberId: {}", memberId);
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> {
-                    log.error("Member not found: memberId: {}", memberId);
-                    return new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND);
-                });
-    }
-
-    private Performance findPerformance(Long performanceId) {
-        log.debug("Finding performance with performanceId: {}", performanceId);
-        return performanceRepository.findById(performanceId)
-                .orElseThrow(() -> {
-                    log.error("Performance not found: performanceId: {}", performanceId);
-                    return new NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND);
-                });
-    }
-
-    private void validateOwnership(Long userId, Performance performance) {
-        if (!performance.getUsers().getId().equals(userId)) {
-            log.error("User ID {} does not own performance ID {}", userId, performance.getId());
-            throw new ForbiddenException(PerformanceErrorCode.NOT_PERFORMANCE_OWNER);
-        }
-    }
-
-    private void updatePerformanceDetails(Performance performance, PerformanceModifyRequest request, boolean isBookerExist) {
-        log.debug("Updating performance details for performanceId: {}", performance.getId());
-
-        performance.update(
-                request.performanceTitle(),
-                request.genre(),
-                request.runningTime(),
-                request.performanceDescription(),
-                request.performanceAttentionNote(),
-                request.bankName(),
-                request.accountNumber(),
-                request.accountHolder(),
-                request.posterImage(),
-                request.performanceTeamName(),
-                request.performanceVenue(),
-                request.performanceContact(),
-                request.performancePeriod(),
-                request.totalScheduleCount()
-        );
-
-        if (!isBookerExist) {
-            log.debug("Updating ticket price to {}", request.ticketPrice());
-            performance.updateTicketPrice(request.ticketPrice());
-        }
-
-        performanceRepository.save(performance);
-        log.debug("Performance details updated for performanceId: {}", performance.getId());
-    }
-
-    private List<ScheduleModifyResponse> processSchedules(List<ScheduleModifyRequest> scheduleRequests, Performance performance) {
-        List<Long> existingScheduleIds = scheduleRepository.findIdsByPerformanceId(performance.getId());
-
-        List<Long> requestScheduleIds = scheduleRequests.stream()
-                .map(ScheduleModifyRequest::scheduleId)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-
-        List<Long> schedulesToDelete = existingScheduleIds.stream()
-                .filter(id -> !requestScheduleIds.contains(id))
-                .collect(Collectors.toList());
-
-        deleteRemainingSchedules(schedulesToDelete);
-
-        List<Schedule> schedules = scheduleRequests.stream()
-                .map(request -> {
-                    Schedule schedule;
-                    if (request.scheduleId() == null) {
-                        schedule = addSchedule(request, performance);
-                    } else {
-                        schedule = updateSchedule(request, performance);
-                    }
-                    jobSchedulerService.addScheduleIfNotExists(schedule);
-
-                    return schedule;
-                })
-                .collect(Collectors.toList());
-
-        assignScheduleNumbers(schedules);
-
-        return schedules.stream()
-                .map(schedule -> ScheduleModifyResponse.of(
-                        schedule.getId(),
-                        schedule.getPerformanceDate(),
-                        schedule.getTotalTicketCount(),
-                        calculateDueDate(schedule.getPerformanceDate()),
-                        schedule.getScheduleNumber()
-                ))
-                .collect(Collectors.toList());
-    }
-
-    private void assignScheduleNumbers(List<Schedule> schedules) {
-        schedules.sort(Comparator.comparing(Schedule::getPerformanceDate));
-
-        for (int i = 0; i < schedules.size(); i++) {
-            ScheduleNumber scheduleNumber = ScheduleNumber.values()[i];
-            schedules.get(i).updateScheduleNumber(scheduleNumber);
-        }
-    }
-
-    private Schedule addSchedule(ScheduleModifyRequest request, Performance performance) {
-        log.debug("Adding schedules for performanceId: {}", performance.getId());
-
-        long existingSchedulesCount = scheduleRepository.countByPerformanceId(performance.getId());
-
-        if ((existingSchedulesCount + 1) > 10) {
-            throw new BadRequestException(PerformanceErrorCode.MAX_SCHEDULE_LIMIT_EXCEEDED);
-        }
-
-        Schedule schedule = Schedule.create(
-                request.performanceDate(),
-                request.totalTicketCount(),
-                0,
-                true,
-                ScheduleNumber.FIRST, // 임시로 1회차
-                performance
-        );
-
-        Schedule savedSchedule = scheduleRepository.save(schedule);
-        log.debug("Added schedule with scheduleId: {} for performanceId: {}", savedSchedule.getId(), performance.getId());
-        return savedSchedule;
-    }
-
-    private Schedule updateSchedule(ScheduleModifyRequest request, Performance performance) {
-        log.debug("Updating schedules for scheduleId: {}", request.scheduleId());
-
-        Schedule schedule = scheduleRepository.findById(request.scheduleId())
-                .orElseThrow(() -> {
-                    log.error("Schedule not found: scheduleId: {}", request.scheduleId());
-                    return new NotFoundException(ScheduleErrorCode.NO_SCHEDULE_FOUND);
-                });
-
-        if (!schedule.getPerformance().equals(performance)) {
-            throw new ForbiddenException(ScheduleErrorCode.SCHEDULE_NOT_BELONG_TO_PERFORMANCE);
-        }
-
-        jobSchedulerService.cancelScheduledTaskForPerformance(schedule);
-
-        schedule.update(
-                request.performanceDate(),
-                request.totalTicketCount(),
-                schedule.getScheduleNumber()  // 기존 scheduleNumber 유지
-        );
-        return scheduleRepository.save(schedule);
-    }
-
-    private void deleteRemainingSchedules(List<Long> scheduleIds) {
-        if (scheduleIds == null || scheduleIds.isEmpty()) {
-            log.debug("No schedules to delete");
-            return;
-        }
-
-        scheduleIds.forEach(scheduleId -> {
-            Schedule schedule = scheduleRepository.findById(scheduleId)
-                    .orElseThrow(() -> {
-                        log.error("Schedule not found: scheduleId: {}", scheduleId);
-                        return new NotFoundException(ScheduleErrorCode.NO_SCHEDULE_FOUND);
-                    });
-
-            jobSchedulerService.cancelScheduledTaskForPerformance(schedule);
-
-            scheduleRepository.delete(schedule);
-            log.debug("Deleted schedule with scheduleId: {}", scheduleId);
-        });
-    }
-
-    private List<CastModifyResponse> processCasts(List<CastModifyRequest> castRequests, Performance performance) {
-        log.debug("Processing casts for performanceId: {}", performance.getId());
-
-        List<Long> existingCastIds = castRepository.findIdsByPerformanceId(performance.getId());
-
-        List<CastModifyResponse> responses = castRequests.stream()
-                .map(request -> {
-                    if (request.castId() == null) {
-                        return addCast(request, performance);
-                    } else {
-                        existingCastIds.remove(request.castId());
-                        return updateCast(request, performance);
-                    }
-                })
-                .toList();
-
-        deleteRemainingCasts(existingCastIds);
-
-        return responses;
-    }
-
-    private CastModifyResponse addCast(CastModifyRequest request, Performance performance) {
-        log.debug("Adding casts for performanceId: {}", performance.getId());
-
-        Cast cast = Cast.create(
-                request.castName(),
-                request.castRole(),
-                request.castPhoto(),
-                performance
-        );
-        Cast savedCast = castRepository.save(cast);
-        log.debug("Added cast with castId: {} for performanceId: {}", savedCast.getId(), performance.getId());
-        return CastModifyResponse.of(
-                savedCast.getId(),
-                savedCast.getCastName(),
-                savedCast.getCastRole(),
-                savedCast.getCastPhoto()
-        );
-    }
-
-    private CastModifyResponse updateCast(CastModifyRequest request, Performance performance) {
-        log.debug("Updating casts for castId: {}", request.castId());
-
-        Cast cast = castRepository.findById(request.castId())
-                .orElseThrow(() -> {
-                    log.error("Cast not found: castId: {}", request.castId());
-                    return new NotFoundException(CastErrorCode.CAST_NOT_FOUND);
-                });
-
-        if (!cast.getPerformance().equals(performance)) {
-            throw new ForbiddenException(CastErrorCode.CAST_NOT_BELONG_TO_PERFORMANCE);
-        }
-
-        cast.update(
-                request.castName(),
-                request.castRole(),
-                request.castPhoto()
-        );
-        castRepository.save(cast);
-        log.debug("Updated cast with castId: {}", cast.getId());
-        return CastModifyResponse.of(
-                cast.getId(),
-                cast.getCastName(),
-                cast.getCastRole(),
-                cast.getCastPhoto()
-        );
-    }
-
-    private void deleteRemainingCasts(List<Long> castIds) {
-        if (castIds == null || castIds.isEmpty()) {
-            log.debug("No casts to delete");
-            return;
-        }
-
-        castIds.forEach(castId -> {
-            Cast cast = castRepository.findById(castId)
-                    .orElseThrow(() -> {
-                        log.error("Cast not found: castId: {}", castId);
-                        return new NotFoundException(CastErrorCode.CAST_NOT_FOUND);
-                    });
-            castRepository.delete(cast);
-            log.debug("Deleted cast with castId: {}", castId);
-        });
-    }
-
-    private List<StaffModifyResponse> processStaffs(List<StaffModifyRequest> staffRequests, Performance performance) {
-        log.debug("Processing staffs for performanceId: {}", performance.getId());
-
-        List<Long> existingStaffIds = staffRepository.findIdsByPerformanceId(performance.getId());
-
-        List<StaffModifyResponse> responses = staffRequests.stream()
-                .map(request -> {
-                    if (request.staffId() == null) {
-                        return addStaff(request, performance);
-                    } else {
-                        existingStaffIds.remove(request.staffId()); // 요청에 포함된 ID는 삭제 후보에서 제거
-                        return updateStaff(request, performance);
-                    }
-                })
-                .collect(Collectors.toList());
-
-        deleteRemainingStaffs(existingStaffIds);
-
-        return responses;
-    }
-
-    private StaffModifyResponse addStaff(StaffModifyRequest request, Performance performance) {
-        log.debug("Adding staffs for performanceId: {}", performance.getId());
-
-        Staff staff = Staff.create(
-                request.staffName(),
-                request.staffRole(),
-                request.staffPhoto(),
-                performance
-        );
-        Staff savedStaff = staffRepository.save(staff);
-        log.debug("Added staff with staffId: {} for performanceId: {}", savedStaff.getId(), performance.getId());
-        return StaffModifyResponse.of(
-                savedStaff.getId(),
-                savedStaff.getStaffName(),
-                savedStaff.getStaffRole(),
-                savedStaff.getStaffPhoto()
-        );
-    }
-
-    private StaffModifyResponse updateStaff(StaffModifyRequest request, Performance performance) {
-        log.debug("Updating staffs for staffId: {}", request.staffId());
-
-        Staff staff = staffRepository.findById(request.staffId())
-                .orElseThrow(() -> {
-                    log.error("Staff not found: staffId: {}", request.staffId());
-                    return new NotFoundException(StaffErrorCode.STAFF_NOT_FOUND);
-                });
-
-        if (!staff.getPerformance().equals(performance)) {
-            throw new ForbiddenException(StaffErrorCode.STAFF_NOT_BELONG_TO_PERFORMANCE);
-        }
-
-        staff.update(
-                request.staffName(),
-                request.staffRole(),
-                request.staffPhoto()
-        );
-        staffRepository.save(staff);
-        log.debug("Updated staff with staffId: {}", staff.getId());
-        return StaffModifyResponse.of(
-                staff.getId(),
-                staff.getStaffName(),
-                staff.getStaffRole(),
-                staff.getStaffPhoto()
-        );
-    }
-
-    private void deleteRemainingStaffs(List<Long> staffIds) {
-        if (staffIds == null || staffIds.isEmpty()) {
-            log.debug("No staffs to delete");
-            return;
-        }
-
-        staffIds.forEach(staffId -> {
-            Staff staff = staffRepository.findById(staffId)
-                    .orElseThrow(() -> {
-                        log.error("Staff not found: staffId: {}", staffId);
-                        return new NotFoundException(StaffErrorCode.STAFF_NOT_FOUND);
-                    });
-            staffRepository.delete(staff);
-            log.debug("Deleted staff with staffId: {}", staffId);
-        });
-    }
-
-    private int calculateDueDate(LocalDateTime performanceDate) {
-        return (int) ChronoUnit.DAYS.between(LocalDate.now(), performanceDate.toLocalDate());
-    }
-
-    private List<PerformanceImageModifyResponse> processPerformanceImages(List<PerformanceImageModifyRequest> performanceImageRequests, Performance performance){
-        log.debug("Processing performanceImages for performanceId: {}", performance.getId());
-
-        List<Long> existingPerformanceImageIds = performanceImageRepository.findIdsByPerformanceId(performance.getId());
-
-        List<PerformanceImageModifyResponse> responses = performanceImageRequests.stream()
-                .map(request -> {
-                    if (request.performanceImageId() == null){
-                        return addPerformanceImage(request, performance);
-                    } else {
-                        existingPerformanceImageIds.remove(request.performanceImageId());
-                        return updatePerformanceImage(request, performance);
-                    }
-                })
-                .toList();
-
-        deleteRemainingPerformanceImages(existingPerformanceImageIds);
-
-        return responses;
-    }
-
-    private PerformanceImageModifyResponse addPerformanceImage(PerformanceImageModifyRequest request, Performance performance) {
-        log.debug("Adding performanceImages for performanceId: {}", performance.getId());
-
-        PerformanceImage performanceImage = PerformanceImage.create(
-                request.performanceImage(),
-                performance
-        );
-        PerformanceImage savedPerformanceImage = performanceImageRepository.save(performanceImage);
-        log.debug("Added performanceImage: {}", savedPerformanceImage.getId());
-        return PerformanceImageModifyResponse.of(
-                savedPerformanceImage.getId(),
-                savedPerformanceImage.getPerformanceImage()
-        );
-    }
-
-    private PerformanceImageModifyResponse updatePerformanceImage(PerformanceImageModifyRequest request, Performance performance) {
-        log.debug("Updating performanceImages for performanceId: {}", performance.getId());
-
-        PerformanceImage performanceImage = performanceImageRepository.findById(request.performanceImageId())
-                .orElseThrow(() -> {
-                    log.error("PerformanceImage not found: performanceId: {}", request.performanceImageId());
-                    return new NotFoundException(PerformanceImageErrorCode.PERFORMANCE_IMAGE_NOT_FOUND);
-                });
-
-        if (!performanceImage.getPerformance().equals(performance)) {
-            throw new ForbiddenException(PerformanceImageErrorCode.PERFORMANCE_IMAGE_NOT_BELONG_TO_PERFORMANCE);
-        }
-
-        performanceImage.update(
-                request.performanceImage()
-        );
-        performanceImageRepository.save(performanceImage);
-        log.debug("Updated performanceImage: {}", performanceImage.getId());
-        return PerformanceImageModifyResponse.of(
-                performanceImage.getId(),
-                performanceImage.getPerformanceImage()
-        );
-    }
-
-    private void deleteRemainingPerformanceImages(List<Long> performanceImageIds) {
-        if (performanceImageIds == null || performanceImageIds.isEmpty()) {
-            log.debug("No performanceImages to delete");
-            return;
-        }
-
-        performanceImageIds.forEach(performanceImageId -> {
-            PerformanceImage performanceImage = performanceImageRepository.findById(performanceImageId)
-                    .orElseThrow(() -> {
-                        log.error("PerformanceImage not found: performanceImageId: {}", performanceImageId);
-                        return new NotFoundException(PerformanceImageErrorCode.PERFORMANCE_IMAGE_NOT_FOUND);
-                    });
-            performanceImageRepository.delete(performanceImage);
-            log.debug("Deleted performanceImage: {}", performanceImageId);
-        });
-    }
-
-    private PerformanceModifyResponse completeModifyResponse(
-            Performance performance,
-            List<ScheduleModifyResponse> scheduleModifyResponses,
-            List<CastModifyResponse> castModifyResponses,
-            List<StaffModifyResponse> staffModifyResponses,
-            List<PerformanceImageModifyResponse> performanceImageModifyResponses
-    ) {
-        log.debug("Creating PerformanceModifyResponse for performanceId: {}", performance.getId());
-        PerformanceModifyResponse response = PerformanceModifyResponse.of(
-                performance.getUsers().getId(),
-                performance.getId(),
-                performance.getPerformanceTitle(),
-                performance.getGenre(),
-                performance.getRunningTime(),
-                performance.getPerformanceDescription(),
-                performance.getPerformanceAttentionNote(),
-                performance.getBankName(),
-                performance.getAccountNumber(),
-                performance.getAccountHolder(),
-                performance.getPosterImage(),
-                performance.getPerformanceTeamName(),
-                performance.getPerformanceVenue(),
-                performance.getPerformanceContact(),
-                performance.getPerformancePeriod(),
-                performance.getTicketPrice(),
-                performance.getTotalScheduleCount(),
-                scheduleModifyResponses,
-                castModifyResponses,
-                staffModifyResponses,
-                performanceImageModifyResponses
-        );
-        log.info("PerformanceModifyResponse created successfully for performanceId: {}", performance.getId());
-        return response;
-    }
+
+	private final PerformanceRepository performanceRepository;
+	private final ScheduleRepository scheduleRepository;
+	private final MemberRepository memberRepository;
+	private final CastRepository castRepository;
+	private final StaffRepository staffRepository;
+	private final BookingRepository bookingRepository;
+	private final PerformanceImageRepository performanceImageRepository;
+	private final JobSchedulerService jobSchedulerService;
+
+	@Transactional
+	public PerformanceModifyResponse modifyPerformance(Long memberId, PerformanceModifyRequest request) {
+		log.info("Starting updatePerformance for memberId: {}, performanceId: {}", memberId, request.performanceId());
+
+		Member member = validateMember(memberId);
+		Long userId = member.getUser().getId();
+
+		Performance performance = findPerformance(request.performanceId());
+
+		validateOwnership(userId, performance);
+
+		List<Long> scheduleIds = scheduleRepository.findIdsByPerformanceId(request.performanceId());
+		boolean isBookerExist = bookingRepository.existsByScheduleIdIn(scheduleIds);
+
+		if (isBookerExist && request.ticketPrice() != performance.getTicketPrice()) {
+			log.error("Ticket price update failed due to existing bookings for performanceId: {}", performance.getId());
+			throw new BadRequestException(PerformanceErrorCode.PRICE_UPDATE_NOT_ALLOWED);
+		}
+
+		updatePerformanceDetails(performance, request, isBookerExist);
+
+		List<ScheduleModifyResponse> modifiedSchedules = processSchedules(request.scheduleModifyRequests(),
+			performance);
+		List<CastModifyResponse> modifiedCasts = processCasts(request.castModifyRequests(), performance);
+		List<StaffModifyResponse> modifiedStaffs = processStaffs(request.staffModifyRequests(), performance);
+		List<PerformanceImageModifyResponse> modifiedPerformanceImages = processPerformanceImages(
+			request.performanceImageModifyRequests(), performance);
+
+		PerformanceModifyResponse response = completeModifyResponse(performance, modifiedSchedules, modifiedCasts,
+			modifiedStaffs, modifiedPerformanceImages);
+
+		log.info("Successfully completed updatePerformance for performanceId: {}", request.performanceId());
+		return response;
+	}
+
+	private Member validateMember(Long memberId) {
+		log.debug("Validating memberId: {}", memberId);
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> {
+				log.error("Member not found: memberId: {}", memberId);
+				return new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND);
+			});
+	}
+
+	private Performance findPerformance(Long performanceId) {
+		log.debug("Finding performance with performanceId: {}", performanceId);
+		return performanceRepository.findById(performanceId)
+			.orElseThrow(() -> {
+				log.error("Performance not found: performanceId: {}", performanceId);
+				return new NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND);
+			});
+	}
+
+	private void validateOwnership(Long userId, Performance performance) {
+		if (!performance.getUsers().getId().equals(userId)) {
+			log.error("User ID {} does not own performance ID {}", userId, performance.getId());
+			throw new ForbiddenException(PerformanceErrorCode.NOT_PERFORMANCE_OWNER);
+		}
+	}
+
+	private void updatePerformanceDetails(Performance performance, PerformanceModifyRequest request,
+		boolean isBookerExist) {
+		log.debug("Updating performance details for performanceId: {}", performance.getId());
+
+		performance.update(
+			request.performanceTitle(),
+			request.genre(),
+			request.runningTime(),
+			request.performanceDescription(),
+			request.performanceAttentionNote(),
+			request.bankName(),
+			request.accountNumber(),
+			request.accountHolder(),
+			request.posterImage(),
+			request.performanceTeamName(),
+			request.performanceVenue(),
+			request.performanceContact(),
+			request.performancePeriod(),
+			request.totalScheduleCount()
+		);
+
+		if (!isBookerExist) {
+			log.debug("Updating ticket price to {}", request.ticketPrice());
+			performance.updateTicketPrice(request.ticketPrice());
+		}
+
+		performanceRepository.save(performance);
+		log.debug("Performance details updated for performanceId: {}", performance.getId());
+	}
+
+	private List<ScheduleModifyResponse> processSchedules(List<ScheduleModifyRequest> scheduleRequests,
+		Performance performance) {
+		List<Long> existingScheduleIds = scheduleRepository.findIdsByPerformanceId(performance.getId());
+
+		List<Long> requestScheduleIds = scheduleRequests.stream()
+			.map(ScheduleModifyRequest::scheduleId)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toList());
+
+		List<Long> schedulesToDelete = existingScheduleIds.stream()
+			.filter(id -> !requestScheduleIds.contains(id))
+			.collect(Collectors.toList());
+
+		deleteRemainingSchedules(schedulesToDelete);
+
+		List<Schedule> schedules = scheduleRequests.stream()
+			.map(request -> {
+				Schedule schedule;
+				if (request.scheduleId() == null) {
+					schedule = addSchedule(request, performance);
+				} else {
+					schedule = updateSchedule(request, performance);
+				}
+				jobSchedulerService.addScheduleIfNotExists(schedule);
+
+				return schedule;
+			})
+			.collect(Collectors.toList());
+
+		assignScheduleNumbers(schedules);
+
+		return schedules.stream()
+			.map(schedule -> ScheduleModifyResponse.of(
+				schedule.getId(),
+				schedule.getPerformanceDate(),
+				schedule.getTotalTicketCount(),
+				calculateDueDate(schedule.getPerformanceDate()),
+				schedule.getScheduleNumber()
+			))
+			.collect(Collectors.toList());
+	}
+
+	private void assignScheduleNumbers(List<Schedule> schedules) {
+		schedules.sort(Comparator.comparing(Schedule::getPerformanceDate));
+
+		for (int i = 0; i < schedules.size(); i++) {
+			ScheduleNumber scheduleNumber = ScheduleNumber.values()[i];
+			schedules.get(i).updateScheduleNumber(scheduleNumber);
+		}
+	}
+
+	private Schedule addSchedule(ScheduleModifyRequest request, Performance performance) {
+		log.debug("Adding schedules for performanceId: {}", performance.getId());
+
+		if (request.performanceDate().isBefore(LocalDateTime.now())) {
+			throw new BadRequestException(PerformanceErrorCode.PAST_SCHEDULE_NOT_ALLOWED);
+		}
+
+		long existingSchedulesCount = scheduleRepository.countByPerformanceId(performance.getId());
+
+		if ((existingSchedulesCount + 1) > 10) {
+			throw new BadRequestException(PerformanceErrorCode.MAX_SCHEDULE_LIMIT_EXCEEDED);
+		}
+
+		Schedule schedule = Schedule.create(
+			request.performanceDate(),
+			request.totalTicketCount(),
+			0,
+			true,
+			ScheduleNumber.FIRST, // 임시로 1회차
+			performance
+		);
+
+		Schedule savedSchedule = scheduleRepository.save(schedule);
+		log.debug("Added schedule with scheduleId: {} for performanceId: {}", savedSchedule.getId(),
+			performance.getId());
+		return savedSchedule;
+	}
+
+	private Schedule updateSchedule(ScheduleModifyRequest request, Performance performance) {
+		log.debug("Updating schedules for scheduleId: {}", request.scheduleId());
+
+		Schedule schedule = scheduleRepository.findById(request.scheduleId())
+			.orElseThrow(() -> {
+				log.error("Schedule not found: scheduleId: {}", request.scheduleId());
+				return new NotFoundException(ScheduleErrorCode.NO_SCHEDULE_FOUND);
+			});
+
+		if (!schedule.getPerformance().equals(performance)) {
+			throw new ForbiddenException(ScheduleErrorCode.SCHEDULE_NOT_BELONG_TO_PERFORMANCE);
+		}
+
+		if (request.performanceDate().isBefore(LocalDateTime.now())) {
+			throw new BadRequestException(PerformanceErrorCode.PAST_SCHEDULE_NOT_ALLOWED);
+		}
+
+		jobSchedulerService.cancelScheduledTaskForPerformance(schedule);
+
+		schedule.update(
+			request.performanceDate(),
+			request.totalTicketCount(),
+			schedule.getScheduleNumber()  // 기존 scheduleNumber 유지
+		);
+		return scheduleRepository.save(schedule);
+	}
+
+	private void deleteRemainingSchedules(List<Long> scheduleIds) {
+		if (scheduleIds == null || scheduleIds.isEmpty()) {
+			log.debug("No schedules to delete");
+			return;
+		}
+
+		scheduleIds.forEach(scheduleId -> {
+			Schedule schedule = scheduleRepository.findById(scheduleId)
+				.orElseThrow(() -> {
+					log.error("Schedule not found: scheduleId: {}", scheduleId);
+					return new NotFoundException(ScheduleErrorCode.NO_SCHEDULE_FOUND);
+				});
+
+			jobSchedulerService.cancelScheduledTaskForPerformance(schedule);
+
+			scheduleRepository.delete(schedule);
+			log.debug("Deleted schedule with scheduleId: {}", scheduleId);
+		});
+	}
+
+	private List<CastModifyResponse> processCasts(List<CastModifyRequest> castRequests, Performance performance) {
+		log.debug("Processing casts for performanceId: {}", performance.getId());
+
+		List<Long> existingCastIds = castRepository.findIdsByPerformanceId(performance.getId());
+
+		List<CastModifyResponse> responses = castRequests.stream()
+			.map(request -> {
+				if (request.castId() == null) {
+					return addCast(request, performance);
+				} else {
+					existingCastIds.remove(request.castId());
+					return updateCast(request, performance);
+				}
+			})
+			.toList();
+
+		deleteRemainingCasts(existingCastIds);
+
+		return responses;
+	}
+
+	private CastModifyResponse addCast(CastModifyRequest request, Performance performance) {
+		log.debug("Adding casts for performanceId: {}", performance.getId());
+
+		Cast cast = Cast.create(
+			request.castName(),
+			request.castRole(),
+			request.castPhoto(),
+			performance
+		);
+		Cast savedCast = castRepository.save(cast);
+		log.debug("Added cast with castId: {} for performanceId: {}", savedCast.getId(), performance.getId());
+		return CastModifyResponse.of(
+			savedCast.getId(),
+			savedCast.getCastName(),
+			savedCast.getCastRole(),
+			savedCast.getCastPhoto()
+		);
+	}
+
+	private CastModifyResponse updateCast(CastModifyRequest request, Performance performance) {
+		log.debug("Updating casts for castId: {}", request.castId());
+
+		Cast cast = castRepository.findById(request.castId())
+			.orElseThrow(() -> {
+				log.error("Cast not found: castId: {}", request.castId());
+				return new NotFoundException(CastErrorCode.CAST_NOT_FOUND);
+			});
+
+		if (!cast.getPerformance().equals(performance)) {
+			throw new ForbiddenException(CastErrorCode.CAST_NOT_BELONG_TO_PERFORMANCE);
+		}
+
+		cast.update(
+			request.castName(),
+			request.castRole(),
+			request.castPhoto()
+		);
+		castRepository.save(cast);
+		log.debug("Updated cast with castId: {}", cast.getId());
+		return CastModifyResponse.of(
+			cast.getId(),
+			cast.getCastName(),
+			cast.getCastRole(),
+			cast.getCastPhoto()
+		);
+	}
+
+	private void deleteRemainingCasts(List<Long> castIds) {
+		if (castIds == null || castIds.isEmpty()) {
+			log.debug("No casts to delete");
+			return;
+		}
+
+		castIds.forEach(castId -> {
+			Cast cast = castRepository.findById(castId)
+				.orElseThrow(() -> {
+					log.error("Cast not found: castId: {}", castId);
+					return new NotFoundException(CastErrorCode.CAST_NOT_FOUND);
+				});
+			castRepository.delete(cast);
+			log.debug("Deleted cast with castId: {}", castId);
+		});
+	}
+
+	private List<StaffModifyResponse> processStaffs(List<StaffModifyRequest> staffRequests, Performance performance) {
+		log.debug("Processing staffs for performanceId: {}", performance.getId());
+
+		List<Long> existingStaffIds = staffRepository.findIdsByPerformanceId(performance.getId());
+
+		List<StaffModifyResponse> responses = staffRequests.stream()
+			.map(request -> {
+				if (request.staffId() == null) {
+					return addStaff(request, performance);
+				} else {
+					existingStaffIds.remove(request.staffId()); // 요청에 포함된 ID는 삭제 후보에서 제거
+					return updateStaff(request, performance);
+				}
+			})
+			.collect(Collectors.toList());
+
+		deleteRemainingStaffs(existingStaffIds);
+
+		return responses;
+	}
+
+	private StaffModifyResponse addStaff(StaffModifyRequest request, Performance performance) {
+		log.debug("Adding staffs for performanceId: {}", performance.getId());
+
+		Staff staff = Staff.create(
+			request.staffName(),
+			request.staffRole(),
+			request.staffPhoto(),
+			performance
+		);
+		Staff savedStaff = staffRepository.save(staff);
+		log.debug("Added staff with staffId: {} for performanceId: {}", savedStaff.getId(), performance.getId());
+		return StaffModifyResponse.of(
+			savedStaff.getId(),
+			savedStaff.getStaffName(),
+			savedStaff.getStaffRole(),
+			savedStaff.getStaffPhoto()
+		);
+	}
+
+	private StaffModifyResponse updateStaff(StaffModifyRequest request, Performance performance) {
+		log.debug("Updating staffs for staffId: {}", request.staffId());
+
+		Staff staff = staffRepository.findById(request.staffId())
+			.orElseThrow(() -> {
+				log.error("Staff not found: staffId: {}", request.staffId());
+				return new NotFoundException(StaffErrorCode.STAFF_NOT_FOUND);
+			});
+
+		if (!staff.getPerformance().equals(performance)) {
+			throw new ForbiddenException(StaffErrorCode.STAFF_NOT_BELONG_TO_PERFORMANCE);
+		}
+
+		staff.update(
+			request.staffName(),
+			request.staffRole(),
+			request.staffPhoto()
+		);
+		staffRepository.save(staff);
+		log.debug("Updated staff with staffId: {}", staff.getId());
+		return StaffModifyResponse.of(
+			staff.getId(),
+			staff.getStaffName(),
+			staff.getStaffRole(),
+			staff.getStaffPhoto()
+		);
+	}
+
+	private void deleteRemainingStaffs(List<Long> staffIds) {
+		if (staffIds == null || staffIds.isEmpty()) {
+			log.debug("No staffs to delete");
+			return;
+		}
+
+		staffIds.forEach(staffId -> {
+			Staff staff = staffRepository.findById(staffId)
+				.orElseThrow(() -> {
+					log.error("Staff not found: staffId: {}", staffId);
+					return new NotFoundException(StaffErrorCode.STAFF_NOT_FOUND);
+				});
+			staffRepository.delete(staff);
+			log.debug("Deleted staff with staffId: {}", staffId);
+		});
+	}
+
+	private int calculateDueDate(LocalDateTime performanceDate) {
+		return (int)ChronoUnit.DAYS.between(LocalDate.now(), performanceDate.toLocalDate());
+	}
+
+	private List<PerformanceImageModifyResponse> processPerformanceImages(
+		List<PerformanceImageModifyRequest> performanceImageRequests, Performance performance) {
+		log.debug("Processing performanceImages for performanceId: {}", performance.getId());
+
+		List<Long> existingPerformanceImageIds = performanceImageRepository.findIdsByPerformanceId(performance.getId());
+
+		List<PerformanceImageModifyResponse> responses = performanceImageRequests.stream()
+			.map(request -> {
+				if (request.performanceImageId() == null) {
+					return addPerformanceImage(request, performance);
+				} else {
+					existingPerformanceImageIds.remove(request.performanceImageId());
+					return updatePerformanceImage(request, performance);
+				}
+			})
+			.toList();
+
+		deleteRemainingPerformanceImages(existingPerformanceImageIds);
+
+		return responses;
+	}
+
+	private PerformanceImageModifyResponse addPerformanceImage(PerformanceImageModifyRequest request,
+		Performance performance) {
+		log.debug("Adding performanceImages for performanceId: {}", performance.getId());
+
+		PerformanceImage performanceImage = PerformanceImage.create(
+			request.performanceImage(),
+			performance
+		);
+		PerformanceImage savedPerformanceImage = performanceImageRepository.save(performanceImage);
+		log.debug("Added performanceImage: {}", savedPerformanceImage.getId());
+		return PerformanceImageModifyResponse.of(
+			savedPerformanceImage.getId(),
+			savedPerformanceImage.getPerformanceImage()
+		);
+	}
+
+	private PerformanceImageModifyResponse updatePerformanceImage(PerformanceImageModifyRequest request,
+		Performance performance) {
+		log.debug("Updating performanceImages for performanceId: {}", performance.getId());
+
+		PerformanceImage performanceImage = performanceImageRepository.findById(request.performanceImageId())
+			.orElseThrow(() -> {
+				log.error("PerformanceImage not found: performanceId: {}", request.performanceImageId());
+				return new NotFoundException(PerformanceImageErrorCode.PERFORMANCE_IMAGE_NOT_FOUND);
+			});
+
+		if (!performanceImage.getPerformance().equals(performance)) {
+			throw new ForbiddenException(PerformanceImageErrorCode.PERFORMANCE_IMAGE_NOT_BELONG_TO_PERFORMANCE);
+		}
+
+		performanceImage.update(
+			request.performanceImage()
+		);
+		performanceImageRepository.save(performanceImage);
+		log.debug("Updated performanceImage: {}", performanceImage.getId());
+		return PerformanceImageModifyResponse.of(
+			performanceImage.getId(),
+			performanceImage.getPerformanceImage()
+		);
+	}
+
+	private void deleteRemainingPerformanceImages(List<Long> performanceImageIds) {
+		if (performanceImageIds == null || performanceImageIds.isEmpty()) {
+			log.debug("No performanceImages to delete");
+			return;
+		}
+
+		performanceImageIds.forEach(performanceImageId -> {
+			PerformanceImage performanceImage = performanceImageRepository.findById(performanceImageId)
+				.orElseThrow(() -> {
+					log.error("PerformanceImage not found: performanceImageId: {}", performanceImageId);
+					return new NotFoundException(PerformanceImageErrorCode.PERFORMANCE_IMAGE_NOT_FOUND);
+				});
+			performanceImageRepository.delete(performanceImage);
+			log.debug("Deleted performanceImage: {}", performanceImageId);
+		});
+	}
+
+	private PerformanceModifyResponse completeModifyResponse(
+		Performance performance,
+		List<ScheduleModifyResponse> scheduleModifyResponses,
+		List<CastModifyResponse> castModifyResponses,
+		List<StaffModifyResponse> staffModifyResponses,
+		List<PerformanceImageModifyResponse> performanceImageModifyResponses
+	) {
+		log.debug("Creating PerformanceModifyResponse for performanceId: {}", performance.getId());
+		PerformanceModifyResponse response = PerformanceModifyResponse.of(
+			performance.getUsers().getId(),
+			performance.getId(),
+			performance.getPerformanceTitle(),
+			performance.getGenre(),
+			performance.getRunningTime(),
+			performance.getPerformanceDescription(),
+			performance.getPerformanceAttentionNote(),
+			performance.getBankName(),
+			performance.getAccountNumber(),
+			performance.getAccountHolder(),
+			performance.getPosterImage(),
+			performance.getPerformanceTeamName(),
+			performance.getPerformanceVenue(),
+			performance.getPerformanceContact(),
+			performance.getPerformancePeriod(),
+			performance.getTicketPrice(),
+			performance.getTotalScheduleCount(),
+			scheduleModifyResponses,
+			castModifyResponses,
+			staffModifyResponses,
+			performanceImageModifyResponses
+		);
+		log.info("PerformanceModifyResponse created successfully for performanceId: {}", performance.getId());
+		return response;
+	}
 }

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -21,8 +21,8 @@ public enum PerformanceErrorCode implements BaseErrorCode {
 	INVALID_PERFORMANCE_DESCRIPTION_LENGTH(400, "공연 소개 글자수가 500자를 초과했습니다."),
 	INVALID_ATTENTION_NOTE_LENGTH(400, "공연 유의사항 글자수가 500자를 초과했습니다."),
 	INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
-	PAST_SCHEDULE_NOT_ALLOWED(400, "과거 날짜 스케쥴을 포함한 공연을 생성할 수 없습니다."),
-	SCHEDULE_MODIFICATION_NOT_ALLOWED_FOR_ENDED_SCHEDULE(400, "종료된 스케쥴을 수정할 수 없습니다."),
+	PAST_SCHEDULE_NOT_ALLOWED(400, "과거 날짜 회차를 포함한 공연을 생성할 수 없습니다."),
+	SCHEDULE_MODIFICATION_NOT_ALLOWED_FOR_ENDED_SCHEDULE(400, "종료된 회차를 수정할 수 없습니다."),
 	INVALID_TICKET_COUNT(400, "판매된 티켓 수보다 적은 수로 판매할 티켓 매수를 수정할 수 없습니다.");
 
 	private final int status;

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -1,27 +1,28 @@
 package com.beat.domain.performance.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum PerformanceErrorCode implements BaseErrorCode {
-    PERFORMANCE_NOT_FOUND(404, "해당 공연 정보를 찾을 수 없습니다."),
-    REQUIRED_DATA_MISSING(400, "필수 데이터가 누락되었습니다."),
-    INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
-    INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
-    PRICE_UPDATE_NOT_ALLOWED(400, "예매자가 존재하여 가격을 수정할 수 없습니다."),
-    NEGATIVE_TICKET_PRICE(400, "티켓 가격은 음수일 수 없습니다."),
-    NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
-    PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
-    NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
-    MAX_SCHEDULE_LIMIT_EXCEEDED(400, "공연 회차는 최대 10개까지 추가할 수 있습니다."),
-    INVALID_PERFORMANCE_DESCRIPTION_LENGTH(400, "공연 소개 글자수가 500자를 초과했습니다."),
-    INVALID_ATTENTION_NOTE_LENGTH(400, "공연 유의사항 글자수가 500자를 초과했습니다."),
-    INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.")
-    ;
+	PERFORMANCE_NOT_FOUND(404, "해당 공연 정보를 찾을 수 없습니다."),
+	REQUIRED_DATA_MISSING(400, "필수 데이터가 누락되었습니다."),
+	INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
+	INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
+	PRICE_UPDATE_NOT_ALLOWED(400, "예매자가 존재하여 가격을 수정할 수 없습니다."),
+	NEGATIVE_TICKET_PRICE(400, "티켓 가격은 음수일 수 없습니다."),
+	NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
+	PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
+	NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
+	MAX_SCHEDULE_LIMIT_EXCEEDED(400, "공연 회차는 최대 10개까지 추가할 수 있습니다."),
+	INVALID_PERFORMANCE_DESCRIPTION_LENGTH(400, "공연 소개 글자수가 500자를 초과했습니다."),
+	INVALID_ATTENTION_NOTE_LENGTH(400, "공연 유의사항 글자수가 500자를 초과했습니다."),
+	INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
+	PAST_SCHEDULE_NOT_ALLOWED(400, "과거 날짜 스케쥴을 포함한 공연을 생성할 수 없습니다.");
 
-    private final int status;
-    private final String message;
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -21,7 +21,9 @@ public enum PerformanceErrorCode implements BaseErrorCode {
 	INVALID_PERFORMANCE_DESCRIPTION_LENGTH(400, "공연 소개 글자수가 500자를 초과했습니다."),
 	INVALID_ATTENTION_NOTE_LENGTH(400, "공연 유의사항 글자수가 500자를 초과했습니다."),
 	INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
-	PAST_SCHEDULE_NOT_ALLOWED(400, "과거 날짜 스케쥴을 포함한 공연을 생성할 수 없습니다.");
+	PAST_SCHEDULE_NOT_ALLOWED(400, "과거 날짜 스케쥴을 포함한 공연을 생성할 수 없습니다."),
+	SCHEDULE_MODIFICATION_NOT_ALLOWED_FOR_ENDED_SCHEDULE(400, "종료된 스케쥴을 수정할 수 없습니다."),
+	INVALID_TICKET_COUNT(400, "판매된 티켓 수보다 적은 수로 판매할 티켓 매수를 수정할 수 없습니다.");
 
 	private final int status;
 	private final String message;


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #211 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
## 공연 등록 관련
과거 스케쥴을 포함한 공연을 등록하지 못하도록 에러 처리를 진행했습니다.
## 공연 수정 관련
### 공연 날짜 수정 관련
- 공연 수정 시 기존 스케쥴을 과거 날짜로 수정하는 것, 과거 날짜의 스케쥴을 추가하는 것을 막는 에러 처리를 진행했습니다.
- 공연 수정 시 종료된 스케쥴을 수정하지 못하도록 에러처리를 진행했습니다.
### 공연 티켓수 수정 관련
- 판매된 티켓 수보다 적은 totalTicketCount로 변경하려는 경우 에러 처리했습니다.
- isBooking이 true인 스케쥴이 totalTicketCount 감소로 매진으로 바뀌어야할 경우 isBooking을 false로 update했습니다.
- isBooking이 false인 스케쥴이 totalTicketCount 증가로 매진이 풀려야할 경우 isBooking을 true로 update했습니다.
### isBooking이 false인 스케쥴을 포함한 공연 수정에 대한 taskScheduler 등록 방식 변경
- 매진 혹은 종료 여부에 따라 isBooking이 false인 스케쥴을 포함한 수정 요청의 경우 isBooking이 false인 스케쥴은 taskScheduler에 등록되지 않도록 검증과정을 거친 후 등록하는 방식으로 바꿨습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
## 공연 등록
### 과거날짜 스케쥴을 등록하려고 했을 때
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/9a052f34-616e-4e85-82a7-f6b574ab9528">
에러를 반환합니다.

## 공연 날짜 수정
### 과거 날짜 스케쥴을 추가했을 때
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/c66d9aca-3594-45a9-8674-ff570e5c0792">
에러를 반환합니다.

### 기존 스케쥴을 과거 날짜로 수정했을 때
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/6549d841-dd52-4e8b-85d5-d56e9082261e">
에러를 반환합니다.

### 종료된 스케쥴의 날짜를 수정했을 때
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/59c9409f-f3cb-4ca5-ba79-aea7bbca1f73">
에러를 반환합니다.

## 공연 티켓수 수정
### 티켓수를 판매된 티켓 수보다 줄였을 때
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/9335a539-9813-4a8c-9483-0c8387790122">
에러를 반환합니다.

### 티켓수를 판매된 티켓 수만큼 줄였을 때
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/7d591f83-ae23-4a82-ac90-41b9dd54de65">

56번 스케쥴의 판매된 티켓 수는 2매로, 총티켓수를 2매로 줄였으므로 매진되어 isBooking이 false로 업데이트되고 스케쥴러에는 등록되지 않아야 합니다.

<img width="699" alt="image" src="https://github.com/user-attachments/assets/b3f9257c-60c3-42aa-bac7-7a838bd9fed1">

해당 스케쥴의 isBooking이 false로 update됐습니다.

<img width="536" alt="image" src="https://github.com/user-attachments/assets/ddddd61a-f69d-46b2-a6ec-108d6d2c4e6c">

55번 스케쥴만 taskScheduler에 재등록되고 매진된 56번은 취소되었습니다.

### 매진인 스케쥴이 포함된 공연의 티켓수를 늘린 경우
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/dff5594b-cba2-4ea7-94f5-85b29e87004e">

판매된 티켓수인 2보다 큰 수로 총 티켓수로 변경했습니다. 매진으로 isBooking이 false였던 56번 스케쥴의 매진이 풀리며 isBooking이 true로 업데이트되고 taskScheduler에 등록돼야합니다.

<img width="697" alt="image" src="https://github.com/user-attachments/assets/01dd8e7e-1c27-425b-9bd2-eada95a73b97">

해당 스케쥴의 isBooking이 false로 update됐습니다.

<img width="528" alt="image" src="https://github.com/user-attachments/assets/97a3e5d3-13da-4540-a93c-929ee3f6ff3f">

56번 스케쥴이 taskScheduler에 재등록되었습니다.

## 정상 공연 수정 요청
### 일부 스케쥴이 종료된 공연일 경우
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/48c60046-c457-4927-ab29-b949f242dae1">
<img width="555" alt="image" src="https://github.com/user-attachments/assets/5bd42685-9a2b-48be-bcec-254aaba6432f">
<img width="553" alt="image" src="https://github.com/user-attachments/assets/22b8ca1d-85db-4d94-a930-6d85063afef5">

schduleId 55와 56만taskScheduler에 등록되었고, 종료된 공연인 57은 taskScheduler에 등록되지 않습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
공연 날짜와 티켓수 수정으로 인해 isBooking이 변경될 수 있는 경우들을 최대한 고려하며 작업했으나 혹시 제가 놓친 경우의 수가 있을 수 있으니 검토 부탁드립니다!