### PR TITLE
[fix] #219 - 캐러셀 번호가 중복된 항목 중에서 promotionId가 다른 경우에만 삭제하도록 수정

### DIFF
--- a/src/main/java/com/beat/admin/port/in/AdminUseCase.java
+++ b/src/main/java/com/beat/admin/port/in/AdminUseCase.java
@@ -11,5 +11,5 @@ public interface AdminUseCase {
 	List<Promotion> findAllPromotionsSortedByCarouselNumber();
 
 	List<Promotion> processPromotionsAndSortByCarouselNumber(List<PromotionModifyRequest> modifyRequests,
-		List<PromotionGenerateRequest> generateRequests, List<CarouselNumber> deleteCarouselNumbers);
+		List<PromotionGenerateRequest> generateRequests, List<CarouselNumber> deleteCarouselNumbers, List<CarouselNumber> overlappingCarouselNumbers);
 }

--- a/src/main/java/com/beat/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/beat/domain/promotion/application/PromotionService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class PromotionService implements PromotionUseCase {
 
@@ -36,41 +37,34 @@ public class PromotionService implements PromotionUseCase {
 	}
 
 	@Override
-	@Transactional
 	public Promotion createPromotion(String newImageUrl, Performance performance, String redirectUrl,
 		boolean isExternal, CarouselNumber carouselNumber) {
-		Promotion newPromotion = Promotion.create(
-			newImageUrl,
-			performance,
-			redirectUrl,
-			isExternal,
-			carouselNumber
-		);
+		Promotion newPromotion = Promotion.create(newImageUrl, performance, redirectUrl, isExternal, carouselNumber);
 		return promotionRepository.save(newPromotion);
 	}
 
 	@Override
-	@Transactional
 	public Promotion modifyPromotion(Promotion promotion, Performance performance, PromotionModifyRequest request) {
-		promotion.updatePromotionDetails(
-			request.carouselNumber(),
-			request.newImageUrl(),
-			request.isExternal(),
-			request.redirectUrl(),
-			performance
-		);
+		promotion.updatePromotionDetails(request.carouselNumber(), request.newImageUrl(), request.isExternal(),
+			request.redirectUrl(), performance);
 		return promotionRepository.save(promotion);
 	}
 
 	@Override
-	@Transactional
-	public void deleteByCarouselNumber(CarouselNumber carouselNumber) {
-		promotionRepository.deleteByCarouselNumber(carouselNumber);
+	public void deleteByCarouselNumber(List<CarouselNumber> carouselNumber) {
+		promotionRepository.deleteByCarouselNumbers(carouselNumber);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public List<CarouselNumber> findAllCarouselNumbers() {
 		return promotionRepository.findAllCarouselNumbers();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Promotion findPromotionByCarouselNumber(CarouselNumber carouselNumber) {
+		return promotionRepository.findByCarouselNumber(carouselNumber)
+			.orElseThrow(() -> new NotFoundException(PromotionErrorCode.PROMOTION_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/beat/domain/promotion/dao/PromotionRepository.java
+++ b/src/main/java/com/beat/domain/promotion/dao/PromotionRepository.java
@@ -3,9 +3,13 @@ package com.beat.domain.promotion.dao;
 import com.beat.domain.promotion.domain.CarouselNumber;
 import com.beat.domain.promotion.domain.Promotion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PromotionRepository extends JpaRepository<Promotion, Long> {
     List<Promotion> findAll();
@@ -13,5 +17,11 @@ public interface PromotionRepository extends JpaRepository<Promotion, Long> {
     @Query("SELECT p.carouselNumber FROM Promotion p")
     List<CarouselNumber> findAllCarouselNumbers();
 
-    void deleteByCarouselNumber(CarouselNumber carouselNumber);
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Promotion p WHERE p.carouselNumber IN :carouselNumbers")
+    void deleteByCarouselNumbers(@Param("carouselNumbers") List<CarouselNumber> carouselNumbers);
+
+    @Query("SELECT p FROM Promotion p WHERE p.carouselNumber = :carouselNumber")
+    Optional<Promotion> findByCarouselNumber(@Param("carouselNumber") CarouselNumber carouselNumber);
 }

--- a/src/main/java/com/beat/domain/promotion/port/in/PromotionUseCase.java
+++ b/src/main/java/com/beat/domain/promotion/port/in/PromotionUseCase.java
@@ -17,7 +17,9 @@ public interface PromotionUseCase {
 
 	Promotion modifyPromotion(Promotion promotion, Performance performance, PromotionModifyRequest request);
 
-	void deleteByCarouselNumber(CarouselNumber carouselNumber);
+	void deleteByCarouselNumber(List<CarouselNumber> carouselNumbers);
 
 	List<CarouselNumber> findAllCarouselNumbers();
+
+	Promotion findPromotionByCarouselNumber(CarouselNumber carouselNumber);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #219

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 기존에 있던 carouselNumber와 추가하려는 carouselNumber가 같은 경우 삭제대상에서 제외되는 문제를 해결했습니다.
- 일단 추가 내용은 추후 적어놓겠습니다. 해당 노션보고 이해해주시면 감사하겠습니다!!!
https://www.notion.so/jiwoothejay/8295f8ad677849039708571a0bffff1b?pvs=4

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
