### PR TITLE
[feat] #288 - 릴리즈 태그 작성 자동화 구현 완료

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,40 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🎯 새로운 기능이 추가되었어요'
+    labels: ['feat 🎯']
+  - title: '🛠️ 기존 버그가 수정되었어요'
+    labels:
+      - 'fix 🛠️'
+      - 'HOTFIX 🚑'
+  - title: '🐬 코드를 개선했어요'
+    labels:
+      - 'refactor 🔁'
+      - 'test 🧪'
+      - 'chore 🔍'
+  - title: '⚙️ 프로젝트를 개선했어요'
+    labels:
+      - 'rename 📛'
+      - 'remove 👻'
+      - 'docs ✍🏻'
+  - title: '🚀 배포'
+    labels:
+      - 'deploy 🚀'
+
+change-template: '- $TITLE #$NUMBER @$AUTHOR '
+template: |
+  ## 이번 버전의 변경사항은 아래와 같아요
+  ---
+  $CHANGES
+no-changes-template: '변경사항이 없어요'
+version-resolver:
+  major:
+    labels:
+      - '1️⃣ major'
+  minor:
+    labels:
+      - '2️⃣ minor'
+  patch:
+    labels:
+      - '3️⃣ patch'
+  default: patch

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - main
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #288 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 릴리즈 태그를 자동으로 작성하는 release-drafter 기능을 구현 하였습니다.
- 아직 GITHUB_TOKEN을 발급받지 않았기 때문에, 머지하기 전 발급을 받으려고 합니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
