### PR TITLE
[HOTFIX] #233 - memberId로 User객체를 잘못 조회했던 문제 해결

### DIFF
--- a/src/main/java/com/beat/admin/facade/AdminFacade.java
+++ b/src/main/java/com/beat/admin/facade/AdminFacade.java
@@ -40,26 +40,26 @@ public class AdminFacade {
 	private final PromotionUseCase promotionUseCase;
 
 	public UserFindAllResponse checkMemberAndFindAllUsers(Long memberId) {
-		memberUseCase.findMemberById(memberId);
+		memberUseCase.findMemberByMemberId(memberId);
 		List<Users> users = userUseCase.findAllUsers();
 		return UserFindAllResponse.from(users);
 	}
 
 	public CarouselPresignedUrlFindAllResponse checkMemberAndIssueAllPresignedUrlsForCarousel(Long memberId,
 		List<String> carouselImages) {
-		memberUseCase.findMemberById(memberId);
+		memberUseCase.findMemberByMemberId(memberId);
 		Map<String, String> carouselPresignedUrls = fileUseCase.issueAllPresignedUrlsForCarousel(carouselImages);
 		return CarouselPresignedUrlFindAllResponse.from(carouselPresignedUrls);
 	}
 
 	public BannerPresignedUrlFindResponse checkMemberAndIssuePresignedUrlForBanner(Long memberId, String bannerImage) {
-		memberUseCase.findMemberById(memberId);
+		memberUseCase.findMemberByMemberId(memberId);
 		String bannerPresignedUrl = fileUseCase.issuePresignedUrlForBanner(bannerImage);
 		return BannerPresignedUrlFindResponse.from(bannerPresignedUrl);
 	}
 
 	public CarouselFindAllResponse checkMemberAndFindAllPromotionsSortedByCarouselNumber(Long memberId) {
-		memberUseCase.findMemberById(memberId);
+		memberUseCase.findMemberByMemberId(memberId);
 		List<Promotion> promotions = adminUsecase.findAllPromotionsSortedByCarouselNumber();
 		return CarouselFindAllResponse.from(promotions);
 	}
@@ -67,7 +67,7 @@ public class AdminFacade {
 	public CarouselHandleAllResponse checkMemberAndProcessAllPromotionsSortedByCarouselNumber(Long memberId,
 		CarouselHandleRequest request) {
 
-		memberUseCase.findMemberById(memberId);
+		memberUseCase.findMemberByMemberId(memberId);
 
 		List<PromotionModifyRequest> modifyRequests = new ArrayList<>();
 		List<PromotionGenerateRequest> generateRequests = new ArrayList<>();

--- a/src/main/java/com/beat/domain/member/application/MemberService.java
+++ b/src/main/java/com/beat/domain/member/application/MemberService.java
@@ -8,8 +8,10 @@ import com.beat.domain.member.port.in.MemberUseCase;
 import com.beat.domain.user.dao.UserRepository;
 import com.beat.domain.user.domain.Users;
 import com.beat.global.common.exception.*;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,34 +20,34 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service
 public class MemberService implements MemberUseCase {
-    private final UserRepository userRepository;
-    private final MemberRepository memberRepository;
+	private final UserRepository userRepository;
+	private final MemberRepository memberRepository;
 
-    @Transactional
-    public void deleteUser(final Long id) {
-        Users users = userRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+	@Override
+	@Transactional(readOnly = true)
+	public Member findMemberByMemberId(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+	}
 
-        userRepository.delete(users);
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public boolean checkMemberExistsBySocialIdAndSocialType(final Long socialId, final SocialType socialType) {
+		return memberRepository.findBySocialTypeAndSocialId(socialId, socialType).isPresent();
+	}
 
-    public boolean checkMemberExistsBySocialIdAndSocialType(final Long socialId, final SocialType socialType) {
-        return memberRepository.findBySocialTypeAndSocialId(socialId, socialType).isPresent();
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public Member findMemberBySocialIdAndSocialType(final Long socialId, final SocialType socialType) {
+		return memberRepository.findBySocialTypeAndSocialId(socialId, socialType)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+	}
 
-    public Member findMemberBySocialIdAndSocialType(final Long socialId, final SocialType socialType) {
-        return memberRepository.findBySocialTypeAndSocialId(socialId, socialType)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-    }
+	@Transactional
+	public void deleteUser(final Long id) {
+		Users users = userRepository.findById(id)
+			.orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-    public Users findUserByMemberId(final Long memberId) {
-        return userRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-    }
-
-    @Override
-    public Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
-    }
+		userRepository.delete(users);
+	}
 }

--- a/src/main/java/com/beat/domain/member/application/SocialLoginService.java
+++ b/src/main/java/com/beat/domain/member/application/SocialLoginService.java
@@ -27,7 +27,6 @@ public class SocialLoginService {
 	private final MemberRegistrationService memberRegistrationService;
 	private final AuthenticationService authenticationService;
 	private final KakaoSocialService kakaoSocialService;
-	private final UserUseCase userUseCase;
 	private final MemberUseCase memberUseCase;
 
 	/**
@@ -90,7 +89,7 @@ public class SocialLoginService {
 		log.info("Found or registered member with memberId: {}", memberId);
 
 		Member member = memberUseCase.findMemberByMemberId(memberId);
-		Users user = userUseCase.findUserByUserId(member.getUser().getId());
+		Users user = member.getUser();
 
 		log.info("User role before generating token: {}", user.getRole());
 

--- a/src/main/java/com/beat/domain/member/port/in/MemberUseCase.java
+++ b/src/main/java/com/beat/domain/member/port/in/MemberUseCase.java
@@ -1,7 +1,14 @@
 package com.beat.domain.member.port.in;
 
 import com.beat.domain.member.domain.Member;
+import com.beat.domain.member.domain.SocialType;
 
 public interface MemberUseCase {
-    Member findMemberById(Long memberId);
+    Member findMemberByMemberId(Long memberId);
+
+    boolean checkMemberExistsBySocialIdAndSocialType(Long socialId, SocialType socialType);
+
+    Member findMemberBySocialIdAndSocialType(Long socialId, SocialType socialType);
+
+    void deleteUser(Long id);
 }

--- a/src/main/java/com/beat/domain/user/application/UserService.java
+++ b/src/main/java/com/beat/domain/user/application/UserService.java
@@ -2,8 +2,12 @@ package com.beat.domain.user.application;
 
 import com.beat.domain.user.dao.UserRepository;
 import com.beat.domain.user.domain.Users;
+import com.beat.domain.user.exception.UserErrorCode;
 import com.beat.domain.user.port.in.UserUseCase;
+import com.beat.global.common.exception.NotFoundException;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,11 +16,18 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class UserService implements UserUseCase {
-    private final UserRepository userRepository;
+	private final UserRepository userRepository;
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<Users> findAllUsers() {
-        return userRepository.findAll();
-    }
+	@Override
+	@Transactional(readOnly = true)
+	public List<Users> findAllUsers() {
+		return userRepository.findAll();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Users findUserByUserId(final Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/beat/domain/user/port/in/UserUseCase.java
+++ b/src/main/java/com/beat/domain/user/port/in/UserUseCase.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface UserUseCase {
     List<Users> findAllUsers();
+
+    Users findUserByUserId(final Long userId);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #233 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 기존에 memberId로 User 객체를 잘못 조회했던 부분을 해결했습니다.
- 해결 방법은 memberId로 Member 객체를 조회하고, getUser()를 사용하여 user 객체를 바로 참조하도록 변경하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### 2024.10.04 오후 5시 20분 ADMIN 권한 확인

<img width="1476" alt="image" src="https://github.com/user-attachments/assets/ad747376-86e6-446b-b39b-c05745c9180f">

- 토큰에 Role을 ADMIN으로 권한을 잘 저장하는지 확인 완료


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
