### PR TITLE
[feat] #274 - @DisableSwaggerSecurity 어노테이션 추가 및 리프레쉬 토큰을 통한 액세스 토큰 발급 로직 변경

### DIFF
--- a/src/main/java/com/beat/domain/booking/api/BookingApi.java
+++ b/src/main/java/com/beat/domain/booking/api/BookingApi.java
@@ -19,6 +19,7 @@ import com.beat.domain.booking.application.dto.MemberBookingRetrieveResponse;
 import com.beat.global.auth.annotation.CurrentMember;
 import com.beat.global.common.dto.ErrorResponse;
 import com.beat.global.common.dto.SuccessResponse;
+import com.beat.global.swagger.annotation.DisableSwaggerSecurity;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -92,6 +93,7 @@ public interface BookingApi {
 		@CurrentMember Long memberId
 	);
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "비회원 예매 API", description = "비회원이 예매를 요청하는 POST API입니다.")
 	@ApiResponses(
 		value = {
@@ -125,6 +127,7 @@ public interface BookingApi {
 		@RequestBody GuestBookingRequest guestBookingRequest
 	);
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "비회원 예매 조회 API", description = "비회원이 예매를 조회하는 POST API입니다.")
 	@ApiResponses(
 		value = {
@@ -143,6 +146,7 @@ public interface BookingApi {
 		@RequestBody GuestBookingRetrieveRequest guestBookingRetrieveRequest
 	);
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "유료공연 예매 환불 요청 API", description = "유료공연 예매자가 환불 요청하는 PATCH API입니다.")
 	@ApiResponses(
 		value = {
@@ -161,6 +165,7 @@ public interface BookingApi {
 		@RequestBody BookingRefundRequest bookingRefundRequest
 	);
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "무료공연/미입금 예매 취소 요청 API", description = "무료공연/미입금 예매자가 취소 요청하는 PATCH API입니다.")
 	@ApiResponses(
 		value = {

--- a/src/main/java/com/beat/domain/member/api/MemberApi.java
+++ b/src/main/java/com/beat/domain/member/api/MemberApi.java
@@ -1,14 +1,17 @@
 package com.beat.domain.member.api;
 
-import java.security.Principal;
-
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.beat.domain.member.dto.AccessTokenGetSuccess;
 import com.beat.domain.member.dto.LoginSuccessResponse;
+import com.beat.global.auth.annotation.CurrentMember;
 import com.beat.global.auth.client.dto.MemberLoginRequest;
 import com.beat.global.common.dto.ErrorResponse;
 import com.beat.global.common.dto.SuccessResponse;
+import com.beat.global.swagger.annotation.DisableSwaggerSecurity;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,6 +24,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @Tag(name = "Member", description = "회원 관련 API")
 public interface MemberApi {
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "로그인/회원가입 API", description = "로그인/회원가입하는 POST API입니다.")
 	@ApiResponses(
 		value = {
@@ -41,8 +45,8 @@ public interface MemberApi {
 		}
 	)
 	ResponseEntity<SuccessResponse<LoginSuccessResponse>> signUp(
-		String authorizationCode,
-		MemberLoginRequest loginRequest,
+		@RequestParam final String authorizationCode,
+		@RequestBody final MemberLoginRequest loginRequest,
 		HttpServletResponse response
 	);
 
@@ -60,8 +64,8 @@ public interface MemberApi {
 			)
 		}
 	)
-	ResponseEntity<SuccessResponse<AccessTokenGetSuccess>> refreshToken(
-		String refreshToken
+	ResponseEntity<SuccessResponse<AccessTokenGetSuccess>> issueAccessTokenUsingRefreshToken(
+		@RequestHeader("Authorization_Refresh") final String refreshToken
 	);
 
 	@Operation(summary = "로그아웃 API", description = "로그아웃하는 POST API입니다.")
@@ -78,6 +82,8 @@ public interface MemberApi {
 			)
 		}
 	)
-	ResponseEntity<SuccessResponse<Void>> signOut(Principal principal);
+	ResponseEntity<SuccessResponse<Void>> signOut(
+		@CurrentMember final Long memberId
+	);
 }
 

--- a/src/main/java/com/beat/domain/member/application/AuthenticationService.java
+++ b/src/main/java/com/beat/domain/member/application/AuthenticationService.java
@@ -30,7 +30,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class AuthenticationService {
-
+	private static final String BEARER_PREFIX = "Bearer ";
 	private final JwtTokenProvider jwtTokenProvider;
 	private final TokenService tokenService;
 
@@ -69,11 +69,16 @@ public class AuthenticationService {
 	 * Refresh Token에서 사용자 ID와 Role 정보를 추출한 후,
 	 * Role에 따라 Admin 또는 Member 권한으로 새로운 Access Token을 발급합니다.
 	 *
-	 * @param refreshToken 사용자의 Refresh Token
+	 * @param refreshTokenWithBearer "Bearer +  사용자의 Refresh Token"
 	 * @return 새로운 Access Token 정보가 포함된 AccessTokenGetSuccess 객체
 	 */
 	@Transactional
-	public AccessTokenGetSuccess generateAccessTokenFromRefreshToken(final String refreshToken) {
+	public AccessTokenGetSuccess generateAccessTokenFromRefreshToken(final String refreshTokenWithBearer) {
+		String refreshToken = refreshTokenWithBearer;
+		if (refreshToken.startsWith(BEARER_PREFIX)) {
+			refreshToken = refreshToken.substring(BEARER_PREFIX.length());
+		}
+
 		log.info("Validation result for refresh token: {}", jwtTokenProvider.validateToken(refreshToken));
 
 		JwtValidationType validationType = jwtTokenProvider.validateToken(refreshToken);

--- a/src/main/java/com/beat/domain/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/beat/domain/member/exception/MemberSuccessCode.java
@@ -13,7 +13,7 @@ public enum MemberSuccessCode implements BaseSuccessCode {
 	*/
 	SIGN_UP_SUCCESS(200, "로그인 성공"),
 	ISSUE_ACCESS_TOKEN_SUCCESS(200, "엑세스토큰 발급 성공"),
-	ISSUE_REFRESH_TOKEN_SUCCESS(200, "리프레쉬토큰 발급 성공"),
+	ISSUE_ACCESS_TOKEN_USING_REFRESH_TOKEN(200, "리프레쉬 토큰으로 액세스 토큰 재발급 성공"),
 	SIGN_OUT_SUCCESS(200, "로그아웃 성공"),
 	USER_DELETE_SUCCESS(200, "회원 탈퇴 성공");
 

--- a/src/main/java/com/beat/domain/performance/api/HomeApi.java
+++ b/src/main/java/com/beat/domain/performance/api/HomeApi.java
@@ -5,12 +5,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.beat.domain.performance.application.dto.home.HomeFindAllResponse;
 import com.beat.domain.performance.domain.Genre;
-import com.beat.global.common.dto.ErrorResponse;
 import com.beat.global.common.dto.SuccessResponse;
+import com.beat.global.swagger.annotation.DisableSwaggerSecurity;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Home", description = "홈 화면에서 공연 및 홍보목록 조회 API")
 public interface HomeApi {
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "전체 공연 및 홍보 목록 조회", description = "홈 화면에서 전체 공연 목록 및 홍보 목록을 조회하는 GET API")
 	@ApiResponses(
 		value = {

--- a/src/main/java/com/beat/domain/performance/api/PerformanceApi.java
+++ b/src/main/java/com/beat/domain/performance/api/PerformanceApi.java
@@ -15,6 +15,7 @@ import com.beat.domain.performance.application.dto.performanceDetail.Performance
 import com.beat.global.auth.annotation.CurrentMember;
 import com.beat.global.common.dto.ErrorResponse;
 import com.beat.global.common.dto.SuccessResponse;
+import com.beat.global.swagger.annotation.DisableSwaggerSecurity;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -108,6 +109,7 @@ public interface PerformanceApi {
 		@PathVariable Long performanceId
 	);
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "공연 상세정보 조회 API", description = "공연 상세페이지의 공연 상세정보를 조회하는 GET API입니다.")
 	@ApiResponses(
 		value = {
@@ -126,6 +128,7 @@ public interface PerformanceApi {
 		@PathVariable Long performanceId
 	);
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "예매하기 관련 공연 정보 조회 API", description = "예매하기 페이지에서 필요한 예매 관련 공연 정보를 조회하는 GET API입니다.")
 	@ApiResponses(
 		value = {

--- a/src/main/java/com/beat/domain/schedule/api/ScheduleApi.java
+++ b/src/main/java/com/beat/domain/schedule/api/ScheduleApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.beat.domain.schedule.application.dto.TicketAvailabilityResponse;
 import com.beat.global.common.dto.ErrorResponse;
 import com.beat.global.common.dto.SuccessResponse;
+import com.beat.global.swagger.annotation.DisableSwaggerSecurity;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Schedule", description = "스케줄 관련 API")
 public interface ScheduleApi {
 
+	@DisableSwaggerSecurity
 	@Operation(summary = "티켓 구매 가능 여부 조회 API", description = "티켓 구매 가능 여부를 확인하는 GET API입니다.")
 	@ApiResponses(
 		value = {

--- a/src/main/java/com/beat/domain/user/api/HealthCheckApi.java
+++ b/src/main/java/com/beat/domain/user/api/HealthCheckApi.java
@@ -2,6 +2,8 @@ package com.beat.domain.user.api;
 
 import org.springframework.web.bind.annotation.GetMapping;
 
+import com.beat.global.swagger.annotation.DisableSwaggerSecurity;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -10,15 +12,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Health-Check", description = "헬스 체크 API")
 public interface HealthCheckApi {
 
-	@Operation(
-		summary = "헬스 체크 조회 API",
-		description = "서버 상태를 확인하기 위한 헬스 체크 API로, 정상적으로 동작할 경우 'OK' 문자열을 반환합니다."
-	)
+	@DisableSwaggerSecurity
+	@Operation(summary = "헬스 체크 조회 API", description = "서버 상태를 확인하기 위한 헬스 체크 API로, 정상적으로 동작할 경우 'OK' 문자열을 반환합니다.")
 	@ApiResponses(
 		value = {
 			@ApiResponse(responseCode = "200", description = "서버가 정상적으로 동작 중입니다.")
 		}
 	)
-	@GetMapping
 	String healthcheck();
 }

--- a/src/main/java/com/beat/global/swagger/annotation/DisableSwaggerSecurity.java
+++ b/src/main/java/com/beat/global/swagger/annotation/DisableSwaggerSecurity.java
@@ -1,0 +1,10 @@
+package com.beat.global.swagger.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DisableSwaggerSecurity {}

--- a/src/main/java/com/beat/global/swagger/config/SwaggerConfig.java
+++ b/src/main/java/com/beat/global/swagger/config/SwaggerConfig.java
@@ -1,4 +1,6 @@
-package com.beat.global.swagger;
+package com.beat.global.swagger.config;
+
+import java.util.Collections;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -7,9 +9,12 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.beat.global.swagger.annotation.DisableSwaggerSecurity;
 
 @Configuration
 public class SwaggerConfig {
@@ -21,23 +26,36 @@ public class SwaggerConfig {
 	public OpenAPI openAPI() {
 		String jwt = "JWT";
 		SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+
 		Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
 			.name(jwt)
 			.type(SecurityScheme.Type.HTTP)
 			.scheme("bearer")
 			.bearerFormat("JWT")
 		);
-		return new OpenAPI().addServersItem(new Server().url(serverUrl))
-			.components(new Components())
+
+		return new OpenAPI()
+			.addServersItem(new Server().url(serverUrl))
+			.components(components)
 			.info(apiInfo())
-			.addSecurityItem(securityRequirement)
-			.components(components);
+			.addSecurityItem(securityRequirement);
+	}
+
+	@Bean
+	public OperationCustomizer customize() {
+		return (operation, handlerMethod) -> {
+			DisableSwaggerSecurity methodAnnotation = handlerMethod.getMethodAnnotation(DisableSwaggerSecurity.class);
+			if (methodAnnotation != null) {
+				operation.setSecurity(Collections.emptyList());
+			}
+			return operation;
+		};
 	}
 
 	private Info apiInfo() {
 		return new Info()
 			.title("BEAT Project API")
 			.description("간편하게 소규모 공연을 등록하고 관리할 수 있는 티켓 예매 플랫폼")
-			.version("1.1.0");
+			.version("1.2.0");
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #274 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
[참고링크](https://devnm.tistory.com/26)

### @DisableSwaggerSecurity 커스텀 어노테이션으로 Swagger UI에서 보안설정 비활성화
- @DisableSwaggerSecurity 커스텀 어노테이션을 추가하여 Swagger UI에서 특정 API의 보안 설정을 비활성화할 수 있도록 구현하였습니다.
- 이를 통해 클라이언트는 API 문서를 확인하면서 인증이 필요한 API와 그렇지 않은 API를 명확히 구분할 수 있어 가독성과 사용성을 높일 수 있습니다.

### 리프레쉬 토큰을 통한 액세스 토큰 발급 로직 변경
- 기존에는 RequestParam으로 리프레시 토큰을 받아 액세스 토큰을 재발급 받도록 하였습니다. 하지만, 해당 방법은 토큰이 URL에 노출되기 때문에 보안상 취약점이 있었습니다.
- 이를 개선하기 위해, RequestHeader를 통해 리프레시 토큰을 전달받도록 수정하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

### Authorization 헤더 중복 처리 문제

![image](https://github.com/user-attachments/assets/937adfb6-c30a-468e-a378-de2ec8d3c764)
<img width="671" alt="image" src="https://github.com/user-attachments/assets/5100b658-d8f7-4a95-b350-839f5fbf9895">
<img width="704" alt="image" src="https://github.com/user-attachments/assets/272c533f-5cbc-4ead-ac77-ce22c2dac4a5">

---

<img width="575" alt="image" src="https://github.com/user-attachments/assets/5220f461-9cfc-4069-8b5f-f1c7777c07f0">

- @RequestHeader("Authorization")은 기본적으로 액세스 토큰을 다루기 위한 로직이고, 그에 따라 JwtAuthenticationFilter에서 이를 처리하도록 설계된 상황입니다. 
- 따라서 Refresh Token 요청 시에도 동일한 헤더(Authorization)를 사용하는 경우, JwtAuthenticationFilter가 이를 처리하려 하면서 중복으로 처리가 되는 문제가 발생했습니다.

### Authorization 헤더 중복 처리 문제 해결

![image](https://github.com/user-attachments/assets/bfce5050-1c2a-4dee-9903-40f780ad3b3f)
<img width="654" alt="image" src="https://github.com/user-attachments/assets/f37e19cd-35e8-4d87-8b7a-e5605afff067">
<img width="834" alt="image" src="https://github.com/user-attachments/assets/cc18bda3-b64b-4f70-9034-b230ee98d548">

- `Authorization_Refresh`라는 별도의 헤더명을 사용해 Refresh Token 요청을 구분하면 문제를 간단히 해결하였습니다.
- Bearer 접두사는 액세스 토큰을 헤더에 담을 경우 `JwtAuthenticationFilter` 제거해주지만, 리프레쉬 토큰을 헤더에 담을 경우 `AuthenticationService`의 `generateAccessTokenFromRefreshToken`에서 Bearer 접두사를 제거해줍니다.

```java
@Transactional
public AccessTokenGetSuccess generateAccessTokenFromRefreshToken(final String refreshTokenWithBearer) {
String refreshToken = refreshTokenWithBearer;
if (refreshToken.startsWith(BEARER_PREFIX)) {  // 해당 부분에서 Bearer 접두사 제거 
	refreshToken = refreshToken.substring(BEARER_PREFIX.length());
}

log.info("Validation result for refresh token: {}", jwtTokenProvider.validateToken(refreshToken));

JwtValidationType validationType = jwtTokenProvider.validateToken(refreshToken);
if (!validationType.equals(JwtValidationType.VALID_JWT)) {
	log.warn("Invalid refresh token: {}", validationType);
	throw switch (validationType) {
		case EXPIRED_JWT_TOKEN -> new UnauthorizedException(TokenErrorCode.REFRESH_TOKEN_EXPIRED_ERROR);
		case INVALID_JWT_TOKEN -> new BadRequestException(TokenErrorCode.INVALID_REFRESH_TOKEN_ERROR);
		case INVALID_JWT_SIGNATURE -> new BadRequestException(TokenErrorCode.REFRESH_TOKEN_SIGNATURE_ERROR);
		case UNSUPPORTED_JWT_TOKEN -> new BadRequestException(TokenErrorCode.UNSUPPORTED_REFRESH_TOKEN_ERROR);
		case EMPTY_JWT -> new BadRequestException(TokenErrorCode.REFRESH_TOKEN_EMPTY_ERROR);
		default -> new BeatException(TokenErrorCode.UNKNOWN_REFRESH_TOKEN_ERROR);
	};
}

Long memberId = jwtTokenProvider.getMemberIdFromJwt(refreshToken);

if (!memberId.equals(tokenService.findIdByRefreshToken(refreshToken))) {
	log.error("MemberId mismatch: token does not match the stored refresh token");
	throw new BadRequestException(TokenErrorCode.REFRESH_TOKEN_MEMBER_ID_MISMATCH_ERROR);
}

Role role = jwtTokenProvider.getRoleFromJwt(refreshToken);
Collection<GrantedAuthority> authorities = List.of(role.toGrantedAuthority());

UsernamePasswordAuthenticationToken authenticationToken = createAuthenticationToken(memberId, role,
	authorities);
log.info("Generated new access token for memberId: {}, role: {}, authorities: {}",
	memberId, role.getRoleName(), authorities);
return AccessTokenGetSuccess.of(jwtTokenProvider.issueAccessToken(authenticationToken));
}
```


## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/b800e40c-6f7b-499d-8ff8-eec5b2039940">

- 인증이 필요없는 API의 경우 좌물쇠가 표시되지 않는 것을 확인하실 수 있습니다.

<img width="1362" alt="image" src="https://github.com/user-attachments/assets/2dc34db7-bae3-4681-aa05-3bf4db5768ef">

- Header에 `Authorization_Refresh`를 명시하고 해당 value로 리프레쉬 토큰 값을 넣어주면 성공적으로 액세스 토큰이 발급되어짐을 확인했습니다.(하단 data에 있는 `accessToken`값은 보안상의 이유로 캡쳐를 하지 않았습니다)

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
