### PR TITLE
[feat] #342 - 예매 이벤트 슬랙 알림 기능 구현

### DIFF
--- a/.github/workflows/prod-CI.yml
+++ b/.github/workflows/prod-CI.yml
@@ -61,7 +61,8 @@ jobs:
           PROD_SERVER_URL: ${{ secrets.PROD_SERVER_URL }}
           PROD_ACTUATOR_PORT: ${{ secrets.PROD_ACTUATOR_PORT }}
           PROD_ACTUATOR_PATH: ${{ secrets.PROD_ACTUATOR_PATH }}
-          PROD_SLACK_WEBHOOK_URL: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+          PROD_SLACK_MEMBER_WEBHOOK_URL: ${{ secrets.PROD_SLACK_MEMBER_WEBHOOK_URL }}
+          PROD_SLACK_BOOKING_WEBHOOK_URL: ${{ secrets.PROD_SLACK_BOOKING_WEBHOOK_URL }}
         run: |
           cd ./src/main/resources
           envsubst < application-prod.yml > application-prod.tmp.yml && mv application-prod.tmp.yml application-prod.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /app
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /app
 

--- a/src/main/java/com/beat/domain/booking/application/GuestBookingService.java
+++ b/src/main/java/com/beat/domain/booking/application/GuestBookingService.java
@@ -1,10 +1,12 @@
 package com.beat.domain.booking.application;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.beat.domain.booking.application.dto.GuestBookingRequest;
 import com.beat.domain.booking.application.dto.GuestBookingResponse;
+import com.beat.domain.booking.application.dto.event.BookingCreatedEvent;
 import com.beat.domain.booking.dao.BookingRepository;
 import com.beat.domain.booking.domain.Booking;
 import com.beat.domain.schedule.dao.ScheduleRepository;
