### PR TITLE
[fix] #272 - 스웨거에서 ResponseDTO가 잡히지 않는 문제 해결

### DIFF
--- a/src/main/java/com/beat/admin/adapter/in/api/AdminApi.java
+++ b/src/main/java/com/beat/admin/adapter/in/api/AdminApi.java
@@ -31,8 +31,7 @@ public interface AdminApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "관리자 권한으로 모든 유저 조회에 성공하였습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "관리자 권한으로 모든 유저 조회에 성공하였습니다."
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -50,8 +49,7 @@ public interface AdminApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "캐러셀 Presigned URL 발급 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "캐러셀 Presigned URL 발급 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -70,8 +68,7 @@ public interface AdminApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "배너 Presigned URL 발급 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "배너 Presigned URL 발급 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -90,8 +87,7 @@ public interface AdminApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "관리자 권한으로 현재 캐러셀에 등록된 모든 공연 조회에 성공하였습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "관리자 권한으로 현재 캐러셀에 등록된 모든 공연 조회에 성공하였습니다."
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -109,8 +105,7 @@ public interface AdminApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "캐러셀 이미지 수정 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "캐러셀 이미지 수정 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",

--- a/src/main/java/com/beat/domain/booking/api/BookingApi.java
+++ b/src/main/java/com/beat/domain/booking/api/BookingApi.java
@@ -35,8 +35,7 @@ public interface BookingApi {
 		value = {
 			@ApiResponse(
 				responseCode = "201",
-				description = "회원 예매가 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "회원 예매가 성공적으로 완료되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "400",
@@ -80,8 +79,7 @@ public interface BookingApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "회원 예매 조회가 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "회원 예매 조회가 성공적으로 완료되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -99,8 +97,7 @@ public interface BookingApi {
 		value = {
 			@ApiResponse(
 				responseCode = "201",
-				description = "비회원 예매가 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "비회원 예매가 성공적으로 완료되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "400",
@@ -133,8 +130,7 @@ public interface BookingApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "비회원 예매 조회가 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "비회원 예매 조회가 성공적으로 완료되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -152,8 +148,7 @@ public interface BookingApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "유료공연 예매 환불 요청이 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "유료공연 예매 환불 요청이 성공적으로 완료되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -171,8 +166,7 @@ public interface BookingApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "무료공연/미입금 예매 취소 요청이 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "무료공연/미입금 예매 취소 요청이 성공적으로 완료되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "404",

--- a/src/main/java/com/beat/domain/booking/api/TicketApi.java
+++ b/src/main/java/com/beat/domain/booking/api/TicketApi.java
@@ -30,8 +30,7 @@ public interface TicketApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "예매자 목록 조회 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "예매자 목록 조회 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -62,8 +61,7 @@ public interface TicketApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "예매자 목록 검색 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "예매자 목록 검색 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -95,8 +93,7 @@ public interface TicketApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "예매자 입금여부 수정 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "예매자 입금여부 수정 성공"
 			),
 			@ApiResponse(
 				responseCode = "400",
@@ -125,8 +122,7 @@ public interface TicketApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "예매자 환불처리 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "예매자 환불처리 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -155,8 +151,7 @@ public interface TicketApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "예매자 삭제 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "예매자 삭제 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",

--- a/src/main/java/com/beat/domain/member/api/MemberApi.java
+++ b/src/main/java/com/beat/domain/member/api/MemberApi.java
@@ -26,8 +26,7 @@ public interface MemberApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "로그인 또는 회원가입 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "로그인 또는 회원가입 성공"
 			),
 			@ApiResponse(
 				responseCode = "400",
@@ -52,8 +51,7 @@ public interface MemberApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "access token 재발급 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "access token 재발급 성공"
 			),
 			@ApiResponse(
 				responseCode = "400",
@@ -71,8 +69,7 @@ public interface MemberApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "로그아웃 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "로그아웃 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",

--- a/src/main/java/com/beat/domain/performance/api/HomeApi.java
+++ b/src/main/java/com/beat/domain/performance/api/HomeApi.java
@@ -23,8 +23,7 @@ public interface HomeApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "홈 화면 공연 목록 조회가 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "홈 화면 공연 목록 조회가 성공적으로 완료되었습니다."
 			)
 		}
 	)

--- a/src/main/java/com/beat/domain/performance/api/PerformanceApi.java
+++ b/src/main/java/com/beat/domain/performance/api/PerformanceApi.java
@@ -31,8 +31,7 @@ public interface PerformanceApi {
 		value = {
 			@ApiResponse(
 				responseCode = "201",
-				description = "공연이 성공적으로 생성되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "공연이 성공적으로 생성되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "400",
@@ -56,8 +55,7 @@ public interface PerformanceApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "공연 정보 수정 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "공연 정보 수정 성공"
 			),
 			@ApiResponse(
 				responseCode = "400",
@@ -96,8 +94,7 @@ public interface PerformanceApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "공연 수정 페이지 정보 조회 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "공연 수정 페이지 정보 조회 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -116,8 +113,7 @@ public interface PerformanceApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "공연 상세정보 조회 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "공연 상세정보 조회 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -135,8 +131,7 @@ public interface PerformanceApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "예매하기 관련 공연 정보 조회 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "예매하기 관련 공연 정보 조회 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -154,8 +149,7 @@ public interface PerformanceApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "회원이 등록한 공연 목록 조회 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "회원이 등록한 공연 목록 조회 성공"
 			),
 			@ApiResponse(
 				responseCode = "404",
@@ -173,8 +167,7 @@ public interface PerformanceApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "공연 삭제 성공",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "공연 삭제 성공"
 			),
 			@ApiResponse(
 				responseCode = "403",

--- a/src/main/java/com/beat/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/beat/domain/schedule/api/ScheduleApi.java
@@ -23,8 +23,7 @@ public interface ScheduleApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "티켓 수량 조회가 성공적으로 완료되었습니다.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "티켓 수량 조회가 성공적으로 완료되었습니다."
 			),
 			@ApiResponse(
 				responseCode = "400",

--- a/src/main/java/com/beat/domain/user/api/HealthCheckApi.java
+++ b/src/main/java/com/beat/domain/user/api/HealthCheckApi.java
@@ -1,0 +1,24 @@
+package com.beat.domain.user.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Health-Check", description = "헬스 체크 API")
+public interface HealthCheckApi {
+
+	@Operation(
+		summary = "헬스 체크 조회 API",
+		description = "서버 상태를 확인하기 위한 헬스 체크 API로, 정상적으로 동작할 경우 'OK' 문자열을 반환합니다."
+	)
+	@ApiResponses(
+		value = {
+			@ApiResponse(responseCode = "200", description = "서버가 정상적으로 동작 중입니다.")
+		}
+	)
+	@GetMapping
+	String healthcheck();
+}

--- a/src/main/java/com/beat/domain/user/api/HealthCheckController.java
+++ b/src/main/java/com/beat/domain/user/api/HealthCheckController.java
@@ -6,7 +6,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/health-check")
-public class HealthCheckController {
+public class HealthCheckController implements HealthCheckApi {
+
+	@Override
 	@GetMapping
 	public String healthcheck() {
 		return "OK";

--- a/src/main/java/com/beat/global/external/s3/api/FileApi.java
+++ b/src/main/java/com/beat/global/external/s3/api/FileApi.java
@@ -24,8 +24,7 @@ public interface FileApi {
 		value = {
 			@ApiResponse(
 				responseCode = "200",
-				description = "공연 메이커를 위한 Presigned URL 발급 성공.",
-				content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+				description = "공연 메이커를 위한 Presigned URL 발급 성공."
 			),
 			@ApiResponse(
 				responseCode = "500",


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #272 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- SuccessResponse<HomeFindAllResponse>와 같은 구조를 사용할 때, Swagger가 내부 HomeFindAllResponse 타입을 인식하지 못하고 SuccessResponse만 인식하는 문제가 발생했습니다.
- @Content 애노테이션을 삭제하면, Swagger가 자동으로 **ResponseEntity<SuccessResponse<HomeFindAllResponse>>** 의 반환 타입을 분석하여 SuccessResponse 내부의 제네릭 타입인 HomeFindAllResponse까지 포함하여 문서화하는 것을 확인했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### AS-IS
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/5427b60a-51dd-4277-93bc-a9b3becfd922">
<img width="1420" alt="image" src="https://github.com/user-attachments/assets/07d3b618-44b4-4720-8c4f-40e868b1f414">

- requestDTO만 스웨거에 schema로 인식되고 responseDTO가 인식이 되지 않았습니다.

### TO-BE
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/26d084a0-e87e-4468-b54a-a1ffc01cd5b4">
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/fa4a7c33-c4b2-4dc3-a6a9-7649a02b1a67">

- requestDTO와 responseDTO 모두 스웨거에 schema로 인식이 되게 되었습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
