### PR TITLE
refactor: batch root dependency removal 및 detached bootstrap 정리

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -1,6 +1,6 @@
 # batch module
 
-> 이 문서는 `batch` 모듈의 최종 To-Be 계약을 정의한다. 현재 배치 lane은 전환기지만, 최종적으로 스케줄/배치 책임은 `batch`에만 남아야 한다.
+> 이 문서는 batch root dependency removal 이후 `batch` 모듈의 현재 detached bootstrap 계약과 남아 있는 transitional debt를 설명한다. `batch`는 이제 root project 의존 없이 자체 classpath로 build/boot/test 되어야 한다.
 
 ## 역할
 
@@ -11,6 +11,7 @@
 
 ## 허용 의존성
 
+- `module-contracts`
 - `domain`
 - `infra`
 - `global-utils`
@@ -25,7 +26,7 @@
 - 전역 스캔에 기대는 구조 금지
 - 스케줄 소유권을 다른 실행 모듈과 중복 활성화 금지
 
-## As-Is 패키지 구조
+## Current bootstrap shape
 
 ```text
 batch/
@@ -37,17 +38,86 @@ batch/
   src/main/java/com/beat/
     global/common/scheduler/application/
     domain/**/application/          # batch-owned scheduled service 포함
+  src/main/resources/
+    application.yml                 # beat.scheduler.owner=true
+  src/test/resources/
+    application-test.yml            # beat.scheduler.owner=false
 ```
 
-설명:
-- 현재 `batch` 모듈은 앱 진입점뿐 아니라 scheduler/service runtime owner도 함께 가진다.
-- `InfraConfig.kt`가 `@EnableInfraBaseConfig`로 필요한 infra 설정 그룹을 선택적으로 import한다.
-- `BatchSchedulerBootstrapConfig.kt`가 scheduler/service bean을 명시적으로 import한다.
-- 전환기 동안 `implementation(project(":"))` root 의존이 남아 있다. 최종적으로 제거 대상이다.
-- root 기본 리소스는 scheduler owner를 비활성화하고, batch 기본 리소스가 owner를 활성화한다.
-- scheduler/service 코드는 `batch` 모듈로 이동했지만, 패키지 네임스페이스는 아직 legacy 경로를 유지한다.
+### Runtime contract
 
