### PR TITLE
refactor: admin root dependency removal 및 boundary guard 고정

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -1,58 +1,116 @@
 # admin module
 
-> 이 문서는 `admin` 모듈의 최종 To-Be 계약을 정의한다. 현재 구현 밀도는 낮지만, 최종적으로 `admin`은 관리자/백오피스 전용 실행 모듈이어야 한다.
+> 이 문서는 admin root dependency removal 이후 `admin` 모듈의 현재 bootstrap 계약과 남아 있는 transitional debt를 설명한다. `admin`은 이제 root project 의존 없이 자체 classpath로 build/boot/test 되어야 한다.
 
 ## 역할
 
-- 관리자/백오피스 HTTP API의 유일한 진입점이다.
+- 관리자/백오피스 HTTP API의 유일한 실행 진입점이다.
 - 사용자 API와 다른 승인 정책, 응답 스펙, 운영 워크플로를 소유한다.
 - 팀 컨벤션상 `Controller -> Facade -> Application Service -> Domain` 흐름을 따른다.
-- `apis` 서비스를 재사용하지 않고, `domain`만 공유한다.
+- `apis` 서비스를 재사용하지 않고, `domain`과 공유 모듈 계약만 사용한다.
 
 ## 허용 의존성
 
+- `module-contracts`
 - `domain`
 - `infra`
 - `global-utils`
 - `observability`
-- `gateway` 공개 계약 또는 전용 enable 경계만
+- `gateway`의 공개 계약/enable 경계만
 
 ## 금지 규칙
 
 - `project(":")` 직접 의존 금지
 - `apis`, `batch` 직접 의존 금지
 - `infra.external.*`, `infra.*.entity`, `infra.*.repository.impl` 직접 import 금지
-- `gateway` 내부 패키지 직접 import 금지
+- `gateway.security.*`, `gateway.filter.*`, `gateway.config.*` 직접 import 금지
+- root legacy bootstrap lane import 금지
+    - `com.beat.BeatApplication`
+    - `com.beat.legacyroot.*`
+    - `com.beat.global.common.scheduler.application.*`
+    - root `SecurityConfig` / `WebConfig`
 - 전역 스캔에 기대는 구조 금지
+- JPA Entity, QueryDSL Q type, Redis document를 admin API DTO로 직접 노출 금지
 
-## As-Is 패키지 구조
+## Current bootstrap shape
 
 ```text
 admin/
   src/main/kotlin/com/beat/admin/
     AdminApplication.kt
     config/
-      InfraConfig.kt           # @EnableInfraBaseConfig(JPA, QUERY_DSL, REDIS, ASYNC, EXTERNAL_CLIENTS)
+      InfraConfig.kt                 # @EnableInfraBaseConfig(JPA, QUERY_DSL, REDIS, ASYNC, EXTERNAL_CLIENTS)
 
   src/main/java/com/beat/admin/
+    config/
+      AdminSecurityConfig.java       # admin-owned HTTP security policy
+      AdminCorsConfig.java
+      AdminWebConverterConfig.java
     adapter/in/api/
     facade/
     application/
-      AdminService.java
-      dto/
-        request/
-        response/
-    exception/
+    handler/
     port/in/
 ```
 
-설명:
+### Runtime contract
 
