### PR TITLE
[chore] #291 - dev 서버에 redis password 설정 추가

### DIFF
--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -48,6 +48,8 @@ jobs:
           DEV_KAKAO_CLIENT_SECRET: ${{ secrets.DEV_KAKAO_CLIENT_SECRET }}
           DEV_KAKAO_REDIRECT_URI: ${{ secrets.DEV_KAKAO_REDIRECT_URI }}
           DEV_REDIS_HOST: ${{ secrets.DEV_REDIS_HOST }}
+          DEV_REDIS_PORT: ${{ secrets.DEV_REDIS_PORT }}
+          DEV_REDIS_PASSWORD: ${{ secrets.DEV_REDIS_PASSWORD }}
           DEV_S3_ACCESS_KEY: ${{ secrets.DEV_S3_ACCESS_KEY }}
           DEV_S3_SECRET_KEY: ${{ secrets.DEV_S3_SECRET_KEY }}
           DEV_COOLSMS_KEY: ${{ secrets.DEV_COOLSMS_KEY }}

--- a/.github/workflows/prod-CI.yml
+++ b/.github/workflows/prod-CI.yml
@@ -48,6 +48,7 @@ jobs:
           PROD_KAKAO_CLIENT_SECRET: ${{ secrets.PROD_KAKAO_CLIENT_SECRET }}
           PROD_KAKAO_REDIRECT_URI: ${{ secrets.PROD_KAKAO_REDIRECT_URI }}
           PROD_REDIS_HOST: ${{ secrets.PROD_REDIS_HOST }}
+          PROD_REDIS_PORT: ${{ secrets.PROD_REDIS_PORT }}
           PROD_S3_ACCESS_KEY: ${{ secrets.PROD_S3_ACCESS_KEY }}
           PROD_S3_SECRET_KEY: ${{ secrets.PROD_S3_SECRET_KEY }}
           PROD_COOLSMS_KEY: ${{ secrets.PROD_COOLSMS_KEY }}

--- a/src/main/java/com/beat/global/common/config/RedisConfig.java
+++ b/src/main/java/com/beat/global/common/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -16,9 +17,14 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
+	@Value("${spring.data.redis.password}")
+	private String password;
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration(host, port);
+		redisConfiguration.setPassword(password);
+		return new LettuceConnectionFactory(redisConfiguration);
 	}
 
 	@Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,8 +28,9 @@ spring:
 
   data:
     redis:
-      host: beat-dev-redis
-      port: 6379
+      host: ${DEV_REDIS_HOST}
+      port: ${DEV_REDIS_PORT}
+      password: ${DEV_REDIS_PASSWORD}
 
   security:
     oauth2:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,8 +28,9 @@ spring:
 
   data:
     redis:
-      host: beat-prod-redis
-      port: 6379
+      host: ${PROD_REDIS_HOST}
+      port: ${PROD_REDIS_PORT}
+      # 추후 password: 설정 필요
 
   security:
     oauth2:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #291

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
https://www.notion.so/jiwoothejay/redis-3c0639fc53374725bebeade081c5753f?pvs=4
redis docker 관련 세팅이 변경되었습니다. 해당 링크 참고해주시면 감사하겠습니다!

- dev 서버에 redis password 설정을 추가했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

<img width="809" alt="image" src="https://github.com/user-attachments/assets/01351994-1982-4a30-92fa-7da71ca50e13" />

- dev 서버에 redis docker에 redis.conf 파일을 이용해 몇가지 운영 환경 설정 및 비밀번호 설정을 했었습니다.
- 그런데 스프링부트에서 Redis 서버에 대한 인증이 실패했음을 나타내는 로그가 찍혔습니다.(구체적으로는, Redis 클라이언트가 Redis 서버에 연결하려고 시도했으나, 인증 과정에서 문제가 발생한 것입니다.)
- 그 이유는 스프링부트에서 redis에 리프레쉬 토큰을 저장하려고 접근할 때, 비밀번호를 입력하지 않고 접근을 해서 해당 오류가 발생했습니다.
- 따라서 dev 서버에만 password 설정을 진행하고자 합니다.**(일단 develop에 머지, main 서버에 머지 전 prod 환경에도 redis 비밀번호 설정 필요!!!!!)**

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
