### PR TITLE
[fix] #327 - 활성 예약 검증 로직에서 예매 삭제 상태(BOOKING_DELETED)도 제외하도록 수정

### DIFF
--- a/src/main/java/com/beat/domain/booking/dao/BookingRepository.java
+++ b/src/main/java/com/beat/domain/booking/dao/BookingRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.beat.domain.booking.domain.Booking;
+import com.beat.domain.booking.domain.BookingStatus;
 
 public interface BookingRepository extends JpaRepository<Booking, Long> {
 	@Query("SELECT b FROM Booking b " +
@@ -33,6 +34,9 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
 
 	List<Booking> findByUsersId(Long userId);
 
-	@Query("SELECT COUNT(b) > 0 FROM Booking b WHERE b.schedule.id IN :scheduleIds AND b.bookingStatus != 'BOOKING_CANCELLED'")
-	boolean existsByScheduleIdIn(@Param("scheduleIds") List<Long> scheduleIds);
+	@Query("SELECT COUNT(b) > 0 FROM Booking b WHERE b.schedule.id IN :scheduleIds AND b.bookingStatus NOT IN :excludedStatuses")
+	boolean existsActiveBookingByScheduleIds(
+		@Param("scheduleIds") List<Long> scheduleIds,
+		@Param("excludedStatuses") List<BookingStatus> excludedStatuses
+	);
 }

--- a/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
+++ b/src/main/java/com/beat/domain/performance/application/PerformanceModifyService.java
@@ -5,12 +5,12 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.beat.domain.booking.dao.BookingRepository;
+import com.beat.domain.booking.domain.BookingStatus;
 import com.beat.domain.cast.dao.CastRepository;
 import com.beat.domain.cast.domain.Cast;
 import com.beat.domain.cast.exception.CastErrorCode;
@@ -73,7 +73,9 @@ public class PerformanceModifyService {
 		validateOwnership(userId, performance);
 
 		List<Long> scheduleIds = scheduleRepository.findIdsByPerformanceId(request.performanceId());
-		boolean isBookerExist = bookingRepository.existsByScheduleIdIn(scheduleIds);
+
+		List<BookingStatus> statusesToExclude = List.of(BookingStatus.BOOKING_CANCELLED, BookingStatus.BOOKING_DELETED);
+		boolean isBookerExist = bookingRepository.existsActiveBookingByScheduleIds(scheduleIds, statusesToExclude);
 
 		if (isBookerExist && request.ticketPrice() != performance.getTicketPrice()) {
 			log.error("Ticket price update failed due to existing bookings for performanceId: {}", performance.getId());
@@ -148,7 +150,7 @@ public class PerformanceModifyService {
 
 		List<LocalDateTime> performanceDates = request.scheduleModifyRequests().stream()
 			.map(ScheduleModifyRequest::performanceDate)
-			.collect(Collectors.toList());
+			.toList();
 		performance.updatePerformancePeriod(performanceDates);
 
 		if (!isBookerExist) {
@@ -167,11 +169,11 @@ public class PerformanceModifyService {
 		List<Long> requestScheduleIds = scheduleRequests.stream()
 			.map(ScheduleModifyRequest::scheduleId)
 			.filter(Objects::nonNull)
-			.collect(Collectors.toList());
+			.toList();
 
 		List<Long> schedulesToDelete = existingScheduleIds.stream()
 			.filter(id -> !requestScheduleIds.contains(id))
-			.collect(Collectors.toList());
+			.toList();
 
 		deleteRemainingSchedules(schedulesToDelete);
 
@@ -191,7 +193,7 @@ public class PerformanceModifyService {
 
 				return schedule;
 			})
-			.collect(Collectors.toList());
+			.toList();
 
 		performance.assignScheduleNumbers(schedules);
 
@@ -203,7 +205,7 @@ public class PerformanceModifyService {
 				calculateDueDate(schedule.getPerformanceDate()),
 				schedule.getScheduleNumber()
 			))
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	private Schedule addSchedule(ScheduleModifyRequest request, Performance performance) {
@@ -409,7 +411,7 @@ public class PerformanceModifyService {
 					return updateStaff(request, performance);
 				}
 			})
-			.collect(Collectors.toList());
+			.toList();
 
 		deleteRemainingStaffs(existingStaffIds);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: local
+    default: dev


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #327 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 활성 예약 검증 로직에서 예매 삭제 상태(BOOKING_DELETED)도 제외하도록 수정했습니다.
- 따라서 예약자 count 시에 제외되는 상태는 예매 삭제 상태(BOOKING_DELETED), 예매 취소 상태(BOOKING_CANCELLED)입니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