-- 현재 `admin`은 `adapter/in/api`, `facade`, `application`, `port/in`이 함께 존재하는 전환기 구조다.
-- `AdminApplication`은 `@SpringBootApplication(scanBasePackageClasses = [AdminApplication::class])`만으로 `com.beat.admin.*`를 기동하고, 별도 transitional `@ComponentScan`은 제거됐다.
-- `InfraConfig.kt`가 `@EnableInfraBaseConfig`로 필요한 infra 설정 그룹을 선택적으로 import한다.
-- 전환기 동안 `implementation(project(":"))` root 의존이 남아 있다. 최종적으로 제거 대상이다.
-- 이미 `apis`와 독립된 관리자 lane은 생겼지만, 패키지 스타일은 아직 최종 통일 전이다.
+- `AdminApplication`은 정확히 아래 bootstrap surface만 import한다.
+    - `GatewayModuleConfig`
+    - `InfraConfig`
+    - `ObservabilityModuleConfig`
+- app-level broad `@ComponentScan`은 없다.
+- `AdminSecurityConfig`가 관리자 route whitelist와 인증 정책을 소유한다.
+- `GatewayModuleConfig`가 gateway 내부 구현 빈을 제공하지만, `admin`은 공개 진입점인 `GatewayModuleConfig`와 `gateway.annotation.CurrentMember`만 직접 참조한다.
+- `InfraConfig.kt`가 필요한 infra base config group만 명시적으로 import한다.
+- `admin` resources는 `beat.scheduler.owner=false`를 유지하고, scheduler owner bean이나 non-owner bridge를 따로 소유하지 않는다.
+
+## What changed in this issue
+
+- `admin/build.gradle.kts`에서 `implementation(project(":"))`를 제거했다.
+- `admin`은 root project classpath 없이 build/boot/test 되는 방향으로 고정됐다.
+- 테스트 계약과 architecture guard를 추가해 root dependency 재도입, root bootstrap import, gateway 내부 패키지 직접 참조를 막는다.
+- `admin/README.md`를 detached bootstrap 상태 기준으로 갱신했다.
+
+## Current ownership notes
+
+### In `admin`
+
+- admin-facing controller / facade / application service / DTO
+- module-owned security route policy
+- admin exception handling
+- admin CORS / converter configuration
+
+### Outside `admin`
+
+- `gateway`: JWT, auth filter, current-member resolver, 인증/인가 shared primitives
+- `infra`: JPA, QueryDSL, Redis, async, external-client bootstrap
+- `domain`: admin이 사용하는 domain model / repository / port contracts
+- `module-contracts`: storage, auth, schedule 같은 cross-module port contracts
+- `global-utils`: shared response DTO와 공통 예외 계층
+- `observability`: logging / metrics / tracing boundary
+
+## Remaining transitional debt
+
+- 소스 파일 상당수가 아직 Java 기반 legacy package style을 유지한다.
+- `adapter`, `port` 패키지명은 그대로 남아 있고 최종 package normalization은 끝나지 않았다.
+- `gateway`와 `observability`는 아직 marker config + legacy implementation 혼합 상태라 공개 표면을 더 명확히 줄일 여지가 있다.
+- 관리자 lane은 root build-time dependency를 제거했지만, repo 전체 root legacy lane retirement는 후속 migration 범위다.
+
+## Guard rails
+
+- `AdminApplicationTest`
+    - `AdminApplication` import 집합 고정
+    - broad app scan 금지
+    - scheduler owner disabled 계약 고정
+    - admin-owned security policy 존재 확인
+- `AdminArchitectureGuardTest`
+    - `admin/build.gradle.kts`의 root dependency 재추가 금지
+    - root bootstrap lane import 금지
+    - gateway 내부 패키지 직접 import 금지
+- `AdminModuleContextBootTest`
+    - module context boot smoke test
+    - scheduler owner / schedule bridge가 admin context에 섞이지 않는지 확인
 
 ## To-Be 패키지 구조
 
@@ -79,13 +137,12 @@ com.beat.admin.<context>/
 - 관리자 애플리케이션 문맥의 에러 코드와 예외는 `application/exception`에 둔다.
 - 관리자 전용 정책이라도 순수 비즈니스 규칙이면 `domain`으로 올린다.
 - `admin -> gateway`는 최종적으로 허용하되, **공통 인증/보안 경계 진입점** 으로만 제한한다.
-- 즉 `GatewayModuleConfig` 또는 `jwt.contract` 같은 공개 표면만 사용하고, `gateway.security.*`, `gateway.filter.*`, `gateway.config.*`
-  를 직접 참조하지 않는다.
+- 즉 `GatewayModuleConfig` 또는 `jwt.contract` 같은 공개 표면만 사용하고, `gateway.security.*`, `gateway.filter.*`, `gateway.config.*`를 직접 참조하지 않는다.
 - `adapter`, `port` 패키지는 BEAT 기본 가이드로 강제하지 않는다.
 - Repository는 지금 즉시 command/query로 나누지 않는다. 조회 복잡도 증가나 jOOQ 도입 필요가 생기면 그때 query 전용 구현을 분리한다.
 
