### PR TITLE
[feat] #286 - QueryDSL 세팅 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ Temporary Items
 
 # Ignore application-local.yml
 src/main/resources/application-local.yml
+
+## Ignore Qclass
+src/main/generated/querydsl

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,20 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+
+	// Configure libraries related to QueryDSL to be required only at compile-time and add QueryDSL configuration to the compile classpath.
+	querydsl.extendsFrom compileClasspath
 }
 
 repositories {
 	mavenCentral()
 	maven { url "https://repo.spring.io/milestone" }
 	maven { url "https://repo.spring.io/snapshot" }
+}
+
+// Set global variables used in the project
+ext {
+	set('queryDslVersion', "5.0.0")
 }
 
 dependencies {
@@ -74,9 +82,15 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 
-	//coolsms
+	// coolsms
 	implementation 'net.nurigo:sdk:4.3.0'
 	implementation 'net.nurigo:javaSDK:2.2'
+
+	// QueryDSL
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 jar {
@@ -85,4 +99,23 @@ jar {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Set the directory path where the Q-Class will be generated.
+def queryDslSrcDir = 'src/main/generated/querydsl/'
+
+// When executing the JavaCompile task, set the output directory for the generated source code to queryDslSrcDir
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(queryDslSrcDir))
+}
+
+// Add the Q-Class files to the directory path recognized as source code.
+// This ensures that the Q-Class is treated as a regular Java class and included in the classpath during compilation and execution.
+sourceSets {
+	main.java.srcDirs += [queryDslSrcDir]
+}
+
+// Configure the clean task to delete the specified directory, automatically removing the generated Q-Class.
+clean {
+	delete file(queryDslSrcDir)
 }

--- a/src/main/java/com/beat/global/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/beat/global/common/config/JpaAuditingConfig.java
@@ -1,23 +1,9 @@
 package com.beat.global.common.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-import com.querydsl.jpa.impl.JPAQueryFactory;
-
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaAuditingConfig {
-
-	@PersistenceContext
-	private EntityManager em;
-
-	@Bean
-	public JPAQueryFactory jpaQueryFactory() {
-		return new JPAQueryFactory(em);
-	}
 }

--- a/src/main/java/com/beat/global/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/beat/global/common/config/JpaAuditingConfig.java
@@ -1,9 +1,23 @@
 package com.beat.global.common.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaAuditingConfig {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
 }

--- a/src/main/java/com/beat/global/common/config/QueryDslConfig.java
+++ b/src/main/java/com/beat/global/common/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.beat.global.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+	@PersistenceContext
+	private EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #286

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### [참고 아티클(클릭)](https://adjh54.tistory.com/485?category=1173558#2.%20QueyDSL%20%EA%B4%80%EB%A0%A8%20%EC%84%A4%EC%A0%95%20%3A%20build.gradle-1)
- 위의 아티클을 참고하여 QueryDSL을 사용하기 위한 사전 작업을 완료하였습니다.
- 밑에서 설명하는 내용이 해당 블로그에 모두 포함되어 있으니, 한번 읽어봐주시기를 부탁드립니다!

### 알아야 햘 점
- Gradle 빌드 스크립트 내에 QueryDSL 관련 설정을 합니다. 해당 설정의 주요 목적은 메타 모델(Q-Class)을 생성/삭제하기 위함에 설정을 합니다.
- build complie을 수행하면 엔티티 클래스를 기반으로 지정한 디렉터리 내에 Q-Class를 생성합니다.
- build clean을 수행하면 생성된 디렉터리 내에 Q-Class를 삭제합니다.

### 주의할 점
- 엔티티 클래스의 필드가 변경되는 경우 컴파일만 수행하면 갱신이 되나? 아니면 build clean을 수행해야 하는가?
  - 엔티티 클래스의 필드가 변경되는 경우, 컴파일만 수행해도 갱신이 됩니다. 그러나 혹시 모를 상황을 대비하여 변경사항이 반영되지 않았을 경우에는 build clean을 수행한 후 다시 컴파일을 수행하면 됩니다.


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="279" alt="image" src="https://github.com/user-attachments/assets/3a4ab3a3-8df9-43d1-ad89-f5ba41415c5a">


- `./gradlew build`를 입력하면 build 패키지가 생성되고, 설정한 경로명(`src/main/generated/querydsl/`)에 QClass가 생성된 것을 확인했습니다.

<img width="299" alt="image" src="https://github.com/user-attachments/assets/ed89c95a-3056-4481-8c3d-bc48fb19e326">

- `./gradlew clean`를 입력하면 build 패키지가 삭제되고, 설정한 경로명(`src/main/generated/querydsl/`)에 QClass가 삭제된 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

- 꼭 `참고 아티클`를 한 번 읽어봐 주시면 감사하겠습니다!