### PR TITLE
[HOTFIX] #223 -캐러셀 삭제 시 promotionId로 판단하도록 수정

### DIFF
--- a/src/main/java/com/beat/admin/port/in/AdminUseCase.java
+++ b/src/main/java/com/beat/admin/port/in/AdminUseCase.java
@@ -2,7 +2,6 @@ package com.beat.admin.port.in;
 
 import com.beat.admin.application.dto.request.CarouselHandleRequest.PromotionGenerateRequest;
 import com.beat.admin.application.dto.request.CarouselHandleRequest.PromotionModifyRequest;
-import com.beat.domain.promotion.domain.CarouselNumber;
 import com.beat.domain.promotion.domain.Promotion;
 
 import java.util.List;
@@ -10,6 +9,6 @@ import java.util.List;
 public interface AdminUseCase {
 	List<Promotion> findAllPromotionsSortedByCarouselNumber();
 
-	List<Promotion> processPromotionsAndSortByCarouselNumber(List<PromotionModifyRequest> modifyRequests,
-		List<PromotionGenerateRequest> generateRequests, List<CarouselNumber> deleteCarouselNumbers, List<CarouselNumber> overlappingCarouselNumbers);
+	List<Promotion> processPromotionsAndSortByPromotionId(List<PromotionModifyRequest> modifyRequests,
+		List<PromotionGenerateRequest> generateRequests, List<Long> deletePromotionIds);
 }

--- a/src/main/java/com/beat/domain/promotion/application/PromotionService.java
+++ b/src/main/java/com/beat/domain/promotion/application/PromotionService.java
@@ -51,20 +51,7 @@ public class PromotionService implements PromotionUseCase {
 	}
 
 	@Override
-	public void deleteByCarouselNumber(List<CarouselNumber> carouselNumber) {
-		promotionRepository.deleteByCarouselNumbers(carouselNumber);
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public List<CarouselNumber> findAllCarouselNumbers() {
-		return promotionRepository.findAllCarouselNumbers();
-	}
-
-	@Override
-	@Transactional(readOnly = true)
-	public Promotion findPromotionByCarouselNumber(CarouselNumber carouselNumber) {
-		return promotionRepository.findByCarouselNumber(carouselNumber)
-			.orElseThrow(() -> new NotFoundException(PromotionErrorCode.PROMOTION_NOT_FOUND));
+	public void deletePromotionsByPromotionIds(List<Long> promotionIds) {
+		promotionRepository.deleteByPromotionIds(promotionIds);
 	}
 }

--- a/src/main/java/com/beat/domain/promotion/dao/PromotionRepository.java
+++ b/src/main/java/com/beat/domain/promotion/dao/PromotionRepository.java
@@ -14,13 +14,10 @@ import java.util.Optional;
 public interface PromotionRepository extends JpaRepository<Promotion, Long> {
     List<Promotion> findAll();
 
-    @Query("SELECT p.carouselNumber FROM Promotion p")
-    List<CarouselNumber> findAllCarouselNumbers();
-
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("DELETE FROM Promotion p WHERE p.carouselNumber IN :carouselNumbers")
-    void deleteByCarouselNumbers(@Param("carouselNumbers") List<CarouselNumber> carouselNumbers);
+    @Query("DELETE FROM Promotion p WHERE p.id IN :promotionIds")
+    void deleteByPromotionIds(@Param("promotionIds") List<Long> promotionIds);
 
     @Query("SELECT p FROM Promotion p WHERE p.carouselNumber = :carouselNumber")
     Optional<Promotion> findByCarouselNumber(@Param("carouselNumber") CarouselNumber carouselNumber);

--- a/src/main/java/com/beat/domain/promotion/port/in/PromotionUseCase.java
+++ b/src/main/java/com/beat/domain/promotion/port/in/PromotionUseCase.java
@@ -17,9 +17,5 @@ public interface PromotionUseCase {
 
 	Promotion modifyPromotion(Promotion promotion, Performance performance, PromotionModifyRequest request);
 
-	void deleteByCarouselNumber(List<CarouselNumber> carouselNumbers);
-
-	List<CarouselNumber> findAllCarouselNumbers();
-
-	Promotion findPromotionByCarouselNumber(CarouselNumber carouselNumber);
+	void deletePromotionsByPromotionIds(List<Long> promotionIds);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #223 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 캐러셀 삭제 시 promotionId 기준으로 처리하도록 수정했습니다.
- 기존에는 수정/삭제/추가 로직을 수행할 때 캐러셀 번호를 기준으로 삭제 리스트를 정했었습니다.
- 그런데 수정하려는 promotion의 캐러셀 번호가 바뀌는 경우(ex. 캐러셀 번호: 2->1), 요청 시 삭제하려고 판단했던 캐러셀 번호가 2일 때, 기존에 캐러셀 번호 2에 해당하는 promotion을 삭제해서 수정하려는 promotion이 캐러셀 번호 1로 변하지 못하고 삭제되는 문제가 있었습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="1366" alt="image" src="https://github.com/user-attachments/assets/26169eba-3611-4cee-90d3-c98cdfdb6bcf">

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/d72b64c6-eff4-4c18-89ca-23151a4012a6">

- 기존에 앞쪽 캐러셀이 삭제되지 않았던 문제를 해결했습니다!

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
