### PR TITLE
[feat] #279 - Swagger 그룹별 API 경로 설정 및 기타 세부 설정 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -84,3 +84,15 @@ app:
 
 springdoc:
   use-fqn: false
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  group-configs:
+    - group: admin
+      paths-to-match: /api/admin/**
+    - group: general
+      paths-to-match: /**
+      paths-to-exclude: /api/admin/**
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter: alpha
+    display-request-duration: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -84,3 +84,15 @@ app:
 
 springdoc:
   use-fqn: false
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  group-configs:
+    - group: admin
+      paths-to-match: /api/admin/**
+    - group: general
+      paths-to-match: /**
+      paths-to-exclude: /api/admin/**
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter: alpha
+    display-request-duration: true


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #279 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- Swagger 그룹별 API 경로 설정 및 기타 세부 설정을 추가하였습니다.
- 자세한 내용은 아래와 같습니다.

```java
springdoc:
  # Fully Qualified Name을 사용하지 않도록 설정. (기본값: true)
  use-fqn: false

  # 기본적으로 요청을 받을 때의 미디어 타입을 설정. 여기서는 JSON 형식으로 지정
  default-consumes-media-type: application/json;charset=UTF-8

  # 기본적으로 응답할 때의 미디어 타입을 설정. 여기서는 JSON 형식으로 지정
  default-produces-media-type: application/json;charset=UTF-8

  # Swagger UI에서 그룹을 나누기 위한 설정
  group-configs:
    # 'admin' 그룹에 해당하는 API 경로를 /api/admin/**로 설정
    - group: admin
      paths-to-match: /api/admin/**

    # 'general' 그룹에 해당하는 API 경로를 /api/**로 설정하되, /api/admin/**는 제외
    - group: general
      paths-to-match: /**            # 모든 경로를 포함
      paths-to-exclude: /api/admin/** # '/api/admin/**' 경로는 제외

  # Swagger UI 관련 설정
  swagger-ui:
    # Swagger UI에서 API 목록을 태그 알파벳 순으로 정렬
    tags-sorter: alpha

    # Swagger UI에서 API 목록을 작업(Operation) 알파벳 순으로 정렬
    operations-sorter: alpha

    # Swagger UI에서 요청 시간(실행 시간)을 표시
    display-request-duration: true
```



## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### general group
<img width="1797" alt="image" src="https://github.com/user-attachments/assets/89560065-661e-4087-b222-ea2188416a61">

### admin group
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/db68a616-6244-49f5-9b59-cd9bf5a1669f">


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