-## To-Be 패키지 구조
+- `BatchApplication`은 정확히 아래 bootstrap surface만 import한다.
+    - `BatchSchedulerBootstrapConfig`
+    - `InfraConfig`
+    - `ObservabilityModuleConfig`
+- `@SpringBootApplication`이 batch package만 스캔한다.
+- `batch`는 실행 모듈 중 유일하게 `@EnableScheduling`을 유지한다.
+- `BatchSchedulerBootstrapConfig`가 아래 batch-owned runtime beans를 명시적으로 import한다.
+    - `JobSchedulerService`
+    - `JobSchedulerTransactionalService`
+    - `TicketCleanupScheduler`
+    - `PromotionSchedulerService`
+- main resources는 `beat.scheduler.owner=true`를 기본값으로 유지한다.
+- external-client / Feign runtime은 batch bootstrap이 아니라 `infra`의 `EXTERNAL_CLIENTS` 경계와 web-app lane에서만 소유한다.
+- test profile은 `beat.scheduler.owner=false`로 내려서 detached smoke boot를 검증하고, owner-enabled contract는 별도 테스트로 검증한다.
+- scheduler/service 코드는 `batch` 모듈로 이동했지만 패키지 네임스페이스는 아직 legacy 경로를 유지한다.
+
+## What changed in this issue
+
+- `batch/build.gradle.kts`에서 `implementation(project(":"))`를 제거했다.
+- `batch`는 root project classpath 없이 build/boot/test 되는 방향으로 고정됐다.
+- 테스트 계약을 갱신해 detached bootstrap, non-owner smoke profile, owner-enabled schedule contract를 고정했다.
+- batch architecture guard를 추가해 root dependency 재도입과 forbidden runtime lane 참조를 막는다.
+- `batch/README.md`를 detached bootstrap 상태 기준으로 갱신했다.
+
+## Current ownership notes
+
+### In `batch`
+
+- scheduler runtime ownership
+- `ScheduleJobPort` implementation for the active scheduler lane
+- scheduled maintenance jobs and batch execution entrypoints
+- batch-local scheduling bootstrap and owner flag defaults
+
+### Outside `batch`
+
+- `module-contracts`: `ScheduleJobPort` 같은 cross-module execution contract
+- `domain`: schedule/booking/promotion domain models and repository contracts
+- `infra`: JPA, QueryDSL, async/task-scheduler bootstrap
+- `global-utils`: shared common types and exception base contracts
+- `observability`: logging / metrics / tracing boundary
+
+## Remaining transitional debt
+
+- scheduler/service 소스 상당수가 아직 `com.beat.domain.*`, `com.beat.global.*` legacy package names를 유지한다.
+- batch 실행 경계는 detached 되었지만 package normalization은 아직 시작 전이다.
+- 일부 legacy domain entity가 여전히 Spring Security 타입(`GrantedAuthority`)을 참조해 `domain` 모듈에 transitional runtime support가 남아 있다.
+- root legacy lane은 repository에 남아 있고, 최종 retirement는 후속 migration 범위다.
+- CQRS/service layer normalization과 batch 전용 package 정리는 다음 단계에서 다룬다.
+
+## Guard rails
+
+- `BatchApplicationTest`
+    - `BatchApplication` import 집합 고정
+    - narrow app bootstrap 유지
+    - scheduler bootstrap import 집합 고정
+    - main/test resource owner flag 계약 고정
+- `BatchArchitectureGuardTest`
+    - `batch/build.gradle.kts`의 root dependency 재추가 금지
+    - `apis`, `admin`, `gateway` 직접 의존 금지
+    - root bootstrap lane 참조 금지
+- `BatchModuleContextBootTest`
+    - module context boot smoke test
+    - test profile에서 `beat.scheduler.owner=false`가 실제로 적용되는지 확인
+    - batch-owned `ScheduleJobPort`가 detached classpath에서 그대로 올라오는지 확인
+- `BatchSchedulerOwnerBootTest`
+    - owner-enabled runtime에서 `ScheduleJobPort -> JobSchedulerService` 해석 고정
+- `AbstractBatchIntegrationTest`
+    - batch 통합 테스트용 MySQL service connection bootstrap 공유
+- `JobSchedulerServiceTest`
+    - reconcile / registerOrRefresh owner behavior 회귀 방지
+
+## To-Be direction
 
 ```text
 com.beat.batch.<context>/
@@ -72,8 +142,8 @@ com.beat.batch.<context>/
 - `adapter`, `port` 패키지는 BEAT 기본 가이드로 강제하지 않는다.
 - Repository는 지금 즉시 분리하지 않고, 복잡한 조회 전용 구현이 필요할 때만 infra query 레이어를 추가한다.
 
-## 최종 목표
+## Follow-up after this issue
 
-- 스케줄 소유권이 `batch` 하나로 고정된다.
-- 운영 작업은 HTTP lane 없이 독립 실행 가능하다.
-- 배치 로직이 사용자 API 코드에 기대지 않는다.
+1. batch-owned legacy package를 `com.beat.batch.<context>` 구조로 점진 이관
+2. root legacy lane retirement 시 scheduler-related transitional docs 추가 축소
+3. shared test bootstrap convergence가 필요해지면 실행 모듈 간 중복 test container setup 정리

--- a/batch/build.gradle.kts
+++ b/batch/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":"))
     implementation(project(":module-contracts"))
     implementation(project(":domain"))
     implementation(project(":infra"))

--- a/batch/src/test/java/com/beat/batch/BatchModuleContextBootTest.java
+++ b/batch/src/test/java/com/beat/batch/BatchModuleContextBootTest.java
@@ -1,26 +1,40 @@
 package com.beat.batch;
 
-import org.junit.jupiter.api.Tag;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.containers.MySQLContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
 
-@SpringBootTest(classes = BatchApplication.class)
-@ActiveProfiles("test")
-@Tag("integration")
-class BatchModuleContextBootTest {
+import com.beat.batch.support.AbstractBatchIntegrationTest;
+import com.beat.contracts.schedule.ScheduleJobPort;
+import com.beat.global.common.scheduler.application.JobSchedulerService;
 
-	@ServiceConnection
-	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.39")
-		.withDatabaseName("beat_batch_test");
+class BatchModuleContextBootTest extends AbstractBatchIntegrationTest {
 
-	static {
-		mysql.start();
-	}
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	private Environment environment;
+
+	@Autowired
+	private ScheduleJobPort scheduleJobPort;
+
+	@Autowired
+	private JobSchedulerService jobSchedulerService;
 
 	@Test
-	void contextLoads() {
+	void contextLoadsWithSchedulerOwnerDisabledInTestProfile() {
+		assertEquals("false", environment.getProperty("beat.scheduler.owner"));
+		assertEquals(1, applicationContext.getBeansOfType(JobSchedulerService.class).size());
+		assertEquals(1, applicationContext.getBeansOfType(ScheduleJobPort.class).size());
+		assertNotNull(scheduleJobPort);
+		assertSame(jobSchedulerService, scheduleJobPort);
+		assertEquals(false, ReflectionTestUtils.getField(jobSchedulerService, "schedulerOwner"));
 	}
 }

--- a/batch/src/test/java/com/beat/batch/BatchSchedulerOwnerBootTest.java
+++ b/batch/src/test/java/com/beat/batch/BatchSchedulerOwnerBootTest.java
@@ -1,40 +1,44 @@
 package com.beat.batch;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.containers.MySQLContainer;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.beat.batch.support.AbstractBatchIntegrationTest;
 import com.beat.contracts.schedule.ScheduleJobPort;
 import com.beat.global.common.scheduler.application.JobSchedulerService;
 
-@SpringBootTest(classes = BatchApplication.class)
-@ActiveProfiles("test")
 @TestPropertySource(properties = "beat.scheduler.owner=true")
-@Tag("integration")
-class BatchSchedulerOwnerBootTest {
+class BatchSchedulerOwnerBootTest extends AbstractBatchIntegrationTest {
 
-	@ServiceConnection
-	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.39")
-		.withDatabaseName("beat_batch_test");
+	@Autowired
+	private ApplicationContext applicationContext;
 
-	static {
-		mysql.start();
-	}
+	@Autowired
+	private Environment environment;
 
 	@Autowired
 	private ScheduleJobPort scheduleJobPort;
 
+	@Autowired
+	private JobSchedulerService jobSchedulerService;
+
 	@Test
 	void contextBootsWithSchedulerOwnerEnabled() {
+		assertEquals("true", environment.getProperty("beat.scheduler.owner"));
+		assertEquals(1, applicationContext.getBeansOfType(JobSchedulerService.class).size());
+		assertEquals(1, applicationContext.getBeansOfType(ScheduleJobPort.class).size());
 		assertNotNull(scheduleJobPort);
 		assertInstanceOf(JobSchedulerService.class, scheduleJobPort);
+		assertSame(jobSchedulerService, scheduleJobPort);
+		assertEquals(true, ReflectionTestUtils.getField(jobSchedulerService, "schedulerOwner"));
 	}
 }

--- a/batch/src/test/java/com/beat/batch/support/AbstractBatchIntegrationTest.java
+++ b/batch/src/test/java/com/beat/batch/support/AbstractBatchIntegrationTest.java
@@ -1,0 +1,23 @@
+package com.beat.batch.support;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MySQLContainer;
+
+import com.beat.batch.BatchApplication;
+
+@SpringBootTest(classes = BatchApplication.class)
+@ActiveProfiles("test")
+@Tag("integration")
+public abstract class AbstractBatchIntegrationTest {
+
+	@ServiceConnection
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.39")
+		.withDatabaseName("beat_batch_test");
+
+	static {
+		mysql.start();
+	}
+}

--- a/batch/src/test/kotlin/com/beat/batch/BatchApplicationTest.kt
+++ b/batch/src/test/kotlin/com/beat/batch/BatchApplicationTest.kt
@@ -2,42 +2,74 @@ package com.beat.batch
 
 import com.beat.batch.config.BatchSchedulerBootstrapConfig
 import com.beat.batch.config.InfraConfig
+import com.beat.domain.booking.application.TicketCleanupScheduler
+import com.beat.domain.promotion.application.PromotionSchedulerService
+import com.beat.global.common.scheduler.application.JobSchedulerService
+import com.beat.global.common.scheduler.application.JobSchedulerTransactionalService
 import com.beat.observability.ObservabilityModuleConfig
-import java.nio.file.Files
-import java.nio.file.Path
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
+import java.nio.file.Files
+import java.nio.file.Path
 
 class BatchApplicationTest {
 
     @Test
-    fun `batch application keeps transition baseline scheduling contract`() {
+    fun `batch application keeps detached module import contract`() {
         val importAnnotation = BatchApplication::class.java.getAnnotation(Import::class.java)
         assertNotNull(importAnnotation, "BatchApplication must declare @Import")
         val importedClassNames = importAnnotation!!.value.map { it.java.name }.toSet()
-        val applicationComponentScan = BatchApplication::class.java.getAnnotation(ComponentScan::class.java)
+
+        assertEquals(
+            setOf(
+                BatchSchedulerBootstrapConfig::class.java.name,
+                InfraConfig::class.java.name,
+                ObservabilityModuleConfig::class.java.name,
+            ),
+            importedClassNames,
+        )
+    }
+
+    @Test
+    fun `batch scheduler bootstrap imports batch owned runtime beans`() {
         val bootstrapImport = BatchSchedulerBootstrapConfig::class.java.getAnnotation(Import::class.java)
         assertNotNull(bootstrapImport, "BatchSchedulerBootstrapConfig must declare @Import")
-        val enableScheduling = BatchApplication::class.java.getAnnotation(EnableScheduling::class.java)
-
-        assertTrue(importedClassNames.contains(BatchSchedulerBootstrapConfig::class.java.name))
-        assertTrue(importedClassNames.contains(InfraConfig::class.java.name))
-        assertTrue(importedClassNames.contains(ObservabilityModuleConfig::class.java.name))
-        assertFalse(importedClassNames.contains("com.beat.gateway.GatewayModuleConfig"))
-        assertNull(applicationComponentScan)
-        assertNotNull(bootstrapImport)
         val bootstrapClassNames = bootstrapImport.value.map { it.java.name }.toSet()
-        assertTrue(bootstrapClassNames.contains("com.beat.global.common.scheduler.application.JobSchedulerService"))
-        assertTrue(bootstrapClassNames.contains("com.beat.global.common.scheduler.application.JobSchedulerTransactionalService"))
-        assertTrue(bootstrapClassNames.contains("com.beat.domain.booking.application.TicketCleanupScheduler"))
-        assertTrue(bootstrapClassNames.contains("com.beat.domain.promotion.application.PromotionSchedulerService"))
-        assertTrue(enableScheduling != null)
+
+        assertEquals(
+            setOf(
+                JobSchedulerService::class.java.name,
+                JobSchedulerTransactionalService::class.java.name,
+                TicketCleanupScheduler::class.java.name,
+                PromotionSchedulerService::class.java.name,
+            ),
+            bootstrapClassNames,
+        )
+    }
+
+    @Test
+    fun `batch application keeps scheduling local to the module bootstrap`() {
+        val springBootApplication = BatchApplication::class.java.getAnnotation(SpringBootApplication::class.java)
+        val componentScan = BatchApplication::class.java.getAnnotation(ComponentScan::class.java)
+        val enableScheduling = BatchApplication::class.java.getAnnotation(EnableScheduling::class.java)
+        val source = Files.readString(Path.of("src/main/kotlin/com/beat/batch/BatchApplication.kt"))
+
+        assertNotNull(springBootApplication)
+        assertNull(componentScan)
+        assertNotNull(enableScheduling)
+        assertEquals(
+            setOf(BatchApplication::class.java.name),
+            springBootApplication!!.scanBasePackageClasses.map { it.java.name }.toSet(),
+        )
+        assertFalse(source.contains("GatewayModuleConfig"))
+        assertFalse(source.contains("@EnableFeignClients"))
+        assertFalse(source.contains("FeignAutoConfiguration"))
+        assertFalse(source.contains("\"com.beat.domain\""))
+        assertFalse(source.contains("\"com.beat.global\""))
     }
 
     @Test
@@ -47,5 +79,15 @@ class BatchApplicationTest {
         assertTrue(config.contains("scheduler:"))
         assertTrue(config.contains("owner: true"))
         assertFalse(config.contains("owner: false"))
+    }
+
+    @Test
+    fun `batch test resources disable scheduler ownership for smoke tests`() {
+        val config = Files.readString(Path.of("src/test/resources/application-test.yml"))
+
+        assertTrue(config.contains("beat:"))
+        assertTrue(config.contains("scheduler:"))
+        assertTrue(config.contains("owner: false"))
+        assertFalse(config.contains("owner: true"))
     }
 }

--- a/batch/src/test/kotlin/com/beat/batch/BatchArchitectureGuardTest.kt
+++ b/batch/src/test/kotlin/com/beat/batch/BatchArchitectureGuardTest.kt
@@ -1,0 +1,64 @@
+package com.beat.batch
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class BatchArchitectureGuardTest {
+
+    private val forbiddenProjectDependencyPatterns = mapOf(
+        "root project" to Regex("""project\(\s*":\"\s*\)"""),
+        "apis module" to Regex("""project\(\s*":apis"\s*\)"""),
+        "admin module" to Regex("""project\(\s*":admin"\s*\)"""),
+        "gateway module" to Regex("""project\(\s*":gateway"\s*\)"""),
+    )
+
+    @Test
+    fun `batch build file must not depend on forbidden modules`() {
+        val buildFile = Files.readString(Path.of("build.gradle.kts"))
+        val violations = forbiddenProjectDependencyPatterns
+            .filterValues { it.containsMatchIn(buildFile) }
+            .keys
+            .toList()
+
+        assertTrue(violations.isEmpty(), "Found forbidden project dependencies: ${violations.joinToString(", ")}")
+    }
+
+    @Test
+    fun `batch main sources must not reference root or forbidden runtime lanes`() {
+        val violations = findForbiddenReferences(
+            "com.beat.BeatApplication",
+            "com.beat.legacyroot.",
+            "com.beat.global.common.config.SecurityConfig",
+            "com.beat.global.common.config.WebConfig",
+            "com.beat.gateway.",
+            "com.beat.apis.",
+            "com.beat.admin.",
+        )
+
+        assertTrue(
+            violations.isEmpty(),
+            "Found forbidden batch source references:\n${violations.joinToString("\n")}",
+        )
+    }
+
+    private fun findForbiddenReferences(vararg forbiddenReferences: String): List<String> {
+        val paths = Files.walk(Path.of("src/main"))
+
+        return try {
+            paths
+                .filter(Files::isRegularFile)
+                .filter { path -> path.toString().endsWith(".java") || path.toString().endsWith(".kt") }
+                .toList()
+                .flatMap { path ->
+                    val source = Files.readString(path)
+                    forbiddenReferences
+                        .filter(source::contains)
+                        .map { pattern -> "$path: $pattern" }
+                }
+        } finally {
+            paths.close()
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/beat.jpa-infra.gradle.kts
+++ b/build-logic/src/main/kotlin/beat.jpa-infra.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation(libs.findLibrary("spring-boot-persistence").get())
     compileOnly(libs.findLibrary("spring-boot-starter-data-jpa").get())
     compileOnly(libs.findLibrary("spring-boot-starter-data-redis").get())
-    compileOnly(libs.findLibrary("spring-boot-starter-security").get())
+    compileOnly(libs.findLibrary("spring-security-core").get())
     compileOnly(libs.findLibrary("querydsl-jpa-jakarta").get()) {
         artifact {
             classifier = "jakarta"

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -8,7 +8,8 @@ dependencies {
     api(project(":global-utils"))
     implementation(kotlin("reflect"))
     compileOnly(libs.spring.boot.starter.data.jpa)
-    compileOnly(libs.spring.boot.starter.security)
+    compileOnly(libs.spring.security.core)
+    runtimeOnly(libs.spring.security.core)
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 lombok = { module = "org.projectlombok:lombok", version = "1.18.44" }
 spring-security-test = { module = "org.springframework.security:spring-security-test" }
+spring-security-core = { module = "org.springframework.security:spring-security-core", version = "7.0.3" }
 
 spring-aop = { module = "org.springframework:spring-aop", version.ref = "spring-framework" }
 spring-tx = { module = "org.springframework:spring-tx", version.ref = "spring-framework" }

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":global-utils"))
     compileOnly(libs.spring.boot.starter.web)
-    implementation(libs.spring.cloud.starter.openfeign)
+    compileOnly(libs.spring.cloud.starter.openfeign)
     implementation(libs.aws.java.sdk.s3)
     implementation(libs.nurigo.java.sdk)
     implementation(libs.querydsl.jpa.jakarta) {


### PR DESCRIPTION
## Related issue 🛠

- closes #370

## Work Description ✏️

- `batch/build.gradle.kts`에서 `project(":")`를 제거해 `:batch`가 root project classpath 없이 build / boot / test 되도록 정리했습니다.
- `BatchApplicationTest`, `BatchModuleContextBootTest`, `BatchSchedulerOwnerBootTest`, `BatchArchitectureGuardTest`를 통해 detached bootstrap 계약, scheduler owner/non-owner 계약, root 재의존 금지 규칙을 고정했습니다.
- `batch/README.md`를 현재 detached bootstrap 상태 기준으로 갱신했습니다.
- 검증 과정에서 드러난 hidden runtime leak를 함께 정리했습니다.
  - `infra/build.gradle.kts`의 `spring-cloud-starter-openfeign`을 `compileOnly`로 낮춰 external client runtime이 batch까지 전파되지 않도록 정리했습니다.
  - `domain/build.gradle.kts`와 `beat.jpa-infra` build-logic에서 security 의존을 `starter-security`가 아니라 더 좁은 `spring-security-core` 기준으로 정리했습니다.
- batch 통합 테스트의 MySQL `@ServiceConnection` bootstrap을 `AbstractBatchIntegrationTest`로 공통화해 중복을 줄였습니다.

## Trouble Shooting ⚽️

- `project(":")` 제거 직후 `:batch` 부팅 시 `FeignAutoConfiguration`이 불필요하게 batch runtime에 섞여 올라오면서 context boot가 실패했습니다.
  - 원인은 `infra`가 OpenFeign을 모든 consumer에 transitive하게 전파하던 구조였습니다.
  - 이를 `infra` 경계에서 `compileOnly`로 낮춰 batch 로컬 exclude 없이 해결했습니다.
- detached batch boot 과정에서 `domain.user.Role`의 `GrantedAuthority` 참조 때문에 security classpath 누락이 드러났습니다.
  - 다만 이건 이번 이슈 범위를 넘는 shared transitional debt라서, 현재 브랜치에서는 `spring-security-core`로 범위를 최소화해 runtime requirement만 닫았습니다.
- `BatchModuleContextBootTest` / `BatchSchedulerOwnerBootTest`가 중복된 container bootstrap을 가지고 있어, 검증 구조도 함께 정리했습니다.

## Related ScreenShot 📷

- 없음

## Uncompleted Tasks 😅

- `domain.user.Role`에서 Spring Security 타입(`GrantedAuthority`)을 제거하고 authority 변환 책임을 `gateway`/auth adapter layer로 이동하는 작업은 남아 있습니다.
- `infra.AsyncConfig`의 security-aware executor 의존을 generic `ASYNC` 경계에서 분리하는 shared cleanup은 후속 이슈에서 처리해야 합니다.
- legacy package namespace(`com.beat.domain.*`, `com.beat.global.*`) 정규화는 이번 브랜치 범위에 포함하지 않았습니다.

## To Reviewers 📢

- 이번 브랜치는 `batch` detach 자체와 그 과정에서 바로 드러난 hidden runtime leak만 최소 범위로 함께 정리했습니다.
- `domain`의 `spring-security-core` runtime support는 의도된 최종형이 아니라, 현재 shared leak를 문서화한 transitional debt입니다.
- 특히 봐주시면 좋은 포인트는 두 가지입니다.
  - OpenFeign 책임을 `batch` 로컬 workaround가 아니라 `infra` 경계에서 정리한 방향이 적절한지
  - batch owner/non-owner boot contract를 테스트로 고정한 방식이 과도하지 않은지
