### PR TITLE
[feat] #310 - log4j2를 이용한 AOP 로깅방식 도입 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,11 @@ configurations {
 
 	// Configure libraries related to QueryDSL to be required only at compile-time and add QueryDSL configuration to the compile classpath.
 	querydsl.extendsFrom compileClasspath
+
+	// Enable Log4j2 except for the Spring Boot Default Logging Framework (Logback)
+	configureEach {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
 }
 
 repositories {
@@ -94,6 +99,12 @@ dependencies {
 
 	// Prometheus
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// log4j2
+	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ configurations {
 	// Enable Log4j2 except for the Spring Boot Default Logging Framework (Logback)
 	configureEach {
 		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+		exclude group: 'commons-logging', module: 'commons-logging'
 	}
 }
 

--- a/src/main/java/com/beat/BeatApplication.java
+++ b/src/main/java/com/beat/BeatApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableFeignClients
 @EnableScheduling
 @EnableAsync
+@EnableAspectJAutoProxy
 @ImportAutoConfiguration({FeignAutoConfiguration.class})
 public class BeatApplication {
 

--- a/src/main/java/com/beat/global/auth/jwt/dao/TokenRepository.java
+++ b/src/main/java/com/beat/global/auth/jwt/dao/TokenRepository.java
@@ -9,6 +9,4 @@ import org.springframework.data.repository.CrudRepository;
 public interface TokenRepository extends CrudRepository<Token, Long> {
 
 	Optional<Token> findByRefreshToken(final String refreshToken);
-
-	Optional<Token> findById(final Long id);
 }

--- a/src/main/java/com/beat/global/auth/redis/Token.java
+++ b/src/main/java/com/beat/global/auth/redis/Token.java
@@ -8,9 +8,9 @@ import lombok.Getter;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
-@RedisHash(value = "refreshToken", timeToLive = 1209600)
 @Getter
 @Builder
+@RedisHash(value = "refreshToken", timeToLive = 1209600)
 public class Token {
 
 	@Id

--- a/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
@@ -68,7 +68,7 @@ public class ControllerLoggingAspect {
 	/** Controller 정상 반환 로깅 */
 	@AfterReturning(value = "com.beat.global.common.aop.Pointcuts.allController()", returning = "result")
 	public void logControllerResponse(JoinPoint joinPoint, Object result) {
-		log.info("[Controller 정상 반환] {}.{}() | 반환 값: {}",
+		log.debug("[Controller 정상 반환] {}.{}() | 반환 값: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
 			joinPoint.getSignature().getName(),
 			result);

--- a/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
@@ -12,6 +12,7 @@ import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -26,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Aspect
 @Order(2)
 @Component
+@Profile("!test")
 public class ControllerLoggingAspect {
 
 	private static final String REQUEST_URI = "requestURI";

--- a/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
@@ -1,0 +1,104 @@
+package com.beat.global.common.aop;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import net.minidev.json.JSONObject;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Order(2)
+@Component
+public class ControllerLoggingAspect {
+
+	private static final String REQUEST_URI = "requestURI";
+	private static final String CONTROLLER = "controller";
+	private static final String METHOD = "method";
+	private static final String HTTP_METHOD = "httpMethod";
+	private static final String LOG_TIME = "logTime";
+	private static final String PARAMS = "params";
+
+	/** Controller 요청 로깅 */
+	@Before("com.beat.global.common.aop.Pointcuts.allController()")
+	public void logControllerRequest(JoinPoint joinPoint) {
+		ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+		if (attributes == null) return;
+
+		HttpServletRequest request = attributes.getRequest();
+		Map<String, Object> logInfo = new HashMap<>();
+
+		logInfo.put(CONTROLLER, joinPoint.getSignature().getDeclaringType().getSimpleName());
+		logInfo.put(METHOD, joinPoint.getSignature().getName());
+		logInfo.put(PARAMS, getParams(request));
+		logInfo.put(LOG_TIME, System.currentTimeMillis());
+		logInfo.put(HTTP_METHOD, request.getMethod());
+
+		try {
+			logInfo.put(REQUEST_URI, URLDecoder.decode(request.getRequestURI(), StandardCharsets.UTF_8));
+		} catch (Exception e) {
+			logInfo.put(REQUEST_URI, request.getRequestURI());
+			log.error("[로깅 에러] URL 디코딩 실패", e);
+		}
+
+		log.info("[HTTP {}] {} | {}.{}() | Params: {}",
+			logInfo.get(HTTP_METHOD), logInfo.get(REQUEST_URI),
+			logInfo.get(CONTROLLER), logInfo.get(METHOD),
+			logInfo.get(PARAMS));
+	}
+
+	/** Controller 정상 반환 로깅 */
+	@AfterReturning(value = "com.beat.global.common.aop.Pointcuts.allController()", returning = "result")
+	public void logControllerResponse(JoinPoint joinPoint, Object result) {
+		log.info("[Controller 정상 반환] {}.{}() | 반환 값: {}",
+			joinPoint.getSignature().getDeclaringType().getSimpleName(),
+			joinPoint.getSignature().getName(),
+			result);
+	}
+
+	/** Controller 예외 발생 시 로깅 */
+	@AfterThrowing(value = "com.beat.global.common.aop.Pointcuts.allController()", throwing = "ex")
+	public void logControllerException(JoinPoint joinPoint, Exception ex) {
+		log.error("[Controller 예외 발생] {}.{}() | 예외 메시지: {}",
+			joinPoint.getSignature().getDeclaringType().getSimpleName(),
+			joinPoint.getSignature().getName(),
+			ex.getMessage(), ex);
+	}
+
+	/** HTTP 요청 파라미터를 JSON 형태로 변환 */
+	private static JSONObject getParams(HttpServletRequest request) {
+		JSONObject jsonObject = new JSONObject();
+		Enumeration<String> params = request.getParameterNames();
+
+		while (params.hasMoreElements()) {
+			String param = params.nextElement();
+			String replacedParam = param.replace(".", "-");
+			String[] values = request.getParameterValues(param);
+
+			if (values == null || values.length == 0) {
+				jsonObject.put(replacedParam, ""); // 값이 없을 경우 빈 문자열 저장
+			} else if (values.length > 1) {
+				jsonObject.put(replacedParam, values); // 여러 값이 있는 경우 배열로 저장
+			} else {
+				jsonObject.put(replacedParam, values[0]); // 단일 값이면 문자열로 저장
+			}
+		}
+		return jsonObject;
+	}
+}

--- a/src/main/java/com/beat/global/common/aop/ExecutionTimeLoggerAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ExecutionTimeLoggerAspect.java
@@ -1,0 +1,55 @@
+package com.beat.global.common.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@Order(0)
+public class ExecutionTimeLoggerAspect {
+
+	private ExecutionTimeLoggerAspect() {
+	}
+
+	/** prod 환경에서는 서비스 계층만 실행 시간 측정 */
+	@Aspect
+	@Component
+	@Profile("prod")
+	public static class ExecutionTimeLoggerForProd {
+		@Around("com.beat.global.common.aop.Pointcuts.allService()")
+		public Object logServiceExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+			return measureExecutionTime(joinPoint);
+		}
+	}
+
+	/** local/dev 환경에서는 전체 애플리케이션 로직 실행 시간 측정 */
+	@Aspect
+	@Component
+	@Profile({"local", "dev"})
+	public static class ExecutionTimeLoggerForLocalDev {
+		@Around("com.beat.global.common.aop.Pointcuts.allApplicationLogic()")
+		public Object logApplicationExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+			return measureExecutionTime(joinPoint);
+		}
+	}
+
+	/** 실행 시간 측정 공통 메서드 */
+	private static Object measureExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		long start = System.currentTimeMillis();
+		try {
+			return joinPoint.proceed();
+		} finally {
+			long timeInMs = System.currentTimeMillis() - start;
+			log.info("[실행 시간] {}.{}() | time = {}ms",
+				joinPoint.getSignature().getDeclaringType().getSimpleName(),
+				joinPoint.getSignature().getName(),
+				timeInMs);
+		}
+	}
+}

--- a/src/main/java/com/beat/global/common/aop/Pointcuts.java
+++ b/src/main/java/com/beat/global/common/aop/Pointcuts.java
@@ -1,0 +1,15 @@
+package com.beat.global.common.aop;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class Pointcuts {
+	@Pointcut("execution(* com.beat..*Controller.*(..))")
+	public void allController() {}
+
+	@Pointcut("execution(* com.beat..*Service.*(..)) || execution(* com.beat..*UseCase.*(..)) || execution(* com.beat..*Facade.*(..))")
+	public void allService() {}
+
+	@Pointcut("execution(* com.beat..*(..))" +
+		" && !within(com.beat.global..*)")
+	public void allApplicationLogic() {}
+}

--- a/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
@@ -22,21 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Profile("!test")
 public class ServiceLoggingAspect {
-	/** 실행 시간 측정 */
-	@Around("com.beat.global.common.aop.Pointcuts.allApplicationLogic()")
-	public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
-		long start = System.currentTimeMillis();
-		try {
-			return joinPoint.proceed();
-		} finally {
-			long end = System.currentTimeMillis();
-			long timeInMs = end - start;
-			log.info("[실행 시간] {}.{}() | time = {}ms",
-				joinPoint.getSignature().getDeclaringType().getSimpleName(),
-				joinPoint.getSignature().getName(),
-				timeInMs);
-		}
-	}
 
 	/** Service 메서드 실행 전 로깅 */
 	@Before("com.beat.global.common.aop.Pointcuts.allService()")

--- a/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
@@ -1,0 +1,73 @@
+package com.beat.global.common.aop;
+
+import java.util.Arrays;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Order(3)
+@Component
+public class ServiceLoggingAspect {
+	/** 실행 시간 측정 */
+	@Around("com.beat.global.common.aop.Pointcuts.allApplicationLogic()")
+	public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		long start = System.currentTimeMillis();
+		try {
+			return joinPoint.proceed();
+		} finally {
+			long end = System.currentTimeMillis();
+			long timeInMs = end - start;
+			log.info("[실행 시간] {}.{}() | time = {}ms",
+				joinPoint.getSignature().getDeclaringType().getSimpleName(),
+				joinPoint.getSignature().getName(),
+				timeInMs);
+		}
+	}
+
+	/** Service 메서드 실행 전 로깅 */
+	@Before("com.beat.global.common.aop.Pointcuts.allService()")
+	public void doLog(JoinPoint joinPoint) {
+		log.info("[메서드 실행] {}.{}() | 인자: {}",
+			joinPoint.getSignature().getDeclaringType().getSimpleName(),
+			joinPoint.getSignature().getName(),
+			Arrays.toString(joinPoint.getArgs()));
+	}
+
+	/** Service 정상 반환 로깅 */
+	@AfterReturning(value = "com.beat.global.common.aop.Pointcuts.allService()", returning = "result")
+	public void logReturn(JoinPoint joinPoint, Object result) {
+		log.info("[Service 정상 반환] {}.{}() | 반환 값: {}",
+			joinPoint.getSignature().getDeclaringType().getSimpleName(),
+			joinPoint.getSignature().getName(),
+			result);
+	}
+
+	/** 예외 발생 시 로깅 */
+	@AfterThrowing(value = "com.beat.global.common.aop.Pointcuts.allService()", throwing = "ex")
+	public void logException(JoinPoint joinPoint, Exception ex) {
+		log.error("[예외 발생] {}.{}() | 예외 메시지: {}",
+			joinPoint.getSignature().getDeclaringType().getSimpleName(),
+			joinPoint.getSignature().getName(),
+			ex.getMessage());
+	}
+
+	/** 메서드 실행 후 로깅 */
+	@After("com.beat.global.common.aop.Pointcuts.allService()")
+	public void doAfter(JoinPoint joinPoint) {
+		log.info("[메서드 종료] {}.{}()",
+			joinPoint.getSignature().getDeclaringType().getSimpleName(),
+			joinPoint.getSignature().getName());
+	}
+}

--- a/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
@@ -10,6 +10,7 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @Aspect
 @Order(3)
 @Component
+@Profile("!test")
 public class ServiceLoggingAspect {
 	/** 실행 시간 측정 */
 	@Around("com.beat.global.common.aop.Pointcuts.allApplicationLogic()")

--- a/src/main/java/com/beat/global/common/aop/TxAspect.java
+++ b/src/main/java/com/beat/global/common/aop/TxAspect.java
@@ -1,0 +1,71 @@
+package com.beat.global.common.aop;
+
+import java.lang.reflect.Method;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Order(1)
+@Component
+public class TxAspect {
+
+	@Around("com.beat.global.common.aop.Pointcuts.allService()")
+	public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+		// 메서드 정보를 추출
+		MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+		Method method = methodSignature.getMethod();
+
+		// @Transactional 애너테이션 정보 확인 (메서드 혹은 클래스 레벨)
+		Transactional transactional = method.getAnnotation(Transactional.class);
+		if (transactional == null) {
+			transactional = joinPoint.getTarget().getClass().getAnnotation(Transactional.class);
+		}
+
+		boolean readOnly = false;
+		Propagation propagation = Propagation.REQUIRED;
+		Isolation isolation = Isolation.DEFAULT;
+		if (transactional != null) {
+			readOnly = transactional.readOnly();
+			propagation = transactional.propagation();
+			isolation = transactional.isolation();
+		}
+
+		// 트랜잭션 시작 로깅 (옵션 포함)
+		log.info("[트랜잭션 시작] {}.{}() | readOnly={} | propagation={} | isolation={}",
+			joinPoint.getSignature().getDeclaringType().getSimpleName(),
+			method.getName(), readOnly, propagation, isolation);
+
+		// 실행 시간 측정을 위한 시작 시간
+		long start = System.currentTimeMillis();
+		try {
+			// 실제 비즈니스 로직 실행
+			Object result = joinPoint.proceed();
+			long elapsed = System.currentTimeMillis() - start;
+			log.info("[트랜잭션 커밋] {}.{}() | 소요 시간: {}ms",
+				joinPoint.getSignature().getDeclaringType().getSimpleName(),
+				method.getName(), elapsed);
+			return result;
+		} catch (Exception e) {
+			long elapsed = System.currentTimeMillis() - start;
+			log.error("[트랜잭션 롤백] {}.{}() | 소요 시간: {}ms",
+				joinPoint.getSignature().getDeclaringType().getSimpleName(),
+				method.getName(), elapsed, e);
+			throw e;
+		} finally {
+			// 리소스 릴리즈 로깅
+			log.info("[리소스 릴리즈] {}.{}()",
+				joinPoint.getSignature().getDeclaringType().getSimpleName(),
+				method.getName());
+		}
+	}
+}

--- a/src/main/java/com/beat/global/common/aop/TxAspect.java
+++ b/src/main/java/com/beat/global/common/aop/TxAspect.java
@@ -5,6 +5,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Aspect
 @Order(1)
 @Component
+@Profile("!test")
 public class TxAspect {
 
 	@Around("com.beat.global.common.aop.Pointcuts.allService()")

--- a/src/main/java/com/beat/global/common/config/RepositoryConfig.java
+++ b/src/main/java/com/beat/global/common/config/RepositoryConfig.java
@@ -1,0 +1,21 @@
+package com.beat.global.common.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableJpaRepositories(
+	basePackages = "com.beat",
+	excludeFilters = @ComponentScan.Filter(
+		type = FilterType.REGEX,
+		pattern = "com\\.beat\\.global\\.auth\\.jwt\\.dao\\..*"
+	)
+)
+@EnableRedisRepositories(
+	basePackages = "com.beat.global.auth.jwt.dao"
+)
+public class RepositoryConfig {
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -95,6 +95,8 @@ cloud:
 logging:
   level:
     root: info
+  config: classpath:log4j2-spring.xml
+
 
 cors:
   allowed-origins: ${DEV_ALLOWED_ORIGINS}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -95,6 +95,7 @@ cloud:
 logging:
   level:
     root: info
+  config: classpath:log4j2-spring.xml
 
 cors:
   allowed-origins: ${PROD_ALLOWED_ORIGINS}

--- a/src/main/resources/log4j2-spring.xml
+++ b/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <!-- Properties 태그 추가 -->
+    <Properties>
+        <Property name="LOG_PATTERN">
+            %style{%d{yyyy-MM-dd HH:mm:ss,SSS}}{blue} %highlight{[%-5p]}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=bright_blue, TRACE=cyan} [%t] %style{[%c{1}.%M():%L]}{BRIGHT_BLACK} - %m%n
+        </Property>
+    </Properties>
+
+    <!-- 콘솔 출력 설정 -->
+    <Appenders>
+        <Console name="Console_Appender" target="SYSTEM_OUT">
+            <PatternLayout pattern="${LOG_PATTERN}"/>
+        </Console>
+    </Appenders>
+
+    <!-- 환경별 로깅 설정 -->
+    <Loggers>
+        <springProfile name="local">
+            <Root level="INFO">
+                <AppenderRef ref="Console_Appender"/>
+            </Root>
+        </springProfile>
+
+        <springProfile name="dev">
+            <Root level="INFO">
+                <AppenderRef ref="Console_Appender"/>
+            </Root>
+        </springProfile>
+
+        <springProfile name="prod">
+            <Root level="INFO">
+                <AppenderRef ref="Console_Appender"/>
+            </Root>
+        </springProfile>
+
+        <springProfile name="test">
+            <Root level="INFO">
+                <AppenderRef ref="Console_Appender"/>
+            </Root>
+        </springProfile>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #310

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

## log4j2 설명
![image](https://github.com/user-attachments/assets/3071be5b-16a1-4937-93fc-a6b23e21a2e6)

> 비동기(AsyncLogger, AsyncAppender)적으로 로깅할 때, 각 로깅 프레임워크의 초당 메시지 처리량(msg/sec)을 측정한 그래프입니다

> 각 색상의 막대 그래프:
> 파란색 (Log4j2: Loggers all async) → Log4j2에서 모든 Logger를 비동기(AsyncLogger)로 설정한 경우
> 빨간색 (Log4j2: Loggers mixed sync/async) → Log4j2에서 일부 로거는 동기(SyncLogger), 일부는 비동기(AsyncLogger)
> 노란색 (Log4j2: Async Appender) → Log4j2에서 AsyncAppender만 사용
> 보라색 (Log4j1: Async Appender) → Log4j1에서 AsyncAppender 사용
> 연두색 (Logback: Async Appender) → Logback에서 AsyncAppender 사용

![image](https://github.com/user-attachments/assets/1252b081-4932-4532-9dc2-1a5b94e02c89)

> 비동기(AsyncLogger, AsyncAppender) 없이 동기적으로 로깅할 때, 각 로깅 프레임워크의 초당 메시지 처리량(msg/sec)을 측정한 그래프입니다
> Log4j2(파란색, 하늘색)가 Logback (주황색)보다 동기 상황에서도 성능이 좋은것을 확인할 수 있습니다.


#### 결론
- 동기/비동기 상황 모두 고부하 환경에서 Log4j2가 Logback에 비해 압도적으로 로깅 처리량이 높은 것을 확인할 수 있습니다.
- 따라서 로깅 구현체로 현재 스프링부트에 기본으로 내장된 logback 대신 log4j2가 적합할 것으로 판단하여 log4j2를 도입하게 되었습니다.

### log4j2-spring.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Configuration status="INFO">
    <!-- Properties 태그 추가 -->
    <Properties>
        <Property name="LOG_PATTERN">
            %style{%d{yyyy-MM-dd HH:mm:ss,SSS}}{blue} %highlight{[%-5p]}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=bright_blue, TRACE=cyan} [%t] %style{[%c{1}.%M():%L]}{BRIGHT_BLACK} - %m%n
        </Property>
    </Properties>

    <!-- 콘솔 출력 설정 -->
    <Appenders>
        <Console name="Console_Appender" target="SYSTEM_OUT">
            <PatternLayout pattern="${LOG_PATTERN}"/>
        </Console>
    </Appenders>

    <!-- 환경별 로깅 설정 -->
    <Loggers>
        <springProfile name="local">
            <Root level="INFO">
                <AppenderRef ref="Console_Appender"/>
            </Root>
        </springProfile>

        <springProfile name="dev">
            <Root level="INFO">
                <AppenderRef ref="Console_Appender"/>
            </Root>
        </springProfile>

        <springProfile name="prod">
            <Root level="INFO">
                <AppenderRef ref="Console_Appender"/>
            </Root>
        </springProfile>

        <springProfile name="test">
            <Root level="INFO">
                <AppenderRef ref="Console_Appender"/>
            </Root>
        </springProfile>
    </Loggers>
</Configuration>

```
- 현재 설정한 log4j2-spirng.xml 구현 코드입니다.
- 모든 profile(local, dev, prod, test)에서 루트 레벨을 info로하여 로깅을 할 수 있도록 설정하였습니다.
- 또한, 비동기 세팅 없이(cc. AsyncLogger, AsyncAppender) 동기적으로 로깅을 하도록 설정을 해둔 상황입니다.
- 그 이유는 AsyncLogger, AsyncAppender와 같은 비동기 방식은 다음과 같은 문제점이 존재하기 때문입니다.

### 비동기 로깅의 단점
#### 1. 로그 유실 가능성 (Lost Logs)
- 애플리케이션이 비정상 종료되거나 예기치 않은 시스템 장애가 발생하면, 큐에 쌓인 로그가 저장되지 않고 유실될 위험이 있습니다.
- AsyncLogger / AsyncAppender 모두 별도 쓰레드에서 로그를 처리하므로, 로그가 실제 파일에 기록되기 전에 종료되면 로그 손실이 발생할 수 있습니다.
- 해결 방법으로는 shutdownHook="true" 설정 추가하여 종료 전에 큐를 비우고 로그 기록 강제 수행하거나, queueFullPolicy="Discard" 대신 queueFullPolicy="Block"으로 설정해 버퍼 초과 시 대기하도록 설정할 수 있습니다.

#### 2. 로깅 실패 감지 어려움 (Error Handling Challenge)
- 동기 로깅은 logger.info("로그 기록") 실행 시점에 바로 로그가 기록되지만, 비동기 로깅은 로그가 큐에 저장된 후 별도 쓰레드에서 처리되므로, 로깅 실패가 발생해도 애플리케이션 코드에서 이를 즉시 감지할 수 없습니다.
- 에를 들어, 디스크 공간 부족, 네트워크 장애, 파일 시스템 문제 등으로 로그 기록이 실패해도 logger.info() 호출 자체는 성공한 것으로 처리되는 상황이 있습니다.
- 해결 방법으로는 queueFullPolicy="enforce"를 설정하여, 큐가 가득 찼을 때 예외를 발생시켜 애플리케이션이 감지하도록 하고, 로깅 중 예외가 발생하면 별도의 ErrorLogger를 사용하여 실패 로그를 기록하도록 설정하는 방법이 있습니다.

#### 결론
- 저는 비즈니스 로직 로깅에서 로그 유실이 발생하는 것이 치명적인 문제라고 판단했습니다.
- 이에 대한 해결책을 조사한 결과, 중요한 로그는 Sync Logger를 사용하고, 그렇지 않은 로그는 Async Logger를 혼합하여 운영하는 방식이 효과적인 대안으로 보였습니다.
- 따라서, 해당 방식을 도입하기 전에 전체적으로 동기로깅을 적용했을 때, dev서버에 부하 테스트를 통해 로깅 성능을 측정하고, 최적의 설정을 찾고자 합니다.

## AOP 도입
- 애플리케이션 전반에 걸친 공통 관심 사항(로깅, 트랜잭션 관리, 실행 시간 측정 등)을 AOP(Aspect Oriented Programming)를 이용해 분리하여 관리하기 위해 도입하게 되었습니다.

### Pointcuts.java
```java
package com.beat.global.common.aop;

import org.aspectj.lang.annotation.Pointcut;

public class Pointcuts {
	@Pointcut("execution(* com.beat..*Controller.*(..))")
	public void allController() {}

	@Pointcut("execution(* com.beat..*Service.*(..)) || execution(* com.beat..*UseCase.*(..)) || execution(* com.beat..*Facade.*(..))")
	public void allService() {}

	@Pointcut("execution(* com.beat..*(..))" +
		" && !within(com.beat.global..*)")
	public void allApplicationLogic() {}
}
```

- 해당 클래스는 AOP가 적용될 대상(포인트컷, Pointcut)을 정의한 것으로, 각각의 메서드는 특정 패키지 내의 클래스를 대상으로 AOP를 적용할 수 있도록 구현하였습니다.
    - `allController()`: com.beat 패키지 아래의 모든 Controller 클래스의 메서드에 AOP 적용
    - `allService()`: Service, UseCase, Facade 클래스를 포함하는 비즈니스 로직 계층에 AOP 적용
    - `allApplicationLogic()`: com.beat.global 패키지를 제외한 모든 클래스의 메서드에 AOP 적용 (이 부분은 추후 변동성 있음)

### ExecutionTimeLoggerAspect.java
```java
@Aspect
@Order(0)
@Component
public class ExecutionTimeLoggerAspect {
...
...
}
```
- 해당 클래스는 애플리케이션의 성능을 모니터링하기 위해 실행 시간을 측정 및 로깅할 수 있도록 구현하였습니다.
- @Order(0)을 적용하여 AOP 체인의 가장 바깥쪽에서 실행되도록 설정하였으며, 트랜잭션, 서비스 로깅 등의 다른 AOP가 적용되기 전에 실행됩니다.
- @Around 어노테이션을 사용하여 메서드 실행 전후로 System.currentTimeMillis()를 이용해 실행 시간을 측정하고, 최종적으로 로깅을 수행합니다.
- prod 환경에서는 서비스 계층 메서드의 실행 시간만 측정하며, dev, local 환경에서는 애플리케이션의 모든 로직을 감싸고 실행 시간을 측정합니다. **(prod 서버에서는 핵심 비즈니스 로직 실행시간만 측정하고, 불필요한 로그 양을 줄이는 방식으로 진행)** 

### ControllerLoggingAspect.java
```java
@Aspect
@Order(2)
@Component
@Profile("!test")
public class ControllerLoggingAspect {
...
...
}
```
- 해당 클래스는 컨트롤러 계층의 HTTP 요청/응답과 예외를 로깅하여, 외부에서 들어오는 요청이 어떻게 처리되는지 추적할 수 있도록 구현하였습니다.
- @Before를 적용해 컨트롤러의 모든 메서드 실행 전 요청 정보를 로깅하고, 
- @AfterReturning를 적용해 컨트롤러의 메서드가 정상적으로 실행된 후 응답 데이터를 로깅하고(**서비스와 반환 값이 같아 debug레벨로 변경**), 
- @AfterThrowing을 적용해 컨트롤러에서 예외가 발생했을 때 예외 정보를 로그에 남길 수 있도록 구현했습니다.

### ServiceLoggingAspect.java
```java
@Aspect
@Order(3)
@Component
@Profile("!test")
public class ServiceLoggingAspect {
...
...
}
```
- 해당 클래스는 서비스 계층(또는 애플리케이션 로직)의 메서드 실행 과정을 상세하게 로깅하여, 실행 시간, 인자, 반환값 및 예외 발생 여부를 추적할 수 있도록 구현하였습니다.
- @Around는 메서드 실행 전후를 감싸서 로깅하고, System.currentTimeMillis()를 사용해 실행 시간을 측정할 수 있도록 하였고, 
- @Before를 적용해 서비스 메서드 실행 전에 실행 정보(메서드명, 인자)를 로깅하고,
- @AfterReturning을 적용해 서비스 메서드 실행 후 정상 반환된 값을 로깅하고,
- @AfterThrowing을 적용해 서비스 메서드 실행 중 예외 발생 시 예외 정보를 로깅하고,
- @After를 적용해 서비스 메서드 종료 시점을 로깅할 수 있도록 구현하였습니다.

### TxAspect.java
```java
@Aspect
@Order(1)
@Component
@Profile("!test")
public class TxAspect {
...
...
}
```
- 해당 클래스는 서비스 계층의 트랜잭션 경계를 관리하면서 트랜잭션 관련 상세 정보를 로깅할 수 있도록 구현하였습니다.
- @Around를 사용해 다음과 같은 정보를 로깅할 수 있도록 구현하였습니다.
    - 메서드 정보 추출:
        - MethodSignature를 통해 호출되는 메서드의 정보를 추출합니다.
        - 이를 통해 메서드에 붙은 @Transactional 애너테이션을 확인합니다.
    - 트랜잭션 옵션 로깅:
        - @Transactional 애너테이션이 있다면, readOnly, propagation, isolation 값들을 추출합니다.
        - 이를 통해 어떤 트랜잭션 옵션으로 메서드가 실행되고 있는지 명시적으로 로깅합니다.
    - 실행 시간 측정:
        - 메서드 실행 전후의 시간을 측정하여, 트랜잭션 처리 소요 시간을 로깅합니다.
    - 트랜잭션 처리 결과:
        - 정상 실행 시 커밋, 예외 발생 시 롤백을 로그에 기록합니다.
    - 리소스 릴리즈:
        - finally 블록에서 리소스 해제 시점을 로깅하여, 트랜잭션 관리 흐름을 추적할 수 있습니다.

#### 왜 이렇게 했는가?
- 트랜잭션이 어떻게 처리되는지(시작, 커밋, 롤백, 리소스 해제)를 명확히 기록하면, DB나 기타 리소스 관련 문제 발생 시 원인을 빠르게 파악할 수 있습니다.
- 특히, 서비스 계층의 메서드에 대해 트랜잭션 옵션과 실행 시간 정보를 남기면, 퍼포먼스 최적화 및 오류 디버깅에 큰 도움이 됩니다.

### Aspect Order의 순서
- @Order(0)인 ExecutionTimeLoggerAspect는 AOP 체인의 가장 처음에 실행되어 전체 실행 시간을 측정합니다.
- @Order(1)인 TxAspect는 서비스 로직이 실행되기 전에 트랜잭션 경계를 잡아줍니다.
- @Order(2)인 ControllerLoggingAspect는 HTTP 요청과 응답을 로깅하여, 트랜잭션 설정 이후에 컨트롤러 진입 및 종료를 기록합니다.
- @Order(3)인 ServiceLoggingAspect는 서비스 메서드의 세부 실행 과정을 로깅합니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### 기존 logging 모듈 삭제
---

#### AS-IS
<img width="476" alt="Image" src="https://github.com/user-attachments/assets/d62e764d-b8bb-4ffb-b776-17548d94a988" />

#### TO-BE
<img width="514" alt="image" src="https://github.com/user-attachments/assets/d2a34ae5-5a14-40ad-8526-6c4691c5237d" />

- Spring에서는 기본적으로 Logback을 이용해서 로깅을 하기 때문에, 다른 로깅 라이브러리인 Log4j2를 그냥 추가하게 되면, 로깅 라이브러리끼리 충돌이 발생합니다.
- 따라서 build.gradle 에서 Logback 설정을 exclude하고 log4j2 설정을 추가했습니다.

### AOP 적용 시 로깅
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/a9f3ecc7-58a8-4068-9b3e-7490e1c29cbc" />

---

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/0be77314-0779-45b6-8350-104de45cb8e9" />

- AOP를 적용하고 local에서 홈 API를 조회했을 때 로깅 화면입니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
[log4j2 참고 블로그](
https://velog.io/@byeongju/Log4j2-AsyncLogger%EC%99%80-%ED%95%A8%EA%BB%98-%ED%95%98%EB%8A%94-Logging-%ED%99%98%EA%B2%BD-%EA%B5%AC%EC%B6%95?ref=codenary)

[AOP 참고 블로그](https://drow724.tistory.com/entry/%EC%8A%A4%ED%94%84%EB%A7%81-%ED%95%B5%EC%8B%AC-%EC%9B%90%EB%A6%AC-%EA%B3%A0%EA%B8%89%ED%8E%B8-09-%EC%8A%A4%ED%94%84%EB%A7%81-AOP-%EA%B5%AC%ED%98%84)

- local-yml을 노션에 업데이트 해두었으니, 변경해주시면 감사하겠습니다!
