### PR TITLE
[fix] #299 - 캐러셀 삭제 로직 수정 완료

### DIFF
--- a/src/main/java/com/beat/domain/promotion/application/PromotionSchedulerService.java
+++ b/src/main/java/com/beat/domain/promotion/application/PromotionSchedulerService.java
@@ -32,7 +32,7 @@ public class PromotionSchedulerService {
 			Performance performance = promotion.getPerformance();
 
 			if (performance == null) {
-				return;
+				continue;
 			}
 
 			List<Schedule> schedules = scheduleRepository.findByPerformanceId(performance.getId());

--- a/src/main/java/com/beat/domain/promotion/application/PromotionSchedulerService.java
+++ b/src/main/java/com/beat/domain/promotion/application/PromotionSchedulerService.java
@@ -15,6 +15,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +36,7 @@ public class PromotionSchedulerService {
 		List<Long> promotionIdsToDelete = promotionRepository.findAll().stream()
 			.filter(this::isInvalidPromotion)
 			.map(Promotion::getId)
-			.collect(Collectors.toList());
+			.toList();
 
 		if (promotionIdsToDelete.isEmpty()) {
 			return;
@@ -60,10 +61,10 @@ public class PromotionSchedulerService {
 		List<Promotion> remainingPromotions = promotionRepository.findAll();
 		remainingPromotions.sort(Comparator.comparing(promotion -> promotion.getCarouselNumber().getNumber()));
 
-		CarouselNumber[] carouselNumbers = CarouselNumber.values();
+		List<CarouselNumber> carouselNumbers = Arrays.asList(CarouselNumber.values());
 		for (int i = 0; i < remainingPromotions.size(); i++) {
 			Promotion promotion = remainingPromotions.get(i);
-			promotion.updateCarouselNumber(carouselNumbers[i]);
+			promotion.updateCarouselNumber(carouselNumbers.get(i));
 		}
 
 		promotionRepository.saveAll(remainingPromotions);

--- a/src/main/java/com/beat/domain/promotion/application/PromotionSchedulerService.java
+++ b/src/main/java/com/beat/domain/promotion/application/PromotionSchedulerService.java
@@ -2,19 +2,25 @@ package com.beat.domain.promotion.application;
 
 import com.beat.domain.performance.domain.Performance;
 import com.beat.domain.promotion.dao.PromotionRepository;
+import com.beat.domain.promotion.domain.CarouselNumber;
 import com.beat.domain.promotion.domain.Promotion;
 import com.beat.domain.schedule.application.ScheduleService;
 import com.beat.domain.schedule.dao.ScheduleRepository;
 import com.beat.domain.schedule.domain.Schedule;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PromotionSchedulerService {
@@ -26,21 +32,42 @@ public class PromotionSchedulerService {
 	@Scheduled(cron = "1 0 0 * * ?")
 	@Transactional
 	public void checkAndDeleteInvalidPromotions() {
-		List<Promotion> promotions = promotionRepository.findAll();
+		List<Promotion> promotionsToDelete = promotionRepository.findAll().stream()
+			.filter(this::isInvalidPromotion)
+			.collect(Collectors.toList());
 
-		for (Promotion promotion : promotions) {
-			Performance performance = promotion.getPerformance();
-
-			if (performance == null) {
-				continue;
-			}
-
-			List<Schedule> schedules = scheduleRepository.findByPerformanceId(performance.getId());
-			int minDueDate = scheduleService.getMinDueDate(schedules);
-
-			if (minDueDate < 0) {
-				promotionRepository.delete(promotion);
-			}
+		if (promotionsToDelete.isEmpty()) {
+			return;
 		}
+
+		log.info("Deleting promotions: {}", promotionsToDelete.stream()
+			.map(Promotion::getId)
+			.collect(Collectors.toList()));
+
+		promotionRepository.deleteAll(promotionsToDelete);
+		reassignCarouselNumbers();
 	}
+
+	private boolean isInvalidPromotion(Promotion promotion) {
+		return Optional.ofNullable(promotion.getPerformance())
+			.map(performance -> {
+				List<Schedule> schedules = scheduleRepository.findByPerformanceId(performance.getId());
+				return scheduleService.getMinDueDate(schedules) < 0; // 지난 공연 여부 확인
+			})
+			.orElse(false);
+	}
+
+	private void reassignCarouselNumbers() {
+		List<Promotion> remainingPromotions = promotionRepository.findAll();
+		remainingPromotions.sort(Comparator.comparing(promotion -> promotion.getCarouselNumber().getNumber()));
+
+		CarouselNumber[] carouselNumbers = CarouselNumber.values();
+		for (int i = 0; i < remainingPromotions.size(); i++) {
+			Promotion promotion = remainingPromotions.get(i);
+			promotion.updateCarouselNumber(carouselNumbers[i]);
+		}
+
+		promotionRepository.saveAll(remainingPromotions);
+	}
+
 }

--- a/src/main/java/com/beat/domain/promotion/domain/Promotion.java
+++ b/src/main/java/com/beat/domain/promotion/domain/Promotion.java
@@ -75,4 +75,8 @@ public class Promotion {
 		this.redirectUrl = redirectUrl;
 		this.performance = performance;
 	}
+
+	public void updateCarouselNumber(CarouselNumber carouselNumber) {
+		this.carouselNumber = carouselNumber;
+	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #299 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
공연 기간이 지나도 해당 공연 관련 캐러셀이 지워지지 않는 이슈가 있었습니다.
공연 관련이 아닌 캐러셀의 경우 db 상 perfomanceId가 null인데, 캐러셀을 검증하는 과정에서 null일 경우 return하도록 잘못 로직을 작성했어서 검증이 중단됐던 것으로 파악됩니다.. continue로 바꾸니 정상적으로 삭제 작업 이루어집니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="1450" alt="스크린샷 2025-01-03 오전 12 42 18" src="https://github.com/user-attachments/assets/9c22657e-0a35-4d29-a6f7-b1d6ab68405e" />

기존에 공연 관련과 공연 관련 아닌 캐러셀이 섞여있는 상태로 테스트 진행했습니다. performanceId 1, 2에 해당하는 공연들은 모두 지나간 공연입니다.

<img width="1454" alt="스크린샷 2025-01-03 오전 12 42 25" src="https://github.com/user-attachments/assets/bce8ac9d-c98d-403a-a370-5458364d811c" />
schedule된 시간 이후 정상적으로 공연 1, 2에 해당하는 캐러셀들이 삭제된 것을 확인했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