-## 최종 목표
+## Follow-up after this issue
 
-- `admin`이 관리자 기능을 독립적으로 소유한다.
-- `apis` 변경 없이 관리자 기능을 추가할 수 있다.
-- 관리자 인증/권한 검사는 `gateway`의 공개 계약/enable 경계를 통해 연결된다.
+1. `admin` package normalization이 충분히 진행되면 `com.beat.admin.<context>` 구조로 점진 정리
+2. `batch` root dependency 제거 lane 진행
+3. 남은 root legacy lane retirement 시 bootstrap/documentation 최종 축소

--- a/admin/build.gradle.kts
+++ b/admin/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     implementation(project(":module-contracts"))
-    implementation(project(":"))
     implementation(project(":gateway"))
     implementation(project(":domain"))
     implementation(project(":infra"))

--- a/admin/src/test/java/com/beat/admin/AdminModuleContextBootTest.java
+++ b/admin/src/test/java/com/beat/admin/AdminModuleContextBootTest.java
@@ -1,14 +1,20 @@
 package com.beat.admin;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.MySQLContainer;
 
 import com.beat.admin.port.in.AdminUseCase;
+import com.beat.contracts.schedule.ScheduleJobPort;
 import com.beat.contracts.storage.FileStoragePort;
 import com.beat.domain.member.port.in.MemberUseCase;
 import com.beat.domain.performance.port.in.PerformanceUseCase;
