### PR TITLE
fix: 로그인 이슈 수정-카카오 응답 매핑 안정화 및 인증 로그 마스킹 적용

### DIFF
--- a/src/main/java/com/beat/domain/member/application/AuthenticationService.java
+++ b/src/main/java/com/beat/domain/member/application/AuthenticationService.java
@@ -56,8 +56,11 @@ public class AuthenticationService {
 		String refreshToken = issueAndSaveRefreshToken(memberId, authenticationToken);
 		String accessToken = jwtTokenProvider.issueAccessToken(authenticationToken);
 
-		log.info("Login success for authorities: {}, accessToken: {}, refreshToken: {}", authorities, accessToken,
-			refreshToken);
+		log.info("Login success for authorities: {}, hasAccessToken={}, hasRefreshToken={}",
+			authorities,
+			accessToken != null && !accessToken.isBlank(),
+			refreshToken != null && !refreshToken.isBlank()
+		);
 
 		return LoginSuccessResponse.of(accessToken, refreshToken, nickname, role.getRoleName());
 	}

--- a/src/main/java/com/beat/global/auth/client/application/KakaoSocialService.java
+++ b/src/main/java/com/beat/global/auth/client/application/KakaoSocialService.java
@@ -48,7 +48,12 @@ public class KakaoSocialService implements SocialService {
 			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
 		}
 		// Access Token으로 유저 정보 불러오기
