### PR TITLE
[fix] #282 - Swagger 그룹화를 코드 기반 설정으로 변경

### DIFF
--- a/src/main/java/com/beat/global/swagger/config/SwaggerConfig.java
+++ b/src/main/java/com/beat/global/swagger/config/SwaggerConfig.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +40,25 @@ public class SwaggerConfig {
 			.components(components)
 			.info(apiInfo())
 			.addSecurityItem(securityRequirement);
+	}
+
+	@Bean
+	public GroupedOpenApi generalApi() {
+		return GroupedOpenApi.builder()
+			.group("general")
+			.pathsToMatch("/**")
+			.pathsToExclude("/api/admin/**")
+			.addOperationCustomizer(customize())
+			.build();
+	}
+
+	@Bean
+	public GroupedOpenApi adminApi() {
+		return GroupedOpenApi.builder()
+			.group("admin")
+			.pathsToMatch("/api/admin/**")
+			.addOperationCustomizer(customize())
+			.build();
 	}
 
 	@Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -86,13 +86,8 @@ springdoc:
   use-fqn: false
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
-  group-configs:
-    - group: admin
-      paths-to-match: /api/admin/**
-    - group: general
-      paths-to-match: /**
-      paths-to-exclude: /api/admin/**
   swagger-ui:
     tags-sorter: alpha
     operations-sorter: alpha
     display-request-duration: true
+    urls-primary-name: general

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -86,13 +86,8 @@ springdoc:
   use-fqn: false
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
-  group-configs:
-    - group: admin
-      paths-to-match: /api/admin/**
-    - group: general
-      paths-to-match: /**
-      paths-to-exclude: /api/admin/**
   swagger-ui:
     tags-sorter: alpha
     operations-sorter: alpha
     display-request-duration: true
+    urls-primary-name: general


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #282 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- Swagger 그룹화를 코드 기반 설정으로 변경하였습니다.
- 코드에서 GroupedOpenApi.builder()를 사용해서, 경로 매칭뿐 아니라 추가적인 커스터마이징 로직을 직접 정의하였습니다.
- 또한, 스웨거 접속 시 admin 그룹을 default로 보여줘서, general 그룹을 default로 보여주도록 변경하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

### OperationCustomizer와 YAML의 한계
- springdoc.group-configs를 통해 YAML에서 그룹을 정의하면, SpringDoc이 해당 경로 설정에 맞는 그룹을 자동으로 생성합니다.
- 하지만 YAML 기반의 그룹 생성 과정에서는 추가적인 OperationCustomizer나 다른 커스터마이징 로직이 적용되지 않는 것을 확인했습니다.
    - 즉, 그룹 설정이 SpringDoc 내부에서 처리되며, 사용자 정의 OperationCustomizer를 연결할 수 없어서 코드에서 명시적으로 등록한 경우에만 동작하는 것 같습니다.
- 그래서 springdoc.group-configs는 단순히 경로 매칭에 따라 그룹을 생성할 뿐, 사용자 정의 로직을 추가할 수 없으므로 @DisableSwaggerSecurity와 같은 커스텀 어노테이션도 작동하지 않았던 것입니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="1479" alt="image" src="https://github.com/user-attachments/assets/c12df4c5-8465-4f9c-8ca3-f88d91a4230b">

- 토큰이 필요하지 않는 API의 경우 좌물쇠가 사라지는 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