@@ -20,6 +26,9 @@ import com.redis.testcontainers.RedisContainer;
 @ActiveProfiles("test")
 @Tag("integration")
 class AdminModuleContextBootTest {
+
+	@Autowired
+	private ApplicationContext applicationContext;
 
 	@MockitoBean
 	private AdminUseCase adminUseCase;
@@ -54,5 +63,7 @@ class AdminModuleContextBootTest {
 
 	@Test
 	void contextLoads() {
+		assertFalse(applicationContext.containsBean("jobSchedulerService"));
+		assertTrue(applicationContext.getBeansOfType(ScheduleJobPort.class).isEmpty());
 	}
 }

--- a/admin/src/test/kotlin/com/beat/admin/AdminApplicationTest.kt
+++ b/admin/src/test/kotlin/com/beat/admin/AdminApplicationTest.kt
@@ -1,32 +1,52 @@
 package com.beat.admin
 
+import com.beat.admin.config.AdminSecurityConfig
 import com.beat.admin.config.InfraConfig
 import com.beat.gateway.GatewayModuleConfig
 import com.beat.observability.ObservabilityModuleConfig
-import java.nio.file.Files
-import java.nio.file.Path
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
+import java.nio.file.Files
+import java.nio.file.Path
 
 class AdminApplicationTest {
 
     @Test
-    fun `admin application keeps transition baseline module imports`() {
+    fun `admin application keeps detached module import contract`() {
         val importAnnotation = AdminApplication::class.java.getAnnotation(Import::class.java)
         val importedClassNames = importAnnotation.value.map { it.java.name }.toSet()
 
-        assertTrue(importedClassNames.contains(GatewayModuleConfig::class.java.name))
-        assertTrue(importedClassNames.contains(InfraConfig::class.java.name))
-        assertTrue(importedClassNames.contains(ObservabilityModuleConfig::class.java.name))
+        assertEquals(
+            setOf(
+                GatewayModuleConfig::class.java.name,
+                InfraConfig::class.java.name,
+                ObservabilityModuleConfig::class.java.name,
+            ),
+            importedClassNames,
+        )
     }
 
     @Test
-    fun `admin application does not keep transitional broad component scan`() {
+    fun `gateway module imports auth bootstrap config`() {
+        val componentScan = GatewayModuleConfig::class.java.getAnnotation(ComponentScan::class.java)
+
+        assertNotNull(componentScan)
+        assertTrue(componentScan.basePackages.contains("com.beat.gateway"))
+    }
+
+    @Test
+    fun `admin security config exists for module owned route policy`() {
+        val configuration = AdminSecurityConfig::class.java.getAnnotation(Configuration::class.java)
+
+        assertNotNull(configuration)
+    }
+
+    @Test
+    fun `admin application no longer owns broad component scan`() {
         val componentScan = AdminApplication::class.java.getAnnotation(ComponentScan::class.java)
         assertNull(componentScan)
     }
@@ -40,7 +60,10 @@ class AdminApplicationTest {
     @Test
     fun `admin application no longer owns feign bootstrap scanning`() {
         val source = Files.readString(Path.of("src/main/kotlin/com/beat/admin/AdminApplication.kt"))
+
         assertFalse(source.contains("@EnableFeignClients"))
+        assertFalse(source.contains("\"com.beat.domain\""))
+        assertFalse(source.contains("\"com.beat.global\""))
     }
 
     @Test

--- a/admin/src/test/kotlin/com/beat/admin/AdminApplicationTest.kt
+++ b/admin/src/test/kotlin/com/beat/admin/AdminApplicationTest.kt
@@ -18,7 +18,8 @@ class AdminApplicationTest {
     @Test
     fun `admin application keeps detached module import contract`() {
         val importAnnotation = AdminApplication::class.java.getAnnotation(Import::class.java)
-        val importedClassNames = importAnnotation.value.map { it.java.name }.toSet()
+        assertNotNull(importAnnotation, "AdminApplication must declare @Import")
+        val importedClassNames = importAnnotation!!.value.map { it.java.name }.toSet()
 
         assertEquals(
             setOf(

--- a/admin/src/test/kotlin/com/beat/admin/AdminArchitectureGuardTest.kt
+++ b/admin/src/test/kotlin/com/beat/admin/AdminArchitectureGuardTest.kt
@@ -1,0 +1,65 @@
+package com.beat.admin
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class AdminArchitectureGuardTest {
+
+    private val rootProjectDependencyPattern = Regex("""project\(\s*":\"\s*\)""")
+
+    @Test
+    fun `admin build file must not depend on root project`() {
+        val buildFile = Files.readString(Path.of("build.gradle.kts"))
+
+        assertFalse(rootProjectDependencyPattern.containsMatchIn(buildFile))
+    }
+
+    @Test
+    fun `admin sources must not reference root bootstrap lanes`() {
+        val violations = findForbiddenReferences(
+            "com.beat.BeatApplication",
+            "com.beat.legacyroot.",
+            "com.beat.global.common.scheduler.application.",
+            "com.beat.global.common.config.SecurityConfig",
+            "com.beat.global.common.config.WebConfig",
+        )
+
+        assertTrue(violations.isEmpty(), "Found forbidden root bootstrap references:\n${violations.joinToString("\n")}")
+    }
+
+    @Test
+    fun `admin sources must not import gateway internal packages`() {
+        val violations = findForbiddenReferences(
+            "com.beat.gateway.security.",
+            "com.beat.gateway.filter.",
+            "com.beat.gateway.config.",
+        )
+
+        assertTrue(
+            violations.isEmpty(),
+            "Found forbidden gateway internal references:\n${violations.joinToString("\n")}"
+        )
+    }
+
+    private fun findForbiddenReferences(vararg forbiddenReferences: String): List<String> {
+        val paths = Files.walk(Path.of("src/main"))
+
+        return try {
+            paths
+                .filter(Files::isRegularFile)
+                .filter { path -> path.toString().endsWith(".java") || path.toString().endsWith(".kt") }
+                .toList()
+                .flatMap { path ->
+                    val source = Files.readString(path)
+                    forbiddenReferences
+                        .filter(source::contains)
+                        .map { pattern -> "$path: $pattern" }
+                }
+        } finally {
+            paths.close()
+        }
+    }
+}

--- a/apis/src/test/kotlin/com/beat/apis/ApisApplicationTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/ApisApplicationTest.kt
@@ -19,7 +19,8 @@ class ApisApplicationTest {
     @Test
     fun `apis application keeps detached module import contract`() {
         val importAnnotation = ApisApplication::class.java.getAnnotation(Import::class.java)
-        val importedClassNames = importAnnotation.value.map { it.java.name }.toSet()
+        assertNotNull(importAnnotation, "ApisApplication must declare @Import")
+        val importedClassNames = importAnnotation!!.value.map { it.java.name }.toSet()
 
         assertEquals(
             setOf(

--- a/batch/src/test/kotlin/com/beat/batch/BatchApplicationTest.kt
+++ b/batch/src/test/kotlin/com/beat/batch/BatchApplicationTest.kt
@@ -19,9 +19,11 @@ class BatchApplicationTest {
     @Test
     fun `batch application keeps transition baseline scheduling contract`() {
         val importAnnotation = BatchApplication::class.java.getAnnotation(Import::class.java)
-        val importedClassNames = importAnnotation.value.map { it.java.name }.toSet()
+        assertNotNull(importAnnotation, "BatchApplication must declare @Import")
+        val importedClassNames = importAnnotation!!.value.map { it.java.name }.toSet()
         val applicationComponentScan = BatchApplication::class.java.getAnnotation(ComponentScan::class.java)
         val bootstrapImport = BatchSchedulerBootstrapConfig::class.java.getAnnotation(Import::class.java)
+        assertNotNull(bootstrapImport, "BatchSchedulerBootstrapConfig must declare @Import")
         val enableScheduling = BatchApplication::class.java.getAnnotation(EnableScheduling::class.java)
 
         assertTrue(importedClassNames.contains(BatchSchedulerBootstrapConfig::class.java.name))


### PR DESCRIPTION
## Related issue 🛠

- closes #359
- related #350

## Work Description ✏️

- `admin/build.gradle.kts`에서 `implementation(project(":"))`를 제거했습니다.
- `AdminApplication`이 `GatewayModuleConfig`, `InfraConfig`, `ObservabilityModuleConfig`만 import하는 detached bootstrap 계약을 유지하도록 정리했습니다.
- `AdminApplicationTest`를 현재 bootstrap 구조 기준으로 갱신했습니다.
- `AdminModuleContextBootTest`를 유지하면서 admin context에 scheduler owner / schedule bridge가 섞이지 않는지 확인하도록 보강했습니다.
- `AdminArchitectureGuardTest`를 추가해 아래 회귀를 막았습니다.
  - root dependency 재추가
  - root bootstrap lane 참조
  - `gateway.security.*`, `gateway.filter.*`, `gateway.config.*` 직접 참조
- `admin/README.md`를 현재 detached 상태와 남은 transitional debt 기준으로 갱신했습니다.

## Trouble Shooting ⚽️

- root dependency 제거 이후에도 admin이 실제로 독립 classpath로 닫히는지 확인이 필요했습니다.
- admin security wiring은 여전히 `GatewayModuleConfig`가 제공하는 공용 security bean에 의존하므로, 이 계약이 깨지지 않도록 bootstrap contract와 context boot test를 함께 고정했습니다.
- architecture guard 범위는 `apis`에서 이미 사용 중인 패턴과 동일하게 `src/main` 기준으로 맞췄습니다.

## Related ScreenShot 📷

- 없음
- 백엔드 bootstrap / dependency / guard 변경 사항입니다.

## Uncompleted Tasks 😅

- 없음
- 다만 reviewer 의견에 따라 architecture guard를 `src/test`까지 확장하는 hardening은 후속으로 분리 가능합니다.

## To Reviewers 📢

- 이번 PR은 `admin`의 root build-time dependency 제거와 detached bootstrap 계약 고정에만 집중했습니다.
- `admin -> gateway` 경계는 공개 surface(`GatewayModuleConfig`, `@CurrentMember`) 기준으로 유지했습니다.
- architecture guard는 선행 `apis` 패턴과 같은 결로 구성했습니다.
