### PR TITLE
[HOTFIX] #229 - 회원 등록 후 flush()를 호출하여 DB에 반영

### DIFF
--- a/src/main/java/com/beat/domain/member/application/MemberRegistrationService.java
+++ b/src/main/java/com/beat/domain/member/application/MemberRegistrationService.java
@@ -28,6 +28,7 @@ public class MemberRegistrationService {
 		log.info("Granting MEMBER role to new user with role: {}", users.getRole());
 
 		users = userRepository.save(users);
+		userRepository.flush();
 
 		log.info("Registering new user with role: {}", users.getRole());
 

--- a/src/main/java/com/beat/domain/member/application/SocialLoginService.java
+++ b/src/main/java/com/beat/domain/member/application/SocialLoginService.java
@@ -11,8 +11,6 @@ import com.beat.global.auth.client.dto.MemberInfoResponse;
 import com.beat.global.auth.client.dto.MemberLoginRequest;
 import com.beat.global.common.exception.BadRequestException;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,9 +26,6 @@ public class SocialLoginService {
 	private final MemberRegistrationService memberRegistrationService;
 	private final AuthenticationService authenticationService;
 	private final KakaoSocialService kakaoSocialService;
-
-	@PersistenceContext
-	private final EntityManager entityManager;
 
 	/**
 	 * 소셜 로그인 또는 회원가입을 처리하는 메서드.
@@ -86,7 +81,6 @@ public class SocialLoginService {
 	 */
 	private LoginSuccessResponse generateLoginResponseFromMemberInfo(final MemberInfoResponse memberInfoResponse) {
 		Long memberId = findOrRegisterMember(memberInfoResponse);
-		entityManager.flush();
 
 		Users user = memberService.findUserByMemberId(memberId);
 

--- a/src/main/java/com/beat/domain/member/application/SocialLoginService.java
+++ b/src/main/java/com/beat/domain/member/application/SocialLoginService.java
@@ -10,8 +10,12 @@ import com.beat.global.auth.client.application.SocialService;
 import com.beat.global.auth.client.dto.MemberInfoResponse;
 import com.beat.global.auth.client.dto.MemberLoginRequest;
 import com.beat.global.common.exception.BadRequestException;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,84 +24,92 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SocialLoginService {
 
-    private final MemberService memberService;
-    private final MemberRegistrationService memberRegistrationService;
-    private final AuthenticationService authenticationService;
-    private final KakaoSocialService kakaoSocialService;
+	private final MemberService memberService;
+	private final MemberRegistrationService memberRegistrationService;
+	private final AuthenticationService authenticationService;
+	private final KakaoSocialService kakaoSocialService;
 
-    /**
-     * 소셜 로그인 또는 회원가입을 처리하는 메서드.
-     * 소셜 서비스에서 받은 authorizationCode와 로그인 요청 정보를 기반으로
-     * 사용자 정보를 조회하고, 로그인 또는 회원가입 후 성공 응답을 반환.
-     *
-     * @param authorizationCode 소셜 인증 코드
-     * @param loginRequest 로그인 요청 정보
-     * @return 로그인 성공 응답(LoginSuccessResponse)
-     */
-    @Transactional
-    public LoginSuccessResponse handleSocialLogin(final String authorizationCode, final MemberLoginRequest loginRequest) {
-        MemberInfoResponse memberInfoResponse = findMemberInfoFromSocialService(authorizationCode, loginRequest);
-        return generateLoginResponseFromMemberInfo(memberInfoResponse);
-    }
+	@PersistenceContext
+	private final EntityManager entityManager;
 
-    /**
-     * 소셜 서비스에서 사용자 정보를 조회하는 메서드.
-     * 소셜 타입에 따라 적절한 소셜 서비스를 사용하여 로그인 정보를 가져옴.
-     *
-     * @param authorizationCode 소셜 인증 코드
-     * @param loginRequest 로그인 요청 정보
-     * @return 소셜 서비스에서 가져온 사용자 정보(MemberInfoResponse)
-     */
-    public MemberInfoResponse findMemberInfoFromSocialService(final String authorizationCode, final MemberLoginRequest loginRequest) {
-        SocialService socialService = findSocialService(loginRequest.socialType());
-        return socialService.login(authorizationCode, loginRequest);
-    }
+	/**
+	 * 소셜 로그인 또는 회원가입을 처리하는 메서드.
+	 * 소셜 서비스에서 받은 authorizationCode와 로그인 요청 정보를 기반으로
+	 * 사용자 정보를 조회하고, 로그인 또는 회원가입 후 성공 응답을 반환.
+	 *
+	 * @param authorizationCode 소셜 인증 코드
+	 * @param loginRequest 로그인 요청 정보
+	 * @return 로그인 성공 응답(LoginSuccessResponse)
+	 */
+	@Transactional
+	public LoginSuccessResponse handleSocialLogin(final String authorizationCode,
+		final MemberLoginRequest loginRequest) {
+		MemberInfoResponse memberInfoResponse = findMemberInfoFromSocialService(authorizationCode, loginRequest);
+		return generateLoginResponseFromMemberInfo(memberInfoResponse);
+	}
 
-    /**
-     * 소셜 타입에 맞는 SocialService를 반환하는 메서드.
-     * 소셜 로그인 타입이 KAKAO인지, GOOGLE인지 등에 따라 적절한 서비스를 반환.
-     *
-     * @param socialType 소셜 타입(KAKAO, GOOGLE 등)
-     * @return 적절한 SocialService 구현체
-     */
-    private SocialService findSocialService(SocialType socialType) {
-        return switch (socialType) {
-            case KAKAO -> kakaoSocialService;
-            // case GOOGLE -> googleSocialService;
-            default -> throw new BadRequestException(MemberErrorCode.SOCIAL_TYPE_BAD_REQUEST);
-        };
-    }
+	/**
+	 * 소셜 서비스에서 사용자 정보를 조회하는 메서드.
+	 * 소셜 타입에 따라 적절한 소셜 서비스를 사용하여 로그인 정보를 가져옴.
+	 *
+	 * @param authorizationCode 소셜 인증 코드
+	 * @param loginRequest 로그인 요청 정보
+	 * @return 소셜 서비스에서 가져온 사용자 정보(MemberInfoResponse)
+	 */
+	private MemberInfoResponse findMemberInfoFromSocialService(final String authorizationCode,
+		final MemberLoginRequest loginRequest) {
+		SocialService socialService = findSocialService(loginRequest.socialType());
+		return socialService.login(authorizationCode, loginRequest);
+	}
 
-    /**
-     * 사용자 정보를 기반으로 로그인 또는 회원가입을 처리한 후 로그인 성공 응답을 생성하는 메서드.
-     * 사용자가 존재하면 로그인 처리를, 존재하지 않으면 회원가입 후 로그인 처리를 수행.
-     *
-     * @param memberInfoResponse 소셜 서비스에서 가져온 사용자 정보
-     * @return 로그인 성공 응답(LoginSuccessResponse)
-     */
-    private LoginSuccessResponse generateLoginResponseFromMemberInfo(final MemberInfoResponse memberInfoResponse) {
-        Long memberId = findOrRegisterMember(memberInfoResponse);
+	/**
+	 * 소셜 타입에 맞는 SocialService를 반환하는 메서드.
+	 * 소셜 로그인 타입이 KAKAO인지, GOOGLE인지 등에 따라 적절한 서비스를 반환.
+	 *
+	 * @param socialType 소셜 타입(KAKAO, GOOGLE 등)
+	 * @return 적절한 SocialService 구현체
+	 */
+	private SocialService findSocialService(SocialType socialType) {
+		return switch (socialType) {
+			case KAKAO -> kakaoSocialService;
+			// case GOOGLE -> googleSocialService;
+			default -> throw new BadRequestException(MemberErrorCode.SOCIAL_TYPE_BAD_REQUEST);
+		};
+	}
 
-        Users user = memberService.findUserByMemberId(memberId);
+	/**
+	 * 사용자 정보를 기반으로 로그인 또는 회원가입을 처리한 후 로그인 성공 응답을 생성하는 메서드.
+	 * 사용자가 존재하면 로그인 처리를, 존재하지 않으면 회원가입 후 로그인 처리를 수행.
+	 *
+	 * @param memberInfoResponse 소셜 서비스에서 가져온 사용자 정보
+	 * @return 로그인 성공 응답(LoginSuccessResponse)
+	 */
+	private LoginSuccessResponse generateLoginResponseFromMemberInfo(final MemberInfoResponse memberInfoResponse) {
+		Long memberId = findOrRegisterMember(memberInfoResponse);
+		entityManager.flush();
 
-        return authenticationService.generateLoginSuccessResponse(memberId, user, memberInfoResponse);
-    }
+		Users user = memberService.findUserByMemberId(memberId);
 
-    /**
-     * 사용자 정보(Social ID와 Social Type)를 통해 기존 회원을 찾거나,
-     * 없으면 새로운 회원을 등록하는 메서드.
-     *
-     * @param memberInfoResponse 소셜 서비스에서 가져온 사용자 정보
-     * @return 등록된 회원 또는 기존 회원의 ID
-     */
-    private Long findOrRegisterMember(final MemberInfoResponse memberInfoResponse) {
-        boolean memberExists = memberService.checkMemberExistsBySocialIdAndSocialType(memberInfoResponse.socialId(), memberInfoResponse.socialType());
+		return authenticationService.generateLoginSuccessResponse(memberId, user, memberInfoResponse);
+	}
 
-        if (memberExists) {
-            Member existingMember = memberService.findMemberBySocialIdAndSocialType(memberInfoResponse.socialId(), memberInfoResponse.socialType());
-            return existingMember.getId();
-        }
+	/**
+	 * 사용자 정보(Social ID와 Social Type)를 통해 기존 회원을 찾거나,
+	 * 없으면 새로운 회원을 등록하는 메서드.
+	 *
+	 * @param memberInfoResponse 소셜 서비스에서 가져온 사용자 정보
+	 * @return 등록된 회원 또는 기존 회원의 ID
+	 */
+	private Long findOrRegisterMember(final MemberInfoResponse memberInfoResponse) {
+		boolean memberExists = memberService.checkMemberExistsBySocialIdAndSocialType(memberInfoResponse.socialId(),
+			memberInfoResponse.socialType());
 
-        return memberRegistrationService.registerMemberWithUserInfo(memberInfoResponse);
-    }
+		if (memberExists) {
+			Member existingMember = memberService.findMemberBySocialIdAndSocialType(memberInfoResponse.socialId(),
+				memberInfoResponse.socialType());
+			return existingMember.getId();
+		}
+
+		return memberRegistrationService.registerMemberWithUserInfo(memberInfoResponse);
+	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #229 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### flush() 호출
- role을 Member로 등록하고 저장 시, flush()를 호출하여 변경 사항을 데이터베이스에 반영하도록 했습니다.

- 회원 정보 조회 시, memberService.findUserByMemberId(memberId)를 호출하여 방금 등록한 회원의 Users 정보를 조회할 때, 데이터베이스에 변경 사항이 반영되어 있으므로, 정상적으로 데이터를 가져올 수 있게 됩니다.

### Propagation.REQUIRES_NEW 
- 대안으로 Propagation.REQUIRES_NEW를 이용해 새로운 트랜잭션을 시작하여 회원 등록을 커밋할 수 있지만, 상위 트랜잭션이 롤백되더라도 하위 트랜잭션의 변경 사항은 롤백되지 않아 데이터 일관성 문제가 발생할 수 있다고 해서 사용하지 않았습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

### 트랜잭션 전파 관련(ROLE을 USER로 부여하는 문제)
- 제 생각에는 트랜잭션 전파 관련 역할을 MEMBER로 저장하는 과정이 flush되지 않고, 후속 로직이 실행되기 때문에 역할이 default값인 USER로 들어갔을 수도 있다고 판단됩니다!!