-		return getLoginDto(loginRequest.socialType(), getUserInfo(accessToken));
+		try {
+			return getLoginDto(loginRequest.socialType(), getUserInfo(accessToken));
+		} catch (FeignException e) {
+			log.error("Failed to fetch Kakao user info with access token", e);
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
 	}
 
 	private String getOAuth2Authentication(
@@ -60,14 +65,36 @@ public class KakaoSocialService implements SocialService {
 			redirectUri,
 			authorizationCode
 		);
-		log.info("Received OAuth2 authentication response: {}", response);
-		return response.accessToken();
+		log.info("Received OAuth2 authentication response: tokenType={}, hasAccessToken={}, hasRefreshToken={}",
+			response.tokenType(),
+			response.accessToken() != null && !response.accessToken().isBlank(),
+			response.refreshToken() != null && !response.refreshToken().isBlank()
+		);
+
+		String accessToken = response.accessToken();
+		if (accessToken == null || accessToken.isBlank()) {
+			log.error("Kakao OAuth token response does not contain access token. response={}", response);
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
+
+		return accessToken;
 	}
 
 	private KakaoUserResponse getUserInfo(
 		final String accessToken
 	) {
+		if (accessToken == null || accessToken.isBlank()) {
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
+
 		KakaoUserResponse kakaoUserResponse = kakaoApiClient.getUserInformation("Bearer " + accessToken);
+
+		log.info("Kakao user response summary: id={}, hasKakaoAccount={}, hasProfile={}",
+			kakaoUserResponse != null ? kakaoUserResponse.id() : null,
+			kakaoUserResponse != null && kakaoUserResponse.kakaoAccount() != null,
+			kakaoUserResponse != null && kakaoUserResponse.kakaoAccount() != null && kakaoUserResponse.kakaoAccount().profile() != null
+		);
+
 		return kakaoUserResponse;
 	}
 
@@ -75,10 +102,32 @@ public class KakaoSocialService implements SocialService {
 		final SocialType socialType,
 		final KakaoUserResponse kakaoUserResponse
 	) {
+		if (kakaoUserResponse == null) {
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
+
+		if (kakaoUserResponse.kakaoAccount() == null) {
+			log.error("Kakao user response does not contain kakao_account. response={}", kakaoUserResponse);
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
+
+		if (kakaoUserResponse.kakaoAccount().profile() == null) {
+			log.error("Kakao user response does not contain profile. response={}", kakaoUserResponse);
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
+
+		String nickname = kakaoUserResponse.kakaoAccount().profile().nickname();
+		String email = kakaoUserResponse.kakaoAccount().email();
+
+		if (nickname == null || nickname.isBlank()) {
+			log.error("Kakao user response does not contain nickname. response={}", kakaoUserResponse);
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
+
 		return MemberInfoResponse.of(
 			kakaoUserResponse.id(),
-			kakaoUserResponse.kakaoAccount().profile().nickname(),
-			kakaoUserResponse.kakaoAccount().email(),
+			nickname,
+			email,
 			socialType
 		);
 	}

--- a/src/main/java/com/beat/global/auth/client/application/KakaoSocialService.java
+++ b/src/main/java/com/beat/global/auth/client/application/KakaoSocialService.java
@@ -65,6 +65,10 @@ public class KakaoSocialService implements SocialService {
 			redirectUri,
 			authorizationCode
 		);
+		if (response == null) {
+			log.error("Kakao OAuth token response is null.");
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
 		log.info("Received OAuth2 authentication response: tokenType={}, hasAccessToken={}, hasRefreshToken={}",
 			response.tokenType(),
 			response.accessToken() != null && !response.accessToken().isBlank(),
@@ -103,6 +107,11 @@ public class KakaoSocialService implements SocialService {
 		final KakaoUserResponse kakaoUserResponse
 	) {
 		if (kakaoUserResponse == null) {
+			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
+		}
+
+		if (kakaoUserResponse.id() == null) {
+			log.error("Kakao user response does not contain id.");
 			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
 		}
 

--- a/src/main/java/com/beat/global/auth/client/application/KakaoSocialService.java
+++ b/src/main/java/com/beat/global/auth/client/application/KakaoSocialService.java
@@ -107,12 +107,12 @@ public class KakaoSocialService implements SocialService {
 		}
 
 		if (kakaoUserResponse.kakaoAccount() == null) {
-			log.error("Kakao user response does not contain kakao_account. response={}", kakaoUserResponse);
+			log.error("Kakao user response does not contain kakao_account. id={}", kakaoUserResponse.id());
 			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
 		}
 
 		if (kakaoUserResponse.kakaoAccount().profile() == null) {
-			log.error("Kakao user response does not contain profile. response={}", kakaoUserResponse);
+			log.error("Kakao user response does not contain profile. id={}", kakaoUserResponse.id());
 			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
 		}
 
@@ -120,7 +120,7 @@ public class KakaoSocialService implements SocialService {
 		String email = kakaoUserResponse.kakaoAccount().email();
 
 		if (nickname == null || nickname.isBlank()) {
-			log.error("Kakao user response does not contain nickname. response={}", kakaoUserResponse);
+			log.error("Kakao user response does not contain nickname. id={}", kakaoUserResponse.id());
 			throw new UnauthorizedException(TokenErrorCode.AUTHENTICATION_CODE_EXPIRED);
 		}
 
@@ -131,5 +131,4 @@ public class KakaoSocialService implements SocialService {
 			socialType
 		);
 	}
-
 }

--- a/src/main/java/com/beat/global/auth/client/kakao/response/KakaoAccessTokenResponse.java
+++ b/src/main/java/com/beat/global/auth/client/kakao/response/KakaoAccessTokenResponse.java
@@ -1,17 +1,26 @@
 package com.beat.global.auth.client.kakao.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoAccessTokenResponse(
-	String accessToken
+	@JsonProperty("token_type")
+	String tokenType,
+
+	@JsonProperty("access_token")
+	String accessToken,
+
+	@JsonProperty("refresh_token")
+	String refreshToken,
+
+	@JsonProperty("expires_in")
+	Long expiresIn,
+
+	@JsonProperty("refresh_token_expires_in")
+	Long refreshTokenExpiresIn
 ) {
-	public static KakaoAccessTokenResponse of(
-		final String accessToken
-	) {
-		return new KakaoAccessTokenResponse(
-			accessToken
-		);
-	}
 }

--- a/src/main/java/com/beat/global/auth/client/kakao/response/KakaoAccount.java
+++ b/src/main/java/com/beat/global/auth/client/kakao/response/KakaoAccount.java
@@ -1,11 +1,17 @@
 package com.beat.global.auth.client.kakao.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record KakaoAccount(
+	@JsonProperty("email")
 	String email,
+
+	@JsonProperty("profile")
 	KakaoUserProfile profile
 ) {
 }

--- a/src/main/java/com/beat/global/auth/client/kakao/response/KakaoUserProfile.java
+++ b/src/main/java/com/beat/global/auth/client/kakao/response/KakaoUserProfile.java
@@ -1,10 +1,14 @@
 package com.beat.global.auth.client.kakao.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record KakaoUserProfile(
+	@JsonProperty("nickname")
 	String nickname
 ) {
 }

--- a/src/main/java/com/beat/global/auth/client/kakao/response/KakaoUserResponse.java
+++ b/src/main/java/com/beat/global/auth/client/kakao/response/KakaoUserResponse.java
@@ -1,11 +1,17 @@
 package com.beat.global.auth.client.kakao.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record KakaoUserResponse(
+	@JsonProperty("id")
 	Long id,
+
+	@JsonProperty("kakao_account")
 	KakaoAccount kakaoAccount
 ) {
 }

--- a/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -37,18 +38,30 @@ public class ControllerLoggingAspect {
 	private static final String LOG_TIME = "logTime";
 	private static final String PARAMS = "params";
 
+	private static final Set<String> SENSITIVE_KEYS = Set.of(
+		"accessToken",
+		"refreshToken",
+		"authorizationCode",
+		"token",
+		"jwt",
+		"password",
+		"secret"
+	);
+
 	/** Controller 요청 로깅 */
 	@Before("com.beat.global.common.aop.Pointcuts.allController()")
 	public void logControllerRequest(JoinPoint joinPoint) {
 		ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-		if (attributes == null) return;
+		if (attributes == null) {
+			return;
+		}
 
 		HttpServletRequest request = attributes.getRequest();
 		Map<String, Object> logInfo = new HashMap<>();
 
 		logInfo.put(CONTROLLER, joinPoint.getSignature().getDeclaringType().getSimpleName());
 		logInfo.put(METHOD, joinPoint.getSignature().getName());
-		logInfo.put(PARAMS, getParams(request));
+		logInfo.put(PARAMS, getMaskedParams(request));
 		logInfo.put(LOG_TIME, System.currentTimeMillis());
 		logInfo.put(HTTP_METHOD, request.getMethod());
 
@@ -60,18 +73,20 @@ public class ControllerLoggingAspect {
 		}
 
 		log.info("[HTTP {}] {} | {}.{}() | Params: {}",
-			logInfo.get(HTTP_METHOD), logInfo.get(REQUEST_URI),
-			logInfo.get(CONTROLLER), logInfo.get(METHOD),
+			logInfo.get(HTTP_METHOD),
+			logInfo.get(REQUEST_URI),
+			logInfo.get(CONTROLLER),
+			logInfo.get(METHOD),
 			logInfo.get(PARAMS));
 	}
 
 	/** Controller 정상 반환 로깅 */
 	@AfterReturning(value = "com.beat.global.common.aop.Pointcuts.allController()", returning = "result")
 	public void logControllerResponse(JoinPoint joinPoint, Object result) {
-		log.debug("[Controller 정상 반환] {}.{}() | 반환 값: {}",
+		log.debug("[Controller 정상 반환] {}.{}() | 반환 타입: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
 			joinPoint.getSignature().getName(),
-			result);
+			result != null ? result.getClass().getSimpleName() : "null");
 	}
 
 	/** Controller 예외 발생 시 로깅 */
@@ -84,7 +99,7 @@ public class ControllerLoggingAspect {
 	}
 
 	/** HTTP 요청 파라미터를 JSON 형태로 변환 */
-	private static JSONObject getParams(HttpServletRequest request) {
+	private static JSONObject getMaskedParams(HttpServletRequest request) {
 		JSONObject jsonObject = new JSONObject();
 		Enumeration<String> params = request.getParameterNames();
 
@@ -93,14 +108,32 @@ public class ControllerLoggingAspect {
 			String replacedParam = param.replace(".", "-");
 			String[] values = request.getParameterValues(param);
 
+			if (isSensitiveKey(param)) {
+				jsonObject.put(replacedParam, "***");
+				continue;
+			}
+
 			if (values == null || values.length == 0) {
-				jsonObject.put(replacedParam, ""); // 값이 없을 경우 빈 문자열 저장
+				jsonObject.put(replacedParam, "");
 			} else if (values.length > 1) {
-				jsonObject.put(replacedParam, values); // 여러 값이 있는 경우 배열로 저장
+				jsonObject.put(replacedParam, values);
 			} else {
-				jsonObject.put(replacedParam, values[0]); // 단일 값이면 문자열로 저장
+				jsonObject.put(replacedParam, values[0]);
 			}
 		}
+
 		return jsonObject;
+	}
+
+	private static boolean isSensitiveKey(String key) {
+		if (key == null) {
+			return false;
+		}
+
+		String normalizedKey = key.toLowerCase();
+
+		return SENSITIVE_KEYS.stream()
+			.map(String::toLowerCase)
+			.anyMatch(normalizedKey::contains);
 	}
 }

--- a/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
+++ b/src/main/java/com/beat/global/common/aop/ServiceLoggingAspect.java
@@ -1,6 +1,10 @@
 package com.beat.global.common.aop;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -10,6 +14,7 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.CodeSignature;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -23,22 +28,32 @@ import lombok.extern.slf4j.Slf4j;
 @Profile("!test")
 public class ServiceLoggingAspect {
 
+	private static final Set<String> SENSITIVE_KEYS = Set.of(
+		"accessToken",
+		"refreshToken",
+		"authorizationCode",
+		"token",
+		"jwt",
+		"password",
+		"secret"
+	);
+
 	/** Service 메서드 실행 전 로깅 */
 	@Before("com.beat.global.common.aop.Pointcuts.allService()")
 	public void doLog(JoinPoint joinPoint) {
 		log.info("[메서드 실행] {}.{}() | 인자: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
 			joinPoint.getSignature().getName(),
-			Arrays.toString(joinPoint.getArgs()));
+			buildMaskedArgs(joinPoint));
 	}
 
 	/** Service 정상 반환 로깅 */
 	@AfterReturning(value = "com.beat.global.common.aop.Pointcuts.allService()", returning = "result")
 	public void logReturn(JoinPoint joinPoint, Object result) {
-		log.debug("[Service 정상 반환] {}.{}() | 반환 값: {}",
+		log.debug("[Service 정상 반환] {}.{}() | 반환 타입: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
 			joinPoint.getSignature().getName(),
-			result);
+			result != null ? result.getClass().getSimpleName() : "null");
 	}
 
 	/** 예외 발생 시 로깅 */
@@ -56,5 +71,44 @@ public class ServiceLoggingAspect {
 		log.info("[메서드 종료] {}.{}()",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
 			joinPoint.getSignature().getName());
+	}
+
+	private Map<String, Object> buildMaskedArgs(JoinPoint joinPoint) {
+		CodeSignature codeSignature = (CodeSignature) joinPoint.getSignature();
+		String[] parameterNames = codeSignature.getParameterNames();
+		Object[] args = joinPoint.getArgs();
+
+		Map<String, Object> maskedArgs = new LinkedHashMap<>();
+
+		for (int index = 0; index < parameterNames.length; index++) {
+			String parameterName = parameterNames[index];
+			Object argumentValue = args[index];
+			maskedArgs.put(parameterName, maskIfSensitive(parameterName, argumentValue));
+		}
+
+		return maskedArgs;
+	}
+
+	private Object maskIfSensitive(String key, Object value) {
+		if (value == null) {
+			return null;
+		}
+
+		String normalizedKey = key == null ? "" : key.toLowerCase();
+
+		boolean isSensitive = SENSITIVE_KEYS.stream()
+			.map(String::toLowerCase)
+			.anyMatch(normalizedKey::contains);
+
+		if (isSensitive) {
+			return "***";
+		}
+
+		if (value.getClass().isArray()) {
+			int length = Array.getLength(value);
+			return "Array(length=" + length + ")";
+		}
+
+		return value;
 	}
 }

--- a/src/main/java/com/beat/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/beat/global/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.beat.global.common.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -61,6 +62,7 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http.csrf(AbstractHttpConfigurer::disable)
+			.cors(Customizer.withDefaults())
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.sessionManagement(session ->


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #353 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 작업 배경
Spring Boot / Feign / Jackson 업그레이드 이후 카카오 소셜 로그인 과정에서 회원가입 및 로그인 흐름이 실패하는 문제가 발생했습니다.
증상상 authorization code 수신과 카카오 토큰 발급은 정상적으로 수행됐지만, 이후 카카오 사용자 정보 응답의 중첩 필드가 null 로 매핑되면서 KakaoSocialService.getLoginDto() 에서 NPE 가 발생했습니다.
또한 로그인/토큰 재발급 흐름에서 access token, refresh token, authorization code 등이 로그에 그대로 남는 문제도 함께 확인되어 운영 로그 기준으로 정리가 필요했습니다.

### 원인
- OpenFeign + Jackson 응답 역직렬화 경계가 업그레이드 이후 더 민감해지면서 카카오 응답 DTO 매핑 안정성이 떨어짐
- 카카오 토큰 응답 / 사용자 응답에 대해 null 방어가 충분하지 않았음
- 인증 관련 민감정보가 로그에 그대로 남고 있었음

### 주요 수정 사항
- 카카오 토큰 응답 DTO 필드 매핑을 명시적으로 고정
- access token null/blank 여부를 확인한 뒤에만 사용자 정보 조회 수행
- 카카오 사용자 응답에 대해 요약 로그를 남겨 매핑 상태를 빠르게 확인할 수 있도록 보강
- 로그인/토큰 재발급/로그 저장 과정에서 access token, refresh token, authorization code 등 민감정보 마스킹 적용
- 프론트엔드와의 cross-origin 통신 시 preflight 요청 및 인증 관련 요청이 Spring Security 단계에서 불필요하게 차단되지 않도록 cors(Customizer.withDefaults()) 추가
  - 이를 통해 기존 CORS 설정이 Security 필터 체인에도 일관되게 반영됨

### 영향 범위
- 카카오 소셜 로그인
- 회원가입 이후 로그인 성공 응답 생성
- access token 재발급
- 서비스/컨트롤러 공통 로깅

### 검증 결과
로컬 기준으로 아래 시나리오 정상 동작 확인
- 로그인 200
- access token 재발급 200
- 로그아웃 200

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
