### PR TITLE
[fix] #243 - 공연 생성 및 수정 시 performancePeriod, scheduleNumber 부여 로직 추가

### DIFF
--- a/src/main/java/com/beat/domain/booking/exception/BookingErrorCode.java
+++ b/src/main/java/com/beat/domain/booking/exception/BookingErrorCode.java
@@ -1,21 +1,28 @@
 package com.beat.domain.booking.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum BookingErrorCode implements BaseErrorCode {
-    REQUIRED_DATA_MISSING(400, "필수 데이터가 누락되었습니다."),
-    INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
-    INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
-    NO_BOOKING_FOUND(404, "입력하신 정보와 일치하는 예매 내역이 없습니다. 확인 후 다시 조회해주세요."),
-    NO_TICKETS_FOUND(404, "입력하신 정보와 일치하는 예매자 목록이 없습니다."),
-    NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
-    NO_SCHEDULE_FOUND(404, "회차를 찾을 수 없습니다.")
-    ;
+	/*
+	400 BadRequest
+	*/
+	REQUIRED_DATA_MISSING(400, "필수 데이터가 누락되었습니다."),
+	INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
+	INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	404 NotFound
+	*/
+	NO_BOOKING_FOUND(404, "입력하신 정보와 일치하는 예매 내역이 없습니다. 확인 후 다시 조회해주세요."),
+	NO_TICKETS_FOUND(404, "입력하신 정보와 일치하는 예매자 목록이 없습니다."),
+	NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
+	NO_SCHEDULE_FOUND(404, "회차를 찾을 수 없습니다.");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/booking/exception/BookingSuccessCode.java
+++ b/src/main/java/com/beat/domain/booking/exception/BookingSuccessCode.java
@@ -1,21 +1,28 @@
 package com.beat.domain.booking.exception;
 
 import com.beat.global.common.exception.base.BaseSuccessCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum BookingSuccessCode implements BaseSuccessCode {
-    MEMBER_BOOKING_SUCCESS(201, "회원 예매가 성공적으로 완료되었습니다"),
-    GUEST_BOOKING_SUCCESS(201, "비회원 예매가 성공적으로 완료되었습니다"),
-    MEMBER_BOOKING_RETRIEVE_SUCCESS(200, "회원 예매 조회가 성공적으로 완료되었습니다."),
-    GUEST_BOOKING_RETRIEVE_SUCCESS(200, "비회원 예매 조회가 성공적으로 완료되었습니다."),
-    TICKET_RETRIEVE_SUCCESS(200, "예매자 목록 조회가 성공적으로 완료되었습니다."),
-    TICKET_UPDATE_SUCCESS(200, "예매자 입금여부 수정이 성공적으로 완료되었습니다."),
-    TICKET_CANCEL_SUCCESS(200, "예매취소 요청이 성공했습니다.")
-    ;
+	/*
+	200 Ok
+	*/
+	MEMBER_BOOKING_RETRIEVE_SUCCESS(200, "회원 예매 조회가 성공적으로 완료되었습니다."),
+	GUEST_BOOKING_RETRIEVE_SUCCESS(200, "비회원 예매 조회가 성공적으로 완료되었습니다."),
+	TICKET_RETRIEVE_SUCCESS(200, "예매자 목록 조회가 성공적으로 완료되었습니다."),
+	TICKET_UPDATE_SUCCESS(200, "예매자 입금여부 수정이 성공적으로 완료되었습니다."),
+	TICKET_CANCEL_SUCCESS(200, "예매취소 요청이 성공했습니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	201 Created
+	*/
+	MEMBER_BOOKING_SUCCESS(201, "회원 예매가 성공적으로 완료되었습니다"),
+	GUEST_BOOKING_SUCCESS(201, "비회원 예매가 성공적으로 완료되었습니다");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/booking/exception/TicketErrorCode.java
+++ b/src/main/java/com/beat/domain/booking/exception/TicketErrorCode.java
@@ -1,14 +1,18 @@
 package com.beat.domain.booking.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum TicketErrorCode implements BaseErrorCode {
-    PAYMENT_COMPLETED_TICKET_UPDATE_NOT_ALLOWED(400, "이미 결제가 완료된 티켓의 상태는 변경할 수 없습니다.");
+	/*
+	400 BadRequest
+	*/
+	PAYMENT_COMPLETED_TICKET_UPDATE_NOT_ALLOWED(400, "이미 결제가 완료된 티켓의 상태는 변경할 수 없습니다.");
 
-    private final int status;
-    private final String message;
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/cast/exception/CastErrorCode.java
+++ b/src/main/java/com/beat/domain/cast/exception/CastErrorCode.java
@@ -1,16 +1,23 @@
 package com.beat.domain.cast.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum CastErrorCode implements BaseErrorCode {
-    CAST_NOT_BELONG_TO_PERFORMANCE(403,"해당 등장인물은 해당 공연에 속해 있지 않습니다."),
-    CAST_NOT_FOUND(404, "등장인물이 존재하지 않습니다.")
-    ;
+	/*
+	403 Forbidden
+	*/
+	CAST_NOT_BELONG_TO_PERFORMANCE(403, "해당 등장인물은 해당 공연에 속해 있지 않습니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	404 NotFound
+	*/
+	CAST_NOT_FOUND(404, "등장인물이 존재하지 않습니다.");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/beat/domain/member/exception/MemberErrorCode.java
@@ -1,15 +1,23 @@
 package com.beat.domain.member.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
-    MEMBER_NOT_FOUND(404, "회원이 없습니다"),
-    SOCIAL_TYPE_BAD_REQUEST(400, "로그인 요청이 유효하지 않습니다.");
+	/*
+	400 BadRequest
+	*/
+	SOCIAL_TYPE_BAD_REQUEST(400, "로그인 요청이 유효하지 않습니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	404 NotFound
+	*/
+	MEMBER_NOT_FOUND(404, "회원이 없습니다");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/beat/domain/member/exception/MemberSuccessCode.java
@@ -1,18 +1,22 @@
 package com.beat.domain.member.exception;
 
 import com.beat.global.common.exception.base.BaseSuccessCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum MemberSuccessCode implements BaseSuccessCode {
-    SIGN_UP_SUCCESS(200, "로그인 성공"),
-    ISSUE_ACCESS_TOKEN_SUCCESS(200, "엑세스토큰 발급 성공"),
-    ISSUE_REFRESH_TOKEN_SUCCESS(200, "리프레쉬토큰 발급 성공"),
-    SIGN_OUT_SUCCESS(200, "로그아웃 성공"),
-    USER_DELETE_SUCCESS(200, "회원 탈퇴 성공");
+	/*
+	200 Ok
+	*/
+	SIGN_UP_SUCCESS(200, "로그인 성공"),
+	ISSUE_ACCESS_TOKEN_SUCCESS(200, "엑세스토큰 발급 성공"),
+	ISSUE_REFRESH_TOKEN_SUCCESS(200, "리프레쉬토큰 발급 성공"),
+	SIGN_OUT_SUCCESS(200, "로그아웃 성공"),
+	USER_DELETE_SUCCESS(200, "회원 탈퇴 성공");
 
-    private final int status;
-    private final String message;
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
@@ -79,7 +79,7 @@ public class PerformanceManagementService {
 			request.performanceTeamName(),
 			request.performanceVenue(),
 			request.performanceContact(),
-			" ",
+			" ", // 이후 dto 변경 필요
 			request.ticketPrice(),
 			request.totalScheduleCount(),
 			user

--- a/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceManagementService.java
@@ -79,7 +79,7 @@ public class PerformanceManagementService {
 			request.performanceTeamName(),
 			request.performanceVenue(),
 			request.performanceContact(),
-			request.performancePeriod(),
+			" ",
 			request.ticketPrice(),
 			request.totalScheduleCount(),
 			user
@@ -101,9 +101,17 @@ public class PerformanceManagementService {
 				);
 			})
 			.collect(Collectors.toList());
+
+		performance.assignScheduleNumbers(schedules);
 		scheduleRepository.saveAll(schedules);
 
 		schedules.forEach(jobSchedulerService::addScheduleIfNotExists);
+
+		List<LocalDateTime> performanceDates = schedules.stream()
+			.map(Schedule::getPerformanceDate)
+			.collect(Collectors.toList());
+		performance.updatePerformancePeriod(performanceDates);
+		performanceRepository.save(performance);
 
 		List<Cast> casts = request.castList().stream()
 			.map(castRequest -> Cast.create(

--- a/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
@@ -3,7 +3,6 @@ package com.beat.domain.performance.application;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -144,6 +143,11 @@ public class PerformanceModifyService {
 			request.totalScheduleCount()
 		);
 
+		List<LocalDateTime> performanceDates = request.scheduleModifyRequests().stream()
+			.map(ScheduleModifyRequest::performanceDate)
+			.collect(Collectors.toList());
+		performance.updatePerformancePeriod(performanceDates);
+
 		if (!isBookerExist) {
 			log.debug("Updating ticket price to {}", request.ticketPrice());
 			performance.updateTicketPrice(request.ticketPrice());
@@ -186,7 +190,7 @@ public class PerformanceModifyService {
 			})
 			.collect(Collectors.toList());
 
-		assignScheduleNumbers(schedules);
+		performance.assignScheduleNumbers(schedules);
 
 		return schedules.stream()
 			.map(schedule -> ScheduleModifyResponse.of(
@@ -197,15 +201,6 @@ public class PerformanceModifyService {
 				schedule.getScheduleNumber()
 			))
 			.collect(Collectors.toList());
-	}
-
-	private void assignScheduleNumbers(List<Schedule> schedules) {
-		schedules.sort(Comparator.comparing(Schedule::getPerformanceDate));
-
-		for (int i = 0; i < schedules.size(); i++) {
-			ScheduleNumber scheduleNumber = ScheduleNumber.values()[i];
-			schedules.get(i).updateScheduleNumber(scheduleNumber);
-		}
 	}
 
 	private Schedule addSchedule(ScheduleModifyRequest request, Performance performance) {

--- a/src/main/java/com/beat/domain/performance/domain/Performance.java
+++ b/src/main/java/com/beat/domain/performance/domain/Performance.java
@@ -1,158 +1,209 @@
 package com.beat.domain.performance.domain;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import com.beat.domain.BaseTimeEntity;
 import com.beat.domain.performance.exception.PerformanceErrorCode;
 import com.beat.domain.promotion.domain.Promotion;
+import com.beat.domain.schedule.domain.Schedule;
+import com.beat.domain.schedule.domain.ScheduleNumber;
 import com.beat.domain.user.domain.Users;
 import com.beat.global.common.exception.BadRequestException;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Performance extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private String performanceTitle;
+	@Column(nullable = false)
+	private String performanceTitle;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Genre genre;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Genre genre;
 
-    @Column(nullable = false)
-    private int runningTime;
+	@Column(nullable = false)
+	private int runningTime;
 
-    @Column(nullable = false, length = 500)
-    private String performanceDescription;
+	@Column(nullable = false, length = 500)
+	private String performanceDescription;
 
-    @Column(nullable = false, length = 500)
-    private String performanceAttentionNote;
+	@Column(nullable = false, length = 500)
+	private String performanceAttentionNote;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = true)
-    private BankName bankName;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = true)
+	private BankName bankName;
 
-    @Column(nullable = true)
-    private String accountNumber;
+	@Column(nullable = true)
+	private String accountNumber;
 
-    @Column(nullable = true)
-    private String accountHolder;
+	@Column(nullable = true)
+	private String accountHolder;
 
-    @Column(nullable = false)
-    private String posterImage;
+	@Column(nullable = false)
+	private String posterImage;
 
-    @Column(nullable = false)
-    private String performanceTeamName;
+	@Column(nullable = false)
+	private String performanceTeamName;
 
-    @Column(nullable = false)
-    private String performanceVenue;
+	@Column(nullable = false)
+	private String performanceVenue;
 
-    @Column(nullable = false)
-    private String performanceContact;
+	@Column(nullable = false)
+	private String performanceContact;
 
-    @Column(nullable = false)
-    private String performancePeriod;
+	@Column(nullable = false)
+	private String performancePeriod;
 
-    @Column(nullable = false)
-    private int ticketPrice = 0;
+	@Column(nullable = false)
+	private int ticketPrice = 0;
 
-    @Column(nullable = false)
-    private int totalScheduleCount;
+	@Column(nullable = false)
+	private int totalScheduleCount;
 
-    @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Promotion> promotions = new ArrayList<>();
+	@OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Promotion> promotions = new ArrayList<>();
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private Users users;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	@OnDelete(action = OnDeleteAction.CASCADE)
+	private Users users;
 
-    @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PerformanceImage> performanceImageList = new ArrayList<>();
+	@OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PerformanceImage> performanceImageList = new ArrayList<>();
 
-    @Builder
-    public Performance(String performanceTitle, Genre genre, int runningTime, String performanceDescription, String performanceAttentionNote,
-                       BankName bankName, String accountNumber, String accountHolder, String posterImage, String performanceTeamName, String performanceVenue, String performanceContact,
-                       String performancePeriod, int ticketPrice, int totalScheduleCount, Users users) {
-        this.performanceTitle = performanceTitle;
-        this.genre = genre;
-        this.runningTime = runningTime;
-        this.performanceDescription = performanceDescription;
-        this.performanceAttentionNote = performanceAttentionNote;
-        this.bankName = bankName;
-        this.accountNumber = accountNumber;
-        this.accountHolder = accountHolder;
-        this.posterImage = posterImage;
-        this.performanceTeamName = performanceTeamName;
-        this.performanceVenue = performanceVenue;
-        this.performanceContact = performanceContact;
-        this.performancePeriod = performancePeriod;
-        this.ticketPrice = ticketPrice;
-        this.totalScheduleCount = totalScheduleCount;
-        this.users = users;
-    }
+	@Builder
+	public Performance(String performanceTitle, Genre genre, int runningTime, String performanceDescription,
+		String performanceAttentionNote,
+		BankName bankName, String accountNumber, String accountHolder, String posterImage, String performanceTeamName,
+		String performanceVenue, String performanceContact,
+		String performancePeriod, int ticketPrice, int totalScheduleCount, Users users) {
+		this.performanceTitle = performanceTitle;
+		this.genre = genre;
+		this.runningTime = runningTime;
+		this.performanceDescription = performanceDescription;
+		this.performanceAttentionNote = performanceAttentionNote;
+		this.bankName = bankName;
+		this.accountNumber = accountNumber;
+		this.accountHolder = accountHolder;
+		this.posterImage = posterImage;
+		this.performanceTeamName = performanceTeamName;
+		this.performanceVenue = performanceVenue;
+		this.performanceContact = performanceContact;
+		this.performancePeriod = performancePeriod;
+		this.ticketPrice = ticketPrice;
+		this.totalScheduleCount = totalScheduleCount;
+		this.users = users;
+	}
 
-    public static Performance create(
-            String performanceTitle, Genre genre, int runningTime, String performanceDescription, String performanceAttentionNote,
-            BankName bankName, String accountNumber, String accountHolder, String posterImage, String performanceTeamName, String performanceVenue, String performanceContact,
-            String performancePeriod, int ticketPrice, int totalScheduleCount, Users users) {
-        return Performance.builder()
-                .performanceTitle(performanceTitle)
-                .genre(genre)
-                .runningTime(runningTime)
-                .performanceDescription(performanceDescription)
-                .performanceAttentionNote(performanceAttentionNote)
-                .bankName(bankName)
-                .accountNumber(accountNumber)
-                .accountHolder(accountHolder)
-                .posterImage(posterImage)
-                .performanceTeamName(performanceTeamName)
-                .performanceVenue(performanceVenue)
-                .performanceContact(performanceContact)
-                .performancePeriod(performancePeriod)
-                .ticketPrice(ticketPrice)
-                .totalScheduleCount(totalScheduleCount)
-                .users(users)
-                .build();
-    }
+	public static Performance create(
+		String performanceTitle, Genre genre, int runningTime, String performanceDescription,
+		String performanceAttentionNote,
+		BankName bankName, String accountNumber, String accountHolder, String posterImage, String performanceTeamName,
+		String performanceVenue, String performanceContact,
+		String performancePeriod, int ticketPrice, int totalScheduleCount, Users users) {
+		return Performance.builder()
+			.performanceTitle(performanceTitle)
+			.genre(genre)
+			.runningTime(runningTime)
+			.performanceDescription(performanceDescription)
+			.performanceAttentionNote(performanceAttentionNote)
+			.bankName(bankName)
+			.accountNumber(accountNumber)
+			.accountHolder(accountHolder)
+			.posterImage(posterImage)
+			.performanceTeamName(performanceTeamName)
+			.performanceVenue(performanceVenue)
+			.performanceContact(performanceContact)
+			.performancePeriod(performancePeriod)
+			.ticketPrice(ticketPrice)
+			.totalScheduleCount(totalScheduleCount)
+			.users(users)
+			.build();
+	}
 
-    public void update(
-            String performanceTitle, Genre genre, int runningTime, String performanceDescription, String performanceAttentionNote,
-            BankName bankName, String accountNumber, String accountHolder, String posterImage, String performanceTeamName, String performanceVenue, String performanceContact,
-            String performancePeriod, int totalScheduleCount) {
-        this.performanceTitle = performanceTitle;
-        this.genre = genre;
-        this.runningTime = runningTime;
-        this.performanceDescription = performanceDescription;
-        this.performanceAttentionNote = performanceAttentionNote;
-        this.bankName = bankName;
-        this.accountNumber = accountNumber;
-        this.accountHolder = accountHolder;
-        this.posterImage = posterImage;
-        this.performanceTeamName = performanceTeamName;
-        this.performanceVenue = performanceVenue;
-        this.performanceContact = performanceContact;
-        this.performancePeriod = performancePeriod;
-        this.totalScheduleCount = totalScheduleCount;
-    }
+	public void update(
+		String performanceTitle, Genre genre, int runningTime, String performanceDescription,
+		String performanceAttentionNote,
+		BankName bankName, String accountNumber, String accountHolder, String posterImage, String performanceTeamName,
+		String performanceVenue, String performanceContact,
+		String performancePeriod, int totalScheduleCount) {
+		this.performanceTitle = performanceTitle;
+		this.genre = genre;
+		this.runningTime = runningTime;
+		this.performanceDescription = performanceDescription;
+		this.performanceAttentionNote = performanceAttentionNote;
+		this.bankName = bankName;
+		this.accountNumber = accountNumber;
+		this.accountHolder = accountHolder;
+		this.posterImage = posterImage;
+		this.performanceTeamName = performanceTeamName;
+		this.performanceVenue = performanceVenue;
+		this.performanceContact = performanceContact;
+		this.performancePeriod = performancePeriod;
+		this.totalScheduleCount = totalScheduleCount;
+	}
 
-    public void updateTicketPrice(int newTicketPrice) {
-        if (newTicketPrice < 0) {
-            throw new BadRequestException(PerformanceErrorCode.NEGATIVE_TICKET_PRICE);
-        }
-        this.ticketPrice = newTicketPrice;
-    }
+	public void updateTicketPrice(int newTicketPrice) {
+		if (newTicketPrice < 0) {
+			throw new BadRequestException(PerformanceErrorCode.NEGATIVE_TICKET_PRICE);
+		}
+		this.ticketPrice = newTicketPrice;
+	}
+
+	public void updatePerformancePeriod(List<LocalDateTime> performanceDates) {
+		if (performanceDates.isEmpty()) {
+			throw new BadRequestException(PerformanceErrorCode.SCHEDULE_LIST_NOT_FOUND);
+		}
+
+		LocalDateTime startDate = performanceDates.stream().min(Comparator.naturalOrder()).get();
+		LocalDateTime endDate = performanceDates.stream().max(Comparator.naturalOrder()).get();
+
+		this.performancePeriod = formatPerformancePeriod(startDate, endDate);
+	}
+
+	private String formatPerformancePeriod(LocalDateTime startDate, LocalDateTime endDate) {
+		if (startDate.toLocalDate().equals(endDate.toLocalDate())) {
+			return startDate.toLocalDate().toString().replace("-", ".");
+		} else {
+			return startDate.toLocalDate().toString().replace("-", ".")
+				+ "~" + endDate.toLocalDate().toString().replace("-", ".");
+		}
+	}
+
+	public void assignScheduleNumbers(List<Schedule> schedules) {
+		schedules.sort(Comparator.comparing(Schedule::getPerformanceDate));
+		for (int i = 0; i < schedules.size(); i++) {
+			ScheduleNumber scheduleNumber = ScheduleNumber.values()[i];
+			schedules.get(i).setScheduleNumber(scheduleNumber);
+		}
+	}
 }

--- a/src/main/java/com/beat/domain/performance/domain/Performance.java
+++ b/src/main/java/com/beat/domain/performance/domain/Performance.java
@@ -193,17 +193,19 @@ public class Performance extends BaseTimeEntity {
 	private String formatPerformancePeriod(LocalDateTime startDate, LocalDateTime endDate) {
 		if (startDate.toLocalDate().equals(endDate.toLocalDate())) {
 			return startDate.toLocalDate().toString().replace("-", ".");
-		} else {
-			return startDate.toLocalDate().toString().replace("-", ".")
-				+ "~" + endDate.toLocalDate().toString().replace("-", ".");
 		}
+		return startDate.toLocalDate().toString().replace("-", ".")
+			+ "~" + endDate.toLocalDate().toString().replace("-", ".");
 	}
 
 	public void assignScheduleNumbers(List<Schedule> schedules) {
+		List<ScheduleNumber> scheduleNumbers = List.of(ScheduleNumber.values());
 		schedules.sort(Comparator.comparing(Schedule::getPerformanceDate));
+
 		for (int i = 0; i < schedules.size(); i++) {
-			ScheduleNumber scheduleNumber = ScheduleNumber.values()[i];
-			schedules.get(i).setScheduleNumber(scheduleNumber);
+			if (i < scheduleNumbers.size()) {
+				schedules.get(i).setScheduleNumber(scheduleNumbers.get(i));
+			}
 		}
 	}
 }

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -8,22 +8,25 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PerformanceErrorCode implements BaseErrorCode {
-	PERFORMANCE_NOT_FOUND(404, "해당 공연 정보를 찾을 수 없습니다."),
 	REQUIRED_DATA_MISSING(400, "필수 데이터가 누락되었습니다."),
 	INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
 	INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
 	PRICE_UPDATE_NOT_ALLOWED(400, "예매자가 존재하여 가격을 수정할 수 없습니다."),
 	NEGATIVE_TICKET_PRICE(400, "티켓 가격은 음수일 수 없습니다."),
-	NO_PERFORMANCE_FOUND(404, "공연을 찾을 수 없습니다."),
-	PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
-	NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
 	MAX_SCHEDULE_LIMIT_EXCEEDED(400, "공연 회차는 최대 10개까지 추가할 수 있습니다."),
 	INVALID_PERFORMANCE_DESCRIPTION_LENGTH(400, "공연 소개 글자수가 500자를 초과했습니다."),
 	INVALID_ATTENTION_NOTE_LENGTH(400, "공연 유의사항 글자수가 500자를 초과했습니다."),
-	INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
 	PAST_SCHEDULE_NOT_ALLOWED(400, "과거 날짜 회차를 포함한 공연을 생성할 수 없습니다."),
 	SCHEDULE_MODIFICATION_NOT_ALLOWED_FOR_ENDED_SCHEDULE(400, "종료된 회차를 수정할 수 없습니다."),
-	INVALID_TICKET_COUNT(400, "판매된 티켓 수보다 적은 수로 판매할 티켓 매수를 수정할 수 없습니다.");
+	INVALID_TICKET_COUNT(400, "판매된 티켓 수보다 적은 수로 판매할 티켓 매수를 수정할 수 없습니다."),
+
+	PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
+	NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
+
+	PERFORMANCE_NOT_FOUND(404, "해당 공연 정보를 찾을 수 없습니다."),
+	SCHEDULE_LIST_NOT_FOUND(404, "스케쥴 리스트에 스케쥴이 없습니다."),
+
+	INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceErrorCode.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PerformanceErrorCode implements BaseErrorCode {
+	/*
+	400 BadRequest
+	*/
 	REQUIRED_DATA_MISSING(400, "필수 데이터가 누락되었습니다."),
 	INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
 	INVALID_REQUEST_FORMAT(400, "잘못된 요청 형식입니다."),
@@ -20,12 +23,21 @@ public enum PerformanceErrorCode implements BaseErrorCode {
 	SCHEDULE_MODIFICATION_NOT_ALLOWED_FOR_ENDED_SCHEDULE(400, "종료된 회차를 수정할 수 없습니다."),
 	INVALID_TICKET_COUNT(400, "판매된 티켓 수보다 적은 수로 판매할 티켓 매수를 수정할 수 없습니다."),
 
+	/*
+	403 Forbidden
+	*/
 	PERFORMANCE_DELETE_FAILED(403, "예매자가 1명 이상 있을 경우, 공연을 삭제할 수 없습니다."),
 	NOT_PERFORMANCE_OWNER(403, "해당 공연의 메이커가 아닙니다."),
 
+	/*
+	404 NotFound
+	*/
 	PERFORMANCE_NOT_FOUND(404, "해당 공연 정보를 찾을 수 없습니다."),
 	SCHEDULE_LIST_NOT_FOUND(404, "스케쥴 리스트에 스케쥴이 없습니다."),
 
+	/*
+	500 InternalServerError
+	*/
 	INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.");
 
 	private final int status;

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceImageErrorCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceImageErrorCode.java
@@ -1,16 +1,23 @@
 package com.beat.domain.performance.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum PerformanceImageErrorCode implements BaseErrorCode {
-    PERFORMANCE_IMAGE_NOT_FOUND(404, "해당 공연 상세이미지를 찾을 수 없습니다."),
-    PERFORMANCE_IMAGE_NOT_BELONG_TO_PERFORMANCE(403, "해당 싱세이미지는 해당 공연에 속해 있지 않습니다.")
-    ;
+	/*
+	403 Forbidden
+	*/
+	PERFORMANCE_IMAGE_NOT_BELONG_TO_PERFORMANCE(403, "해당 싱세이미지는 해당 공연에 속해 있지 않습니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	404 NotFound
+	*/
+	PERFORMANCE_IMAGE_NOT_FOUND(404, "해당 공연 상세이미지를 찾을 수 없습니다.");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
+++ b/src/main/java/com/beat/domain/performance/exception/PerformanceSuccessCode.java
@@ -1,22 +1,29 @@
 package com.beat.domain.performance.exception;
 
 import com.beat.global.common.exception.base.BaseSuccessCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum PerformanceSuccessCode implements BaseSuccessCode {
-    PERFORMANCE_CREATE_SUCCESS(201, "공연이 성공적으로 생성되었습니다."),
-    PERFORMANCE_UPDATE_SUCCESS(200, "공연이 성공적으로 수정되었습니다."),
-    PERFORMANCE_RETRIEVE_SUCCESS(200, "공연 상세 정보 조회가 성공적으로 완료되었습니다."),
-    PERFORMANCE_MODIFY_PAGE_SUCCESS(200, "공연 수정 페이지 조회가 성공적으로 완료되었습니다."),
-    PERFORMANCE_DELETE_SUCCESS(200, "공연이 성공적으로 삭제되었습니다."),
-    BOOKING_PERFORMANCE_RETRIEVE_SUCCESS(200, "예매 관련 공연 정보 조회가 성공적으로 완료되었습니다."),
-    HOME_PERFORMANCE_RETRIEVE_SUCCESS(200, "홈 화면 공연 목록 조회가 성공적으로 완료되었습니다."),
-    MAKER_PERFORMANCE_RETRIEVE_SUCCESS(200, "회원이 등록한 공연 목록의 조회가 성공적으로 완료되었습니다.")
-    ;
+	/*
+	200 Ok
+	*/
+	PERFORMANCE_UPDATE_SUCCESS(200, "공연이 성공적으로 수정되었습니다."),
+	PERFORMANCE_RETRIEVE_SUCCESS(200, "공연 상세 정보 조회가 성공적으로 완료되었습니다."),
+	PERFORMANCE_MODIFY_PAGE_SUCCESS(200, "공연 수정 페이지 조회가 성공적으로 완료되었습니다."),
+	PERFORMANCE_DELETE_SUCCESS(200, "공연이 성공적으로 삭제되었습니다."),
+	BOOKING_PERFORMANCE_RETRIEVE_SUCCESS(200, "예매 관련 공연 정보 조회가 성공적으로 완료되었습니다."),
+	HOME_PERFORMANCE_RETRIEVE_SUCCESS(200, "홈 화면 공연 목록 조회가 성공적으로 완료되었습니다."),
+	MAKER_PERFORMANCE_RETRIEVE_SUCCESS(200, "회원이 등록한 공연 목록의 조회가 성공적으로 완료되었습니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	201 Created
+	*/
+	PERFORMANCE_CREATE_SUCCESS(201, "공연이 성공적으로 생성되었습니다.");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/promotion/exception/PromotionErrorCode.java
+++ b/src/main/java/com/beat/domain/promotion/exception/PromotionErrorCode.java
@@ -8,8 +8,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PromotionErrorCode implements BaseErrorCode {
-	PROMOTION_NOT_FOUND(404,"해당 홍보 정보를 찾을 수 없습니다.")
-	;
+	/*
+	404 NotFound
+	*/
+	PROMOTION_NOT_FOUND(404, "해당 홍보 정보를 찾을 수 없습니다.");
 	private final int status;
 	private final String message;
 }

--- a/src/main/java/com/beat/domain/schedule/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/beat/domain/schedule/exception/ScheduleErrorCode.java
@@ -1,19 +1,34 @@
 package com.beat.domain.schedule.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum ScheduleErrorCode implements BaseErrorCode {
-    INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
-    SCHEDULE_NOT_BELONG_TO_PERFORMANCE(403,"해당 스케줄은 해당 공연에 속해 있지 않습니다."),
-    NO_SCHEDULE_FOUND(404, "해당 회차를 찾을 수 없습니다."),
-    INSUFFICIENT_TICKETS(409, "요청한 티켓 수량이 잔여 티켓 수를 초과했습니다. 다른 수량을 선택해 주세요."),
-    EXCESS_TICKET_DELETE(409, "예매된 티켓 수 이상을 삭제할 수 없습니다.")
-    ;
+	/*
+	400 BadRequest
+	*/
+	INVALID_DATA_FORMAT(400, "잘못된 데이터 형식입니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	403 Forbidden
+	*/
+	SCHEDULE_NOT_BELONG_TO_PERFORMANCE(403, "해당 스케줄은 해당 공연에 속해 있지 않습니다."),
+
+	/*
+	404 NotFound
+	*/
+	NO_SCHEDULE_FOUND(404, "해당 회차를 찾을 수 없습니다."),
+
+	/*
+	409 Conflict
+	*/
+	INSUFFICIENT_TICKETS(409, "요청한 티켓 수량이 잔여 티켓 수를 초과했습니다. 다른 수량을 선택해 주세요."),
+	EXCESS_TICKET_DELETE(409, "예매된 티켓 수 이상을 삭제할 수 없습니다.");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/schedule/exception/ScheduleSuccessCode.java
+++ b/src/main/java/com/beat/domain/schedule/exception/ScheduleSuccessCode.java
@@ -1,15 +1,18 @@
 package com.beat.domain.schedule.exception;
 
 import com.beat.global.common.exception.base.BaseSuccessCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum ScheduleSuccessCode implements BaseSuccessCode {
-    TICKET_AVAILABILITY_RETRIEVAL_SUCCESS(200, "티켓 수량 조회가 성공적으로 완료되었습니다.")
-    ;
+	/*
+	200 Ok
+	*/
+	TICKET_AVAILABILITY_RETRIEVAL_SUCCESS(200, "티켓 수량 조회가 성공적으로 완료되었습니다.");
 
-    private final int status;
-    private final String message;
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/staff/exception/StaffErrorCode.java
+++ b/src/main/java/com/beat/domain/staff/exception/StaffErrorCode.java
@@ -1,16 +1,23 @@
 package com.beat.domain.staff.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum StaffErrorCode implements BaseErrorCode {
-    STAFF_NOT_BELONG_TO_PERFORMANCE(403, "해당 스태프는 해당 공연에 속해있지 않습니다."),
-    STAFF_NOT_FOUND(404, "스태프가 존재하지 않습니다.")
-    ;
+	/*
+	403 Forbidden
+	*/
+	STAFF_NOT_BELONG_TO_PERFORMANCE(403, "해당 스태프는 해당 공연에 속해있지 않습니다."),
 
-    private final int status;
-    private final String message;
+	/*
+	404 NotFound
+	*/
+	STAFF_NOT_FOUND(404, "스태프가 존재하지 않습니다.");
+
+	private final int status;
+	private final String message;
 }

--- a/src/main/java/com/beat/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/beat/domain/user/exception/UserErrorCode.java
@@ -1,15 +1,18 @@
 package com.beat.domain.user.exception;
 
 import com.beat.global.common.exception.base.BaseErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
-    USER_NOT_FOUND(404, "유저가 없습니다")
-    ;
+	/*
+	404 NotFound
+	*/
+	USER_NOT_FOUND(404, "유저가 없습니다");
 
-    private final int status;
-    private final String message;
+	private final int status;
+	private final String message;
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #243 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 공연 생성, 수정 시 request body의 schduleList의 회차날짜를 기준으로 performancePeriod를 생성하고, schduleNumber를 부여하도록 코드를 수정했습니다.
- 생성과 수정 모두에 사용되는 코드이기에 재사용을 위해 performance에 update 비즈니스 로직을 작성했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
# 공연 생성
<img width="729" alt="image" src="https://github.com/user-attachments/assets/5cf6976b-c39f-4bd6-bcf2-c6cab5ac4af3">

- performanceDate들을 이용해 performancePeriod가 2024.11.10~2024.11.21로 정상적으로 부여된 것을 확인했습니다.
- request에서 schduleNumber를 잘못 작성한 경우에도 schduleNumber가 다시 정상적으로 부여된 것을 확인했습니다.

# 공연 수정
<img width="731" alt="image" src="https://github.com/user-attachments/assets/940e277e-0ef9-4b6d-89e0-bf80226e5a67">

- 수정된 performanceDate들을 이용해 performancePeriod가 2024.11.06~2024.12.31로 정상적으로 부여된 것을 확인했습니다.
- 수정된 회차 날짜에 맞게 schduleNumber가 다시 정상적으로 부여된 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
