### PR TITLE
[refactor] #276 - Swagger의 use-fqn 설정을 false로 변경

### DIFF
--- a/src/main/java/com/beat/domain/booking/application/dto/TicketRefundRequest.java
+++ b/src/main/java/com/beat/domain/booking/application/dto/TicketRefundRequest.java
@@ -10,7 +10,7 @@ public record TicketRefundRequest(
 		return new TicketRefundRequest(performanceId, bookingList);
 	}
 
-	public static record Booking(
+	public record Booking(
 		long bookingId
 	) {
 	}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -83,4 +83,4 @@ app:
     url: ${DEV_SERVER_URL}
 
 springdoc:
-  use-fqn: true
+  use-fqn: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -83,4 +83,4 @@ app:
     url: ${PROD_SERVER_URL}
 
 springdoc:
-  use-fqn: true
+  use-fqn: false


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #276 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 스웨거의 use-fqn의 설정을 true에서 false로 변경하였습니다.
- 자세한 내용은 #276 이슈에 설명이 되어있으니 읽어주시면 감사하겠습니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/8004af7d-3a89-4eba-8754-ec938099549f">

```java
package com.beat.domain.booking.application.dto;

import java.util.List;

public record TicketRefundRequest(
	Long performanceId,
	List<Booking> bookingList
) {
	public static TicketRefundRequest of(Long performanceId, List<Booking> bookingList) {
		return new TicketRefundRequest(performanceId, bookingList);
	}

	public record Booking(
		long bookingId
	) {
	}
}
```

- Booking이 nested DTO인데, use-fqn을 false로 변경해도 Swagger의 schema에 인식되는 것을 확인할 수 있습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

- record는 내부적으로 항상 static으로 동작합니다. 
- 즉, 내부 클래스(Booking)를 record로 정의하면, 기본적으로 static 클래스가 되기 때문에, static을 명시적으로 붙이지 않아도 이미 static이 적용된 것처럼 동작합니다.
- 따라서 nested record의 static을 삭제하였습니다!
