### PR TITLE
refactor: apis detach를 위한 gateway auth bootstrap 분리 및 root coupling surface 정리

### DIFF
--- a/apis/README.md
+++ b/apis/README.md
@@ -79,3 +79,105 @@ com.beat.apis.<context>/
 - 신규 v2 기능은 root legacy lane이 아니라 `apis` 아래에서 확장된다.
 - `apis -> infra.external.*` 직접 참조가 0건이 된다.
 - `apis -> gateway`는 공개 계약 또는 명시적 import 경계만 남는다.
+
+---
+
+## Root Coupling Surface
+
+> `:apis`가 `project(":")` 를 통해 root에서 끌어오는 bean/config/bootstrap surface 전체 목록.
+> `:apis` detach (#360) 에서 이 목록을 하나씩 해소해야 한다.
+
+### 1. Auth/Security — gateway bootstrap으로 이전 완료
+
+`GatewayModuleConfig` → `GatewayAuthBootstrapConfig` → `GatewayAuthImportSelector` 경로로
+아래 빈의 runtime 등록 ownership을 gateway 경계로 옮겼다.
+`ApisApplication`의 broad scan excludeFilter에서 제외하고 gateway가 대신 import한다.
+
+| Bean | 원래 위치 | 상태 |
+|------|----------|------|
+| `JwtAuthenticationFilter` | `global.auth.jwt.filter` | gateway bootstrap |
+| `JwtTokenProvider` | `global.auth.jwt.provider` | gateway bootstrap |
+| `CurrentMemberArgumentResolver` | `global.auth.resolver` | gateway bootstrap |
+| `CustomAccessDeniedHandler` | `global.auth.security` | gateway bootstrap |
+| `CustomJwtAuthenticationEntryPoint` | `global.auth.security` | gateway bootstrap |
+| `SecurityConfig` | `global.common.config` | gateway bootstrap |
+| `WebConfig` | `global.common.config` | gateway bootstrap |
+
+### 2. Auth/Global 비즈니스 — broad scan으로 아직 root에서 끌어옴
+
+| Bean | 위치 | detach 시 행선지 |
+|------|------|-----------------|
+| `TokenService` | `global.auth.jwt.application` | gateway 또는 apis |
+| `KakaoSocialService` | `global.auth.client.application` | apis 또는 infra |
+| `LettuceLockRepository` | `global.auth.redis` | infra |
+
+### 3. Domain — broad scan `com.beat.domain` 으로 끌어옴
+
+| Bean | 위치 | detach 시 행선지 |
+|------|------|-----------------|
+| `AuthenticationService` | `domain.member.application` | apis |
+| `SocialLoginService` | `domain.member.application` | apis |
+| `MemberRegistrationService` | `domain.member.application` | apis |
+| `MemberService` | `domain.member.application` | apis |
+| `MemberBookingService` | `domain.booking.application` | apis |
+| `MemberBookingRetrieveService` | `domain.booking.application` | apis |
+| `GuestBookingService` | `domain.booking.application` | apis |
+| `GuestBookingRetrieveService` | `domain.booking.application` | apis |
+| `BookingCancelService` | `domain.booking.application` | apis |
+| `TicketService` | `domain.booking.application` | apis |
+| `CoolSmsService` | `domain.booking.application` | infra |
+| `PerformanceService` | `domain.performance.application` | apis |
+| `PerformanceManagementService` | `domain.performance.application` | apis |
+| `PerformanceModifyService` | `domain.performance.application` | apis |
+| `HomeService` | `domain.performance.application` | apis |
+| `PromotionService` | `domain.promotion.application` | apis |
+| `PromotionSchedulerService` | `domain.promotion.application` | batch (scheduler 소관) |
+| `ScheduleService` | `domain.schedule.application` | apis |
+| `UserService` | `domain.user.application` | apis |
+| `TicketRepositoryCustomImpl` | `domain.booking.dao` | infra |
+| `ScheduleRepositoryCustomImpl` | `domain.schedule.dao` | infra |
+
+### 4. Global 공통 — broad scan `com.beat.global` 로 끌어옴
+
+| Bean | 위치 | detach 시 행선지 |
+|------|------|-----------------|
+| `GlobalExceptionHandler` | `global.common.handler` | apis 또는 global-utils |
+| `SwaggerConfig` | `global.swagger.config` | apis |
+| `S3Config` | `global.external.s3.config` | infra |
+| `FileService` | `global.external.s3.application` | infra |
+| `SlackService` | `global.external.notification.slack.application` | infra |
+| `BookingCreatedEventListener` | `global.external.notification.slack.event` | apis |
+| `MemberRegisteredEventListener` | `global.external.notification.slack.event` | apis |
+| `ControllerLoggingAspect` | `global.common.aop` | observability |
+| `ServiceLoggingAspect` | `global.common.aop` | observability |
+| `ExecutionTimeLoggerAspect` | `global.common.aop` | observability |
+| `TxAspect` | `global.common.aop` | observability |
+| `JobSchedulerService` | `global.common.scheduler.application` | batch |
+| `JobSchedulerTransactionalService` | `global.common.scheduler.application` | batch |
+
+### 5. Infra bootstrap — explicit import 경계는 있지만 scan 범위가 넓음
+
+| 설정 | 현재 범위 | 문제 |
+|------|----------|------|
+| `JpaConfig` `@EntityScan` | `"com.beat"` 전체 | root entity 사라지면 실패 |
+| `JpaConfig` `@EnableJpaRepositories` | `"com.beat"` 전체 | root repo 사라지면 실패 |
+| `RedisConfig` `@EnableRedisRepositories` | `"com.beat.global.auth.jwt.dao"` | auth 패키지 직접 참조 |
+
+### 6. 기타 bootstrap surface
+
+| 항목 | 현재 상태 | 문제 |
+|------|----------|------|
+| `@EnableFeignClients` | `basePackages = ["com.beat.global"]` | feign client가 root에 있음 |
+| `@ConfigurationPropertiesScan` | `basePackages = ["com.beat.infra.config"]` | 이미 infra 모듈 — 문제 없음 |
+
+### #360 에서 바로 해야 할 일
+
+1. domain service/dao를 apis, domain, infra 모듈로 물리 이동
+2. global 공통 빈(exception handler, swagger, aop)을 apis/global-utils/observability로 분리
+3. external adapter(S3, Slack, CoolSms)를 infra로 이동
+4. feign client를 infra로 이동하고 `@EnableFeignClients` basePackages 변경
+5. `JpaConfig`의 `@EntityScan`, `@EnableJpaRepositories` 범위를 모듈별로 축소
+6. `RedisConfig`의 `@EnableRedisRepositories` basePackages를 gateway/auth ownership으로 이동
+7. scheduler 빈은 batch 소관 — apis에서 exclude 필요
+8. 위 이동이 끝나면 `@ComponentScan(basePackages = ["com.beat.domain", "com.beat.global"])` 제거
+9. 최종적으로 `apis/build.gradle.kts`에서 `project(":")` 제거

--- a/apis/src/main/kotlin/com/beat/apis/ApisApplication.kt
+++ b/apis/src/main/kotlin/com/beat/apis/ApisApplication.kt
@@ -24,6 +24,13 @@ import org.springframework.context.annotation.Import
             type = org.springframework.context.annotation.FilterType.REGEX,
             pattern = [
                 "com\\.beat\\.admin\\..*",
+                // auth/security beans → gateway bootstrap이 소유. broad scan 중복 방지.
+                "com\\.beat\\.global\\.auth\\.jwt\\.filter\\..*",
+                "com\\.beat\\.global\\.auth\\.jwt\\.provider\\..*",
+                "com\\.beat\\.global\\.auth\\.resolver\\..*",
+                "com\\.beat\\.global\\.auth\\.security\\..*",
+                "com\\.beat\\.global\\.common\\.config\\.SecurityConfig",
+                "com\\.beat\\.global\\.common\\.config\\.WebConfig",
             ],
         ),
     ],