@@ -26,6 +28,7 @@ public class GuestBookingService {
 	private final ScheduleRepository scheduleRepository;
 	private final BookingRepository bookingRepository;
 	private final UserRepository userRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
 	public GuestBookingResponse createGuestBooking(GuestBookingRequest guestBookingRequest) {
@@ -70,6 +73,8 @@ public class GuestBookingService {
 		bookingRepository.save(booking);
 
 		log.info("Guest Booking created: {}", booking);
+
+		eventPublisher.publishEvent(BookingCreatedEvent.of(booking, schedule));
 
 		return GuestBookingResponse.of(
 			booking.getId(),

--- a/src/main/java/com/beat/domain/booking/application/MemberBookingService.java
+++ b/src/main/java/com/beat/domain/booking/application/MemberBookingService.java
@@ -1,10 +1,12 @@
 package com.beat.domain.booking.application;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.beat.domain.booking.application.dto.MemberBookingRequest;
 import com.beat.domain.booking.application.dto.MemberBookingResponse;
+import com.beat.domain.booking.application.dto.event.BookingCreatedEvent;
 import com.beat.domain.booking.dao.BookingRepository;
 import com.beat.domain.booking.domain.Booking;
 import com.beat.domain.member.dao.MemberRepository;
@@ -31,6 +33,7 @@ public class MemberBookingService {
 	private final BookingRepository bookingRepository;
 	private final MemberRepository memberRepository;
 	private final UserRepository userRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional(timeout = 200)
 	public MemberBookingResponse createMemberBooking(Long memberId, MemberBookingRequest memberBookingRequest) {
@@ -67,6 +70,8 @@ public class MemberBookingService {
 		scheduleRepository.save(schedule);
 
 		log.info("Member Booking created: {}", booking);
+
+		eventPublisher.publishEvent(BookingCreatedEvent.of(booking, schedule));
 
 		return MemberBookingResponse.of(
 			booking.getId(),

--- a/src/main/java/com/beat/domain/booking/application/dto/event/BookingCreatedEvent.java
+++ b/src/main/java/com/beat/domain/booking/application/dto/event/BookingCreatedEvent.java
@@ -1,0 +1,26 @@
+package com.beat.domain.booking.application.dto.event;
+
+import java.time.LocalDateTime;
+
+import com.beat.domain.booking.domain.Booking;
+import com.beat.domain.schedule.domain.Schedule;
+
+public record BookingCreatedEvent(
+	LocalDateTime bookingDateTime,
+	String performanceTitle,
+	int purchaseTicketCount,
+	String bookerName,
+	int currentSoldTicketCount,
+	int totalTicketCount
+) {
+	public static BookingCreatedEvent of(Booking booking, Schedule schedule) {
+		return new BookingCreatedEvent(
+			booking.getCreatedAt(),
+			schedule.getPerformance().getPerformanceTitle(),
+			booking.getPurchaseTicketCount(),
+			booking.getBookerName(),
+			schedule.getSoldTicketCount(),
+			schedule.getTotalTicketCount()
+		);
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/application/BookingSlackClient.java
+++ b/src/main/java/com/beat/global/external/notification/slack/application/BookingSlackClient.java
@@ -1,15 +1,15 @@
 package com.beat.global.external.notification.slack.application;
 
-import java.util.Map;
-
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.beat.global.external.notification.slack.vo.message.SlackMessage;
+
 @FeignClient(name = "bookingSlackClient", url = "${slack.webhook.booking-url}")
 public interface BookingSlackClient {
 
 	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
-	void sendMessage(@RequestBody Map<String, String> payload);
+	void sendMessage(@RequestBody SlackMessage payload);
 }

--- a/src/main/java/com/beat/global/external/notification/slack/application/BookingSlackClient.java
+++ b/src/main/java/com/beat/global/external/notification/slack/application/BookingSlackClient.java
@@ -1,0 +1,15 @@
+package com.beat.global.external.notification.slack.application;
+
+import java.util.Map;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "bookingSlackClient", url = "${slack.webhook.booking-url}")
+public interface BookingSlackClient {
+
+	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+	void sendMessage(@RequestBody Map<String, String> payload);
+}

--- a/src/main/java/com/beat/global/external/notification/slack/application/MemberSlackClient.java
+++ b/src/main/java/com/beat/global/external/notification/slack/application/MemberSlackClient.java
@@ -1,15 +1,15 @@
 package com.beat.global.external.notification.slack.application;
 
-import java.util.Map;
-
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.beat.global.external.notification.slack.vo.message.SlackMessage;
+
 @FeignClient(name = "memberSlackClient", url = "${slack.webhook.member-url}")
 public interface MemberSlackClient {
 
 	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
-	void sendMessage(@RequestBody Map<String, String> payload);
+	void sendMessage(@RequestBody SlackMessage payload);
 }

--- a/src/main/java/com/beat/global/external/notification/slack/application/MemberSlackClient.java
+++ b/src/main/java/com/beat/global/external/notification/slack/application/MemberSlackClient.java
@@ -1,14 +1,14 @@
 package com.beat.global.external.notification.slack.application;
 
+import java.util.Map;
+
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.Map;
-
-@FeignClient(name = "slackClient", url = "${slack.webhook.url}")
-public interface SlackClient {
+@FeignClient(name = "memberSlackClient", url = "${slack.webhook.member-url}")
+public interface MemberSlackClient {
 
 	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
 	void sendMessage(@RequestBody Map<String, String> payload);

--- a/src/main/java/com/beat/global/external/notification/slack/application/SlackService.java
+++ b/src/main/java/com/beat/global/external/notification/slack/application/SlackService.java
@@ -1,8 +1,8 @@
 package com.beat.global.external.notification.slack.application;
 
-import java.util.Map;
-
 import org.springframework.stereotype.Service;
+
+import com.beat.global.external.notification.slack.vo.message.SlackMessage;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,11 +13,11 @@ public class SlackService {
 	private final MemberSlackClient memberSlackClient;
 	private final BookingSlackClient bookingSlackClient;
 
-	public void sendToMemberChannel(Map<String, String> payload) {
+	public void sendToMemberChannel(SlackMessage payload) {
 		memberSlackClient.sendMessage(payload);
 	}
 
-	public void sendToBookingChannel(Map<String, String> payload) {
+	public void sendToBookingChannel(SlackMessage payload) {
 		bookingSlackClient.sendMessage(payload);
 	}
 }

--- a/src/main/java/com/beat/global/external/notification/slack/application/SlackService.java
+++ b/src/main/java/com/beat/global/external/notification/slack/application/SlackService.java
@@ -10,9 +10,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SlackService {
 
-	private final SlackClient slackClient;
+	private final MemberSlackClient memberSlackClient;
+	private final BookingSlackClient bookingSlackClient;
 
-	public void sendMessage(Map<String, String> payload) {
-		slackClient.sendMessage(payload);
+	public void sendToMemberChannel(Map<String, String> payload) {
+		memberSlackClient.sendMessage(payload);
+	}
+
+	public void sendToBookingChannel(Map<String, String> payload) {
+		bookingSlackClient.sendMessage(payload);
 	}
 }

--- a/src/main/java/com/beat/global/external/notification/slack/event/BookingCreatedEventListener.java
+++ b/src/main/java/com/beat/global/external/notification/slack/event/BookingCreatedEventListener.java
@@ -1,0 +1,55 @@
+package com.beat.global.external.notification.slack.event;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.beat.domain.booking.application.dto.event.BookingCreatedEvent;
+import com.beat.global.external.notification.slack.application.SlackService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookingCreatedEventListener {
+	private static final String TEXT_KEY = "text";
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+	private final SlackService slackService;
+
+	@Async("taskExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void sendSlackNotification(BookingCreatedEvent event) {
+		String message = formatMessage(event);
+		Map<String, String> payload = Map.of(TEXT_KEY, message);
+
+		try {
+			slackService.sendMessage(payload);
+		} catch (Exception e) {
+			log.error("Slack 전송 실패 - 공연: {}, 예매자: {}", event.performanceTitle(), event.bookerName(), e);
+		}
+	}
+
+	String formatMessage(BookingCreatedEvent event) {
+		return String.format(
+			"🎟️ BEAT 예매 발생 🎟️\n\n"
+				+ "📅 예매일시: %s\n"
+				+ "🎭 공연명: %s\n"
+				+ "🔢 예매매수: %d매\n"
+				+ "🙋 예매자: %s\n"
+				+ "🔔 예매현황: %d/%d매",
+			event.bookingDateTime().format(DATE_FORMATTER),
+			event.performanceTitle(),
+			event.purchaseTicketCount(),
+			event.bookerName(),
+			event.currentSoldTicketCount(),
+			event.totalTicketCount()
+		);
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/event/BookingCreatedEventListener.java
+++ b/src/main/java/com/beat/global/external/notification/slack/event/BookingCreatedEventListener.java
@@ -1,7 +1,9 @@
 package com.beat.global.external.notification.slack.event;
 
+import static com.beat.global.external.notification.slack.vo.SlackConstant.BRAND_COLOR;
+
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -10,6 +12,11 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.beat.domain.booking.application.dto.event.BookingCreatedEvent;
 import com.beat.global.external.notification.slack.application.SlackService;
+import com.beat.global.external.notification.slack.vo.block.DividerBlock;
+import com.beat.global.external.notification.slack.vo.block.HeaderBlock;
+import com.beat.global.external.notification.slack.vo.block.SectionBlock;
+import com.beat.global.external.notification.slack.vo.message.SlackMessage;
+import com.beat.global.external.notification.slack.vo.text.MarkdownText;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class BookingCreatedEventListener {
-	private static final String TEXT_KEY = "text";
+
 	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
 	private final SlackService slackService;
@@ -26,31 +33,32 @@ public class BookingCreatedEventListener {
 	@Async("taskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void sendSlackNotification(BookingCreatedEvent event) {
-		String message = formatMessage(event);
-		Map<String, String> payload = Map.of(TEXT_KEY, message);
-
 		try {
-			slackService.sendToBookingChannel(payload);
+			slackService.sendToBookingChannel(buildMessage(event));
 		} catch (Exception e) {
 			log.error("Slack 전송 실패 - 공연: {}, 예매자: {}", event.performanceTitle(), event.bookerName(), e);
 		}
 	}
 
-	String formatMessage(BookingCreatedEvent event) {
-		return """
-			🎟️ BEAT 예매 발생 🎟️
-			
-			📅 예매일시: %s
-			🎭 공연명: %s
-			🔢 예매매수: %d매
-			🙋 예매자: %s
-			🔔 예매현황: %d/%d매""".formatted(
-			event.bookingDateTime().format(DATE_FORMATTER),
-			event.performanceTitle(),
-			event.purchaseTicketCount(),
-			event.bookerName(),
-			event.currentSoldTicketCount(),
-			event.totalTicketCount()
+	private SlackMessage buildMessage(BookingCreatedEvent event) {
+		return SlackMessage.newInstance(
+			List.of(
+				HeaderBlock.newInstance("🎟️ BEAT 예매 발생 🎟️"),
+				SectionBlock.newInstanceWithFields(List.of(
+					MarkdownText.newInstance("*📅 예매일시*\n" + event.bookingDateTime().format(DATE_FORMATTER)),
+					MarkdownText.newInstance("*🎭 공연명*\n" + event.performanceTitle())
+				)),
+				SectionBlock.newInstanceWithFields(List.of(
+					MarkdownText.newInstance("*🔢 예매매수*\n" + event.purchaseTicketCount() + "매"),
+					MarkdownText.newInstance("*🙋 예매자*\n" + event.bookerName())
+				)),
+				SectionBlock.newInstanceWithFields(List.of(
+					MarkdownText.newInstance(
+						"*🔔 예매현황*\n" + event.currentSoldTicketCount() + "/" + event.totalTicketCount() + "매")
+				)),
+				DividerBlock.newInstance()
+			),
+			BRAND_COLOR
 		);
 	}
 }

--- a/src/main/java/com/beat/global/external/notification/slack/event/BookingCreatedEventListener.java
+++ b/src/main/java/com/beat/global/external/notification/slack/event/BookingCreatedEventListener.java
@@ -30,20 +30,21 @@ public class BookingCreatedEventListener {
 		Map<String, String> payload = Map.of(TEXT_KEY, message);
 
 		try {
-			slackService.sendMessage(payload);
+			slackService.sendToBookingChannel(payload);
 		} catch (Exception e) {
 			log.error("Slack 전송 실패 - 공연: {}, 예매자: {}", event.performanceTitle(), event.bookerName(), e);
 		}
 	}
 
 	String formatMessage(BookingCreatedEvent event) {
-		return String.format(
-			"🎟️ BEAT 예매 발생 🎟️\n\n"
-				+ "📅 예매일시: %s\n"
-				+ "🎭 공연명: %s\n"
-				+ "🔢 예매매수: %d매\n"
-				+ "🙋 예매자: %s\n"
-				+ "🔔 예매현황: %d/%d매",
+		return """
+			🎟️ BEAT 예매 발생 🎟️
+			
+			📅 예매일시: %s
+			🎭 공연명: %s
+			🔢 예매매수: %d매
+			🙋 예매자: %s
+			🔔 예매현황: %d/%d매""".formatted(
 			event.bookingDateTime().format(DATE_FORMATTER),
 			event.performanceTitle(),
 			event.purchaseTicketCount(),

--- a/src/main/java/com/beat/global/external/notification/slack/event/MemberRegisteredEventListener.java
+++ b/src/main/java/com/beat/global/external/notification/slack/event/MemberRegisteredEventListener.java
@@ -21,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberRegisteredEventListener {
 	private static final String TEXT_KEY = "text";
 	private static final String WELCOME_MESSAGE = "번째 유저가 회원가입했띠예 🎉🎉 - ";
-	private static final String SLACK_TRANSFER_ERROR = "Slack 전송 실패";
 
 	private final MemberUseCase memberUseCase;
 	private final SlackService slackService;
@@ -33,9 +32,9 @@ public class MemberRegisteredEventListener {
 		payload.put(TEXT_KEY, memberUseCase.countMembers() + WELCOME_MESSAGE + event.nickname());
 
 		try {
-			slackService.sendMessage(payload);
+			slackService.sendToMemberChannel(payload);
 		} catch (Exception e) {
-			throw new RuntimeException(SLACK_TRANSFER_ERROR);
+			log.error("Slack 전송 실패 - 닉네임: {}", event.nickname(), e);
 		}
 	}
 }

--- a/src/main/java/com/beat/global/external/notification/slack/event/MemberRegisteredEventListener.java
+++ b/src/main/java/com/beat/global/external/notification/slack/event/MemberRegisteredEventListener.java
@@ -1,7 +1,8 @@
 package com.beat.global.external.notification.slack.event;
 
-import java.util.HashMap;
-import java.util.Map;
+import static com.beat.global.external.notification.slack.vo.SlackConstant.BRAND_COLOR;
+
+import java.util.List;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,11 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import com.beat.domain.member.application.dto.event.MemberRegisteredEvent;
 import com.beat.domain.member.port.in.MemberUseCase;
 import com.beat.global.external.notification.slack.application.SlackService;
+import com.beat.global.external.notification.slack.vo.block.DividerBlock;
+import com.beat.global.external.notification.slack.vo.block.HeaderBlock;
+import com.beat.global.external.notification.slack.vo.block.SectionBlock;
+import com.beat.global.external.notification.slack.vo.message.SlackMessage;
+import com.beat.global.external.notification.slack.vo.text.MarkdownText;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,8 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class MemberRegisteredEventListener {
-	private static final String TEXT_KEY = "text";
-	private static final String WELCOME_MESSAGE = "번째 유저가 회원가입했띠예 🎉🎉 - ";
 
 	private final MemberUseCase memberUseCase;
 	private final SlackService slackService;
@@ -28,13 +32,25 @@ public class MemberRegisteredEventListener {
 	@Async("taskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void sendSlackNotification(MemberRegisteredEvent event) {
-		Map<String, String> payload = new HashMap<>();
-		payload.put(TEXT_KEY, memberUseCase.countMembers() + WELCOME_MESSAGE + event.nickname());
-
 		try {
-			slackService.sendToMemberChannel(payload);
+			slackService.sendToMemberChannel(buildMessage(event));
 		} catch (Exception e) {
 			log.error("Slack 전송 실패 - 닉네임: {}", event.nickname(), e);
 		}
+	}
+
+	private SlackMessage buildMessage(MemberRegisteredEvent event) {
+		long memberCount = memberUseCase.countMembers();
+		return SlackMessage.newInstance(
+			List.of(
+				HeaderBlock.newInstance("🎉 BEAT 신규 회원 가입 🎉"),
+				SectionBlock.newInstanceWithFields(List.of(
+					MarkdownText.newInstance("*🙋 닉네임*\n" + event.nickname()),
+					MarkdownText.newInstance("*👥 누적 회원 수*\n" + memberCount + "명")
+				)),
+				DividerBlock.newInstance()
+			),
+			BRAND_COLOR
+		);
 	}
 }

--- a/src/main/java/com/beat/global/external/notification/slack/vo/SlackConstant.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/SlackConstant.java
@@ -1,0 +1,16 @@
+package com.beat.global.external.notification.slack.vo;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SlackConstant {
+	public static final String BRAND_COLOR = "#FF006B";
+
+	public static final String BLOCK_TYPE_HEADER = "header";
+	public static final String BLOCK_TYPE_SECTION = "section";
+	public static final String BLOCK_TYPE_DIVIDER = "divider";
+
+	public static final String TEXT_TYPE_PLAIN = "plain_text";
+	public static final String TEXT_TYPE_MARKDOWN = "mrkdwn";
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/block/Block.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/block/Block.java
@@ -1,0 +1,5 @@
+package com.beat.global.external.notification.slack.vo.block;
+
+public sealed interface Block permits HeaderBlock, SectionBlock, DividerBlock {
+	String type();
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/block/DividerBlock.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/block/DividerBlock.java
@@ -1,0 +1,12 @@
+package com.beat.global.external.notification.slack.vo.block;
+
+import static com.beat.global.external.notification.slack.vo.SlackConstant.BLOCK_TYPE_DIVIDER;
+
+public record DividerBlock(
+	String type
+) implements Block {
+
+	public static DividerBlock newInstance() {
+		return new DividerBlock(BLOCK_TYPE_DIVIDER);
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/block/HeaderBlock.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/block/HeaderBlock.java
@@ -1,0 +1,16 @@
+package com.beat.global.external.notification.slack.vo.block;
+
+import static com.beat.global.external.notification.slack.vo.SlackConstant.BLOCK_TYPE_HEADER;
+
+import com.beat.global.external.notification.slack.vo.text.PlainText;
+import com.beat.global.external.notification.slack.vo.text.Text;
+
+public record HeaderBlock(
+	String type,
+	Text text
+) implements Block {
+
+	public static HeaderBlock newInstance(String text) {
+		return new HeaderBlock(BLOCK_TYPE_HEADER, PlainText.newInstance(text));
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/block/SectionBlock.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/block/SectionBlock.java
@@ -1,0 +1,24 @@
+package com.beat.global.external.notification.slack.vo.block;
+
+import static com.beat.global.external.notification.slack.vo.SlackConstant.BLOCK_TYPE_SECTION;
+
+import java.util.List;
+
+import com.beat.global.external.notification.slack.vo.text.Text;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SectionBlock(
+	String type,
+	List<Text> fields,
+	Text text
+) implements Block {
+
+	public static SectionBlock newInstanceWithFields(List<Text> fields) {
+		return new SectionBlock(BLOCK_TYPE_SECTION, fields, null);
+	}
+
+	public static SectionBlock newInstanceWithText(Text text) {
+		return new SectionBlock(BLOCK_TYPE_SECTION, null, text);
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/message/SlackMessage.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/message/SlackMessage.java
@@ -1,0 +1,21 @@
+package com.beat.global.external.notification.slack.vo.message;
+
+import java.util.List;
+
+import com.beat.global.external.notification.slack.vo.block.Block;
+
+public record SlackMessage(
+	List<Attachment> attachments
+) {
+
+	public static SlackMessage newInstance(List<Block> blocks, String color) {
+		return new SlackMessage(List.of(Attachment.of(color, blocks)));
+	}
+
+	public record Attachment(String color, List<Block> blocks) {
+
+		public static Attachment of(String color, List<Block> blocks) {
+			return new Attachment(color, blocks);
+		}
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/text/MarkdownText.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/text/MarkdownText.java
@@ -1,0 +1,13 @@
+package com.beat.global.external.notification.slack.vo.text;
+
+import static com.beat.global.external.notification.slack.vo.SlackConstant.TEXT_TYPE_MARKDOWN;
+
+public record MarkdownText(
+	String type,
+	String text
+) implements Text {
+
+	public static MarkdownText newInstance(String text) {
+		return new MarkdownText(TEXT_TYPE_MARKDOWN, text);
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/text/PlainText.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/text/PlainText.java
@@ -1,0 +1,14 @@
+package com.beat.global.external.notification.slack.vo.text;
+
+import static com.beat.global.external.notification.slack.vo.SlackConstant.TEXT_TYPE_PLAIN;
+
+public record PlainText(
+	String type,
+	String text,
+	boolean emoji
+) implements Text {
+
+	public static PlainText newInstance(String text) {
+		return new PlainText(TEXT_TYPE_PLAIN, text, true);
+	}
+}

--- a/src/main/java/com/beat/global/external/notification/slack/vo/text/Text.java
+++ b/src/main/java/com/beat/global/external/notification/slack/vo/text/Text.java
@@ -1,0 +1,7 @@
+package com.beat.global.external.notification.slack.vo.text;
+
+public sealed interface Text permits PlainText, MarkdownText {
+	String type();
+
+	String text();
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -118,7 +118,8 @@ springdoc:
 
 slack:
   webhook:
-    url: ${DEV_SLACK_WEBHOOK_URL}
+    member-url: ${DEV_SLACK_MEMBER_WEBHOOK_URL}
+    booking-url: ${DEV_SLACK_BOOKING_WEBHOOK_URL}
 
 thread-pool:
   core-size: 2

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -116,7 +116,8 @@ springdoc:
 
 slack:
   webhook:
-    url: ${PROD_SLACK_WEBHOOK_URL}
+    member-url: ${PROD_SLACK_MEMBER_WEBHOOK_URL}
+    booking-url: ${PROD_SLACK_BOOKING_WEBHOOK_URL}
 
 thread-pool:
   core-size: 2

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -40,7 +40,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         dialect: com.beat.global.common.config.MysqlCustomDialect


### PR DESCRIPTION
## Related issue 🛠            

- closes #342                                                                                                                                                                                                              
 
## Work Description ✏️                                                                                                                                                                                                          
                                                                                                                                                                                                                              
예매(Booking) 생성 성공 시 Slack 채널에 알림을 전송하는 이벤트 기반 알림 시스템을 구현했습니다.

**구현 내용**

- `BookingCreatedEvent` — 예매 생성 이벤트 레코드 (정팩메 `of(Booking, Schedule)` 포함)
- `BookingCreatedEventListener` — `@Async` + `@TransactionalEventListener(AFTER_COMMIT)` 기반 Slack 알림 리스너
- `MemberBookingService`, `GuestBookingService` — 예매 저장 후 이벤트 발행 추가
- `MemberRegisteredEventListener` — 비동기 컨텍스트에서 의미 없는 `throw new RuntimeException` → `log.error`로 수정

### Slack Block Kit VO 계층 도입
`Map<String, Object>` 기반의 비타입 안전한 페이로드 구성 방식을 제거하고, Sealed Interface + Record 기반의 타입 안전한 VO 계층으로 교체
```
com.beat.global.external.notification.slack.vo
├── SlackConstant.java         # 블록 타입 상수, 브랜드 컬러(#FF006B)
├── message/SlackMessage.java  # 최상위 VO (blocks + attachments)
├── block/
│   ├── Block.java             # sealed interface
│   ├── HeaderBlock.java
│   ├── SectionBlock.java      # @JsonInclude(NON_NULL)
│   └── DividerBlock.java
└── text/
    ├── Text.java              # sealed interface
    ├── PlainText.java
    └── MarkdownText.java
```

### Slack Block Kit + Attachment 메시지 포맷
- HeaderBlock + SectionBlock + DividerBlock 조합으로 구조화된 메시지 구성
- Attachment의 `color` 필드를 활용해 브랜드 핑크(`#FF006B`) 좌측 테두리 적용

### MemberRegisteredEventListener 개선
- 기존 `throw new RuntimeException(SLACK_TRANSFER_ERROR)` 제거
  - `@Async` 컨텍스트에서 던진 예외는 호출자에 전파되지 않으므로 무의미
- `log.error`로 교체하여 Slack 실패가 메인 트랜잭션에 영향 없음을 명시
- Block Kit 형식으로 메시지 포맷 통일


### 트랜잭션 롤백 안전성

- @TransactionalEventListener(phase = AFTER_COMMIT)을 사용하여 트랜잭션이 롤백되면 리스너 자체가 실행되지 않아 Slack 메시지가 발송되지 않습니다. 
- @Async와 함께 사용하므로 Slack 전송 실패 시에도 메인 트랜잭션에 영향을 주지 않습니다.


## Trouble Shooting ⚽️

**Slack FeignClient 구조 설계**

초기에는 단일 `SlackClient`에 `URI` 파라미터를 넘겨 채널별 URL을 동적으로 override하는 방식으로 구현했습니다.

```java
// 초기 구현 — URI override 방식
@FeignClient(name = "slackClient", url = "https://hooks.slack.com")
public interface SlackClient {
    void sendMessage(URI uri, @RequestBody Map<String, String> payload);
}
```

이 방식은 기술적으로는 동작하지만 두 가지 문제가 있었습니다.

1. url = "https://hooks.slack.com" 은 URI 파라미터가 들어오면 실제로 무시되어 dead annotation이 됨
2. SlackService 생성자에 채널이 추가될 때마다 @Value URI 파라미터를 직접 수동으로 추가해야 해서 `@RequiredArgsConstructor` 사용 불가

채널이 늘어날수록 SlackService 생성자가 비대해지는 구조적 문제를 OCP 관점에서 검토하여, 채널별 FeignClient 분리 방식으로 변경했습니다.

```java
// 최종 구현 — 채널별 FeignClient 분리
@FeignClient(name = "memberSlackClient", url = "${slack.webhook.member-url}")
public interface MemberSlackClient { ... }

@FeignClient(name = "bookingSlackClient", url = "${slack.webhook.booking-url}")
public interface BookingSlackClient { ... }
```  

  이로써 채널 추가 시 새 XxxSlackClient 파일 1개 추가 + SlackService에 필드/메서드 추가만 하면 되고, 기존 클라이언트에는 영향이 없습니다.

### `Map<String, Object>` vs VO 설계 결정
초기 구현은 `Map<String, Object>`로 Slack 페이로드를 구성했으나 다음 문제 존재:
- 키 오타 시 런타임까지 오류 감지 불가
- 중첩 구조가 깊어질수록 가독성 저하
- Slack API 스펙 변경 시 영향 범위 파악 어려움

→ Sealed Interface를 활용한 타입 안전 VO 계층 도입으로 컴파일 타임 검증 확보

## Related ScreenShot 📷

### Uncompleted Tasks 😅
- Slack 전송 실패에 대한 재시도(Retry) 전략 미구현 (현재는 log.error로 기록만 함)

## To Reviewers 📢

- 이벤트 페이로드(BookingCreatedEvent)에 리스너가 필요한 모든 데이터를 담아 리스너에서 추가 DB 조회가 없도록 설계했습니다. 페이로드 구성이 적절한지 검토 부탁드립니다.
- MemberRegisteredEventListener의 기존 throw new RuntimeException 패턴을 log.error로 수정했습니다. @Async 컨텍스트에서 예외를 던져도 호출자 스레드에 전파되지 않아 실질적으로 의미가 없기 때문입니다. 동의하시는지 확인 부탁드립니다.
