### PR TITLE
[feat] #290 - Prometheus actuator 설정 완료

### DIFF
--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -59,6 +59,8 @@ jobs:
           DEV_REFRESH_TOKEN_EXPIRE_TIME: ${{ secrets.DEV_REFRESH_TOKEN_EXPIRE_TIME }}
           DEV_ALLOWED_ORIGINS: ${{ secrets.DEV_ALLOWED_ORIGINS }}
           DEV_SERVER_URL: ${{ secrets.DEV_SERVER_URL }}
+          DEV_ACTUATOR_PORT: ${{ secrets.DEV_ACTUATOR_PORT }}
+          DEV_ACTUATOR_PATH: ${{ secrets.DEV_ACTUATOR_PATH }}
         run: |
           cd ./src/main/resources
           envsubst < application-dev.yml > application-dev.tmp.yml && mv application-dev.tmp.yml application-dev.yml

--- a/.github/workflows/prod-CI.yml
+++ b/.github/workflows/prod-CI.yml
@@ -59,6 +59,8 @@ jobs:
           PROD_REFRESH_TOKEN_EXPIRE_TIME: ${{ secrets.PROD_REFRESH_TOKEN_EXPIRE_TIME }}
           PROD_ALLOWED_ORIGINS: ${{ secrets.PROD_ALLOWED_ORIGINS }}
           PROD_SERVER_URL: ${{ secrets.PROD_SERVER_URL }}
+          PROD_ACTUATOR_PORT: ${{ secrets.PROD_ACTUATOR_PORT }}
+          PROD_ACTUATOR_PATH: ${{ secrets.PROD_ACTUATOR_PATH }}
         run: |
           cd ./src/main/resources
           envsubst < application-prod.yml > application-prod.tmp.yml && mv application-prod.tmp.yml application-prod.yml

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 jar {

--- a/src/main/java/com/beat/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/beat/global/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.beat.global.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,26 +26,33 @@ public class SecurityConfig {
 	private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
 	private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-	private static final String[] AUTH_WHITELIST = {
-		"/api/users/sign-up",
-		"/api/users/refresh-token",
-		"/api/bookings/guest/**",
-		"/api/main",
-		"/api/performances/booking/**",
-		"/api/schedules/**",
-		"/api/notifications/**",
-		"/api/performances/detail/**",
-		"/health-check",
-		"/actuator/health",
-		"/v3/api-docs/**",
-		"/swagger-ui/**",
-		"/swagger-resources/**",
-		"/api/files/**",
-		"/error",
-		"/api/bookings/refund",
-		"/api/bookings/cancel",
-		"/"
-	};
+	@Value("${management.endpoints.web.base-path}")
+	private String actuatorEndPoint;
+
+	public String[] getAuthWhitelist() {
+		return new String[] {
+			"/api/users/sign-up",
+			"/api/users/refresh-token",
+			"/api/bookings/guest/**",
+			"/api/main",
+			"/api/performances/booking/**",
+			"/api/schedules/**",
+			"/api/notifications/**",
+			"/api/performances/detail/**",
+			"/health-check",
+			"/actuator/health",
+			"/v3/api-docs/**",
+			"/swagger-ui/**",
+			"/swagger-resources/**",
+			"/api/files/**",
+			"/error",
+			"/api/bookings/refund",
+			"/api/bookings/cancel",
+			actuatorEndPoint + "/health",
+			actuatorEndPoint + "/prometheus",
+			"/"
+		};
+	}
 
 	private static final String[] AUTH_ADMIN_ONLY = {
 		"/api/admin/**"
@@ -62,7 +70,7 @@ public class SecurityConfig {
 					.accessDeniedHandler(customAccessDeniedHandler));
 
 		http.authorizeHttpRequests(auth ->
-				auth.requestMatchers(AUTH_WHITELIST).permitAll()
+				auth.requestMatchers(getAuthWhitelist()).permitAll()
 					.requestMatchers(AUTH_ADMIN_ONLY).hasAuthority(Role.ADMIN.getRoleName())
 					.anyRequest().authenticated())
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,9 +2,29 @@ server:
   port: 8080
 
 management:
+  server:
+    port: ${DEV_ACTUATOR_PORT}
   endpoint:
     health:
       show-details: always
+      enabled: true
+    info:
+      enabled: true
+    prometheus:
+      enabled: true
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: info, health, prometheus
+      base-path: ${DEV_ACTUATOR_PATH}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 spring:
   config:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,9 +2,29 @@ server:
   port: 8080
 
 management:
+  server:
+    port: ${PROD_ACTUATOR_PORT}
   endpoint:
     health:
       show-details: always
+      enabled: true
+    info:
+      enabled: true
+    prometheus:
+      enabled: true
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: info, health, prometheus
+      base-path: ${PROD_ACTUATOR_PATH}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 spring:
   config:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #290

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
https://techblog.woowahan.com/9232/

밑의 설명을 이해하기 위해서는 위의 블로그를 보고 오시는 것을 추천합니다.

### 1. actuator path 및 port 변경(Actuator는 서비스 운영에 사용되는 포트와 다른 포트를 사용한다.  Actuator Default 경로를 사용하지 않고, 경로를 변경하여 운영한다.)
- 보안을 위해서 actuator path와 actuator port를 환경변수 처리했습니다.
- actuator path와 port는 github secret에 추가했고, 노션에도 업로드 해두었습니다.

### 2. Actuator endpoint는 all disable 상태에서 필요한 것만 include하여 화이트리스트 형태로 운영
- 불필요한 endpoint가 활성화되어 추후 잠재적 위험이 될 수 있어, 기본 설정을 따르지 않겠다는 설정을 해주었습니다.

### 3. HTTP(WEB) 엔드포인트 설정
- HTTP(WEB)은 health endpoint만이 유일하게 기본적으로 expose되어 있기에 info, health, prometheus를 추가해주었습니다.

### 4. JMX형태로 Actuator 사용이 필요하지 않을 경우, 반드시 disable한다.
- JMX는 Default로 expose되어있는 endpoint가 많기 때문에, 사용하지 않음에도 enable 시켜두면 잠재적 위험이 될 수 있어서 비활성화 해두었습니다.

### 5. Actuator에 접근할 때에는, 인증되었으며 권한이 있는 사용자만이 접근가능하도록 제어한다?
- 이 부분은 적용하지 않았습니다.
- 설정을 하면 보안상 이점이 있을 수 있지만, 이미 Actuator 포트와 경로를 환경변수로 처리했기 때문에 굳이 설정을 추가하지 않아도 될 것 같다고 판단했습니다. (이에 대해 혜린님의 의견도 궁금합니다!)
- 또한, 저희는 헤더에 토큰이 포함된 요청에 대해 현재 로그를 많이 찍고 있습니다. 예를 들어, 프로메테우스가 15초마다 요청을 보낸다면 로그의 개수가 급격히 늘어나고, 이는 사용자의 액션과 관계없는 의미 없는 로그이기 때문에 도입하기 부적절하다고 판단했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### 보안상의 이유로 스크린샷을 첨부하지는 못하지만, 바뀐 actuator path와 port로 heatlh와 prometheus 요청이 잘 성공한 것을 확인했습니다.

### 머지 후 그라파나 연동 확인 완료
<img width="1494" alt="image" src="https://github.com/user-attachments/assets/44d10842-e313-4034-9dab-9e9d9fb71862" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