--- a/apis/src/test/kotlin/com/beat/apis/ApisApplicationTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/ApisApplicationTest.kt
@@ -2,14 +2,19 @@ package com.beat.apis
 
 import com.beat.apis.config.InfraConfig
 import com.beat.gateway.GatewayModuleConfig
+import com.beat.gateway.bootstrap.GatewayAuthBootstrapConfig
+import com.beat.gateway.bootstrap.GatewayAuthImportSelector
 import com.beat.observability.ObservabilityModuleConfig
 import java.nio.file.Files
 import java.nio.file.Path
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
+import org.springframework.core.type.AnnotationMetadata
 import org.springframework.scheduling.annotation.EnableScheduling
 
 class ApisApplicationTest {
@@ -22,6 +27,62 @@ class ApisApplicationTest {
         assertTrue(importedClassNames.contains(GatewayModuleConfig::class.java.name))
         assertTrue(importedClassNames.contains(InfraConfig::class.java.name))
         assertTrue(importedClassNames.contains(ObservabilityModuleConfig::class.java.name))
+    }
+
+    @Test
+    fun `gateway module imports auth bootstrap config`() {
+        val importAnnotation = GatewayModuleConfig::class.java.getAnnotation(Import::class.java)
+        assertNotNull(importAnnotation)
+        val imported = importAnnotation.value.map { it.java.name }.toSet()
+        assertTrue(imported.contains(GatewayAuthBootstrapConfig::class.java.name))
+    }
+
+    @Test
+    fun `gateway auth bootstrap imports all auth and security beans`() {
+        val selector = GatewayAuthImportSelector()
+        val imported = selector.selectImports(
+            AnnotationMetadata.introspect(GatewayAuthBootstrapConfig::class.java),
+        ).toSet()
+
+        // auth beans
+        assertTrue(imported.contains("com.beat.global.auth.jwt.filter.JwtAuthenticationFilter"))
+        assertTrue(imported.contains("com.beat.global.auth.jwt.provider.JwtTokenProvider"))
+        assertTrue(imported.contains("com.beat.global.auth.resolver.CurrentMemberArgumentResolver"))
+        assertTrue(imported.contains("com.beat.global.auth.security.CustomAccessDeniedHandler"))
+        assertTrue(imported.contains("com.beat.global.auth.security.CustomJwtAuthenticationEntryPoint"))
+
+        // config beans
+        assertTrue(imported.contains("com.beat.global.common.config.SecurityConfig"))
+        assertTrue(imported.contains("com.beat.global.common.config.WebConfig"))
+    }
+
+    @Test
+    fun `apis broad scan excludes auth packages owned by gateway`() {
+        val scan = ApisApplication::class.java.getAnnotation(ComponentScan::class.java)
+        assertNotNull(scan)
+
+        val excluded = scan.excludeFilters.flatMap { it.pattern.toList() }.toSet()
+
+        setOf(
+            "com\\.beat\\.global\\.auth\\.jwt\\.filter\\..*",
+            "com\\.beat\\.global\\.auth\\.jwt\\.provider\\..*",
+            "com\\.beat\\.global\\.auth\\.resolver\\..*",
+            "com\\.beat\\.global\\.auth\\.security\\..*",
+            "com\\.beat\\.global\\.common\\.config\\.SecurityConfig",
+            "com\\.beat\\.global\\.common\\.config\\.WebConfig",
+        ).forEach { pattern ->
+            assertTrue(excluded.contains(pattern), "missing exclude: $pattern")
+        }
+    }
+
+    @Test
+    fun `apis infra config keeps explicit base bootstrap groups`() {
+        val configSource = Files.readString(Path.of("src/main/kotlin/com/beat/apis/config/InfraConfig.kt"))
+
+        assertTrue(configSource.contains("InfraBaseConfigGroup.JPA"))
+        assertTrue(configSource.contains("InfraBaseConfigGroup.QUERY_DSL"))
+        assertTrue(configSource.contains("InfraBaseConfigGroup.REDIS"))
+        assertTrue(configSource.contains("InfraBaseConfigGroup.ASYNC"))
     }
 
     @Test

--- a/gateway/src/main/kotlin/com/beat/gateway/GatewayModuleConfig.kt
+++ b/gateway/src/main/kotlin/com/beat/gateway/GatewayModuleConfig.kt
@@ -1,9 +1,11 @@
 package com.beat.gateway
 
+import com.beat.gateway.bootstrap.GatewayAuthBootstrapConfig
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 
-// Marker config for the gateway module.
-// Next step: gather security/auth-related imports here so runtimes can depend on
-// an explicit gateway boundary instead of broad package scanning.
+// Gateway module entry point.
+// Auth/security bootstrap ownership을 gateway 경계로 모은다.
 @Configuration(proxyBeanMethods = false)
+@Import(GatewayAuthBootstrapConfig::class)
 class GatewayModuleConfig

--- a/gateway/src/main/kotlin/com/beat/gateway/bootstrap/GatewayAuthBootstrapConfig.kt
+++ b/gateway/src/main/kotlin/com/beat/gateway/bootstrap/GatewayAuthBootstrapConfig.kt
@@ -1,0 +1,17 @@
+package com.beat.gateway.bootstrap
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+/**
+ * Transition bootstrap — gateway가 소유하는 auth/security bean surface.
+ *
+ * 현재 auth 코드는 아직 legacy root에 있지만, runtime bean 등록 ownership은
+ * 이 config를 통해 gateway 경계로 옮긴다. apis/admin의 broad scan에서
+ * auth 패키지를 exclude하고 이 config이 대신 가져온다.
+ *
+ * auth 코드가 gateway 모듈로 물리 이동하면 이 config은 제거된다.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import(GatewayAuthImportSelector::class)
+class GatewayAuthBootstrapConfig

--- a/gateway/src/main/kotlin/com/beat/gateway/bootstrap/GatewayAuthImportSelector.kt
+++ b/gateway/src/main/kotlin/com/beat/gateway/bootstrap/GatewayAuthImportSelector.kt
@@ -1,0 +1,34 @@
+package com.beat.gateway.bootstrap
+
+import org.springframework.context.annotation.DeferredImportSelector
+import org.springframework.core.type.AnnotationMetadata
+
+/**
+ * Gateway가 소유하는 auth/security bean을 FQCN 문자열로 import 한다.
+ *
+ * gateway 모듈은 root project에 compile 의존하지 않으므로
+ * class reference 대신 FQCN string으로 deferred import 한다.
+ * auth 코드가 gateway로 물리 이동하면 이 selector는 제거된다.
+ */
+class GatewayAuthImportSelector : DeferredImportSelector {
+
+    override fun selectImports(importingClassMetadata: AnnotationMetadata): Array<String> =
+        AUTH_BEANS + CONFIG_BEANS
+
+    companion object {
+        /** auth 패키지 소속 bean (filter, provider, resolver, security handler) */
+        val AUTH_BEANS = arrayOf(
+            "com.beat.global.auth.jwt.filter.JwtAuthenticationFilter",
+            "com.beat.global.auth.jwt.provider.JwtTokenProvider",
+            "com.beat.global.auth.resolver.CurrentMemberArgumentResolver",
+            "com.beat.global.auth.security.CustomAccessDeniedHandler",
+            "com.beat.global.auth.security.CustomJwtAuthenticationEntryPoint",
+        )
+
+        /** SecurityConfig, WebConfig — auth 패키지 밖이지만 auth 빈에 의존 */
+        val CONFIG_BEANS = arrayOf(
+            "com.beat.global.common.config.SecurityConfig",
+            "com.beat.global.common.config.WebConfig",
+        )
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closes #361

## Work Description ✏️

- `:apis` detach(#360)를 막고 있는 최소 blocker를 정리했습니다.                                                                                                                                                                                       
- gateway 모듈에 auth/security bootstrap surface를 만들어, auth 빈 등록 ownership을 gateway 경계로 이전했습니다.
  - `GatewayAuthBootstrapConfig` + `GatewayAuthImportSelector`(DeferredImportSelector)로 7개 auth/security 빈을 FQCN 기반 deferred import합니다.                                                                                                      
  - `GatewayModuleConfig`이 auth bootstrap을 `@Import`하므로, apis는 기존처럼 `GatewayModuleConfig`만 참조합니다.                                                                                                                                     
- `ApisApplication`의 broad scan excludeFilter에 auth 패키지 6개 패턴을 추가해 gateway bootstrap과의 중복 등록을 방지했습니다.                                                                                                                        
- `ApisApplicationTest`에 gateway bootstrap surface 검증, exclude filter 검증, infra config 검증 테스트 4개를 추가했습니다.                                                                                                                           
- `apis/README.md`에 Root Coupling Surface 섹션을 추가해, `:apis`가 root에서 끌어오는 전체 bean/config/bootstrap surface 목록과 #360 action items를 문서화했습니다.                                                                                   
                                                                                                                                                                                                                                                      
## Trouble Shooting ⚽️                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                      
- gateway 모듈은 root project에 compile 의존하지 않으므로, auth 클래스를 직접 reference할 수 없습니다. `DeferredImportSelector`에서 FQCN 문자열로 deferred import하는 방식으로 해결했습니다.                                                          
- 초기에 `@ComponentScan(basePackages = [...])` 방식을 사용했으나, gateway 모듈 classpath에 해당 패키지가 없어 IDE에서 패키지 해결 불가 경고가 발생했습니다. 전부 `DeferredImportSelector` 기반으로 전환해 해결했습니다.
- auth 코드가 gateway 모듈로 물리 이동하면 `bootstrap/` 패키지는 통째로 제거되고, To-Be 구조(`jwt.contract`, `jwt.internal`, `security.servlet`)의 직접 `@Import`로 전환됩니다.                                                                       
                                                                                                                                                                                                                                                      
## Related ScreenShot 📷                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                      
- 서버 구조/빌드 변경 PR이라 별도 스크린샷은 없습니다.                                                                                                                                                                                                
                
## Uncompleted Tasks 😅                                                                                                                                                                                                                               
                
- `apis/README.md` Root Coupling Surface 섹션에 정리된 #360 action items:                                                                                                                                                                             
  1. domain service/dao를 apis, domain, infra 모듈로 물리 이동
  2. global 공통 빈(exception handler, swagger, aop)을 apis/global-utils/observability로 분리                                                                                                                                                         
  3. external adapter(S3, Slack, CoolSms)를 infra로 이동                                                                                                                                                                                              
  4. feign client를 infra로 이동                                                                                                                                                                                                                      
  5. `JpaConfig`의 `@EntityScan`, `@EnableJpaRepositories` 범위 축소                                                                                                                                                                                  
  6. `RedisConfig`의 `@EnableRedisRepositories` basePackages gateway ownership 이동                                                                                                                                                                   
  7. scheduler 빈 apis exclude                                                                                                                                                                                                                        
  8. broad `@ComponentScan` 제거                                                                                                                                                                                                                      
  9. `apis/build.gradle.kts`에서 `project(":")` 제거                                                                                                                                                                                                  
                                                                                                                                                                                                                                                      
## To Reviewers 📢                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                      
- 이번 PR은 코드 이동이 아니라, **auth bootstrap ownership 이전 + coupling surface 식별/문서화**입니다.                                                                                                                                               
- `apis/build.gradle.kts`의 `project(":")` 는 이번에 제거하지 않습니다.
- 변경 파일이 6개로 범위가 작으니, gateway bootstrap 구조가 To-Be 전환 경로와 맞는지 중점으로 봐주시면 좋겠습니다.                                                                                                                                    
- 검증 결과: `./gradlew :apis:test`, `verifyV2WebBaseline`, `verifyModuleBootJars` 모두 통과했습니다.