### PR TITLE
[fix] #235 - 초 단위에 맞게 TTL 변경

### DIFF
--- a/src/main/java/com/beat/global/auth/redis/Token.java
+++ b/src/main/java/com/beat/global/auth/redis/Token.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
-@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 1000L * 14)
+@RedisHash(value = "refreshToken", timeToLive = 1209600)
 @Getter
 @Builder
 public class Token {


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #235

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- TTL의 단위는 초(sec)이기 때문에, 단위를 맞춰 리프레시 토큰의 만료일과 일치시키는 작업을 수행하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
