### PR TITLE
docs: Kotlin migration 기준 문서 정리

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,166 @@
+# BEAT-SERVER 마이그레이션 기준 문서
+
+이 문서는 BEAT-SERVER의 Java → Kotlin 전환을 시작하기 전에 현재 백엔드 구조와 검증 기준을 고정하기 위한 기준 문서입니다.
+
+루트 `README.md`는 제품/프로젝트 소개 문서로 유지합니다. 이 파일은 #384와 상위 migration 이슈 #350을 위한 백엔드 migration 기준점입니다.
+
+## 현재 백엔드 기준
+
+| 구분 | 현재 기준 |
+| --- | --- |
+| Spring | Spring Boot `4.0.3` |
+| Language / Runtime | Kotlin `2.2.20`, Java toolchain JDK `25`, Java compile release / Kotlin JVM target `21` |
+| Build | Gradle wrapper, root project는 실행 모듈이 아니라 공통 검증/조정 역할 |
+| 실행 모듈 | `apis`, `admin`, `batch` |
+| shared/support 모듈 | `domain`, `gateway`, `infra`, `global-utils`, `module-contracts`, `observability` |
+| CI | GitHub Actions PR gate: Gradle baseline 검증, Docker image build, Trivy image scan |
+| 배포 검증 | `infra/ansible` 기준 Ansible/SOPS secret-aware GitHub Actions 검증 |
+| 품질 도구 | SonarQube / Kover Gradle plugin은 존재하지만, SonarCloud 설정과 hard coverage threshold는 #384 범위가 아님 |
+
+Jenkins 관련 내용은 과거 운영 이력으로는 의미가 있을 수 있지만, 현재 이 저장소의 기준 CI/CD gate는 GitHub Actions입니다.
+
+## 모듈 지도
+
+### 실행 모듈
+
+| 모듈 | 현재 책임 | 문서 |
+| --- | --- | --- |
+| `apis` | 사용자 대상 HTTP API 실행 모듈. 사용자 API controller, DTO, Swagger/OpenAPI, API 보안 정책을 소유한다. | [`apis/README.md`](apis/README.md) |
+| `admin` | 관리자/백오피스 HTTP API 실행 모듈. 관리자 API 정책, DTO, Swagger/OpenAPI, 운영성 workflow entrypoint를 소유한다. | [`admin/README.md`](admin/README.md) |
+| `batch` | scheduler/batch 실행 모듈. scheduler runtime, scheduled job, batch maintenance flow를 소유한다. | [`batch/README.md`](batch/README.md) |
+
+### shared/support 모듈
+
+| 모듈 | 현재 책임 | 문서 |
+| --- | --- | --- |
+| `domain` | 도메인 모델, 도메인 규칙, repository interface의 최종 소유자. 현재는 migration 중이라 JPA entity / Spring Data repository concern이 아직 남아 있다. | [`domain/README.md`](domain/README.md) |
+| `gateway` | 실행 모듈이 사용하는 security/JWT/bootstrap public surface. public/internal surface tightening은 아직 후속 작업이다. | [`gateway/README.md`](gateway/README.md) |
+| `infra` | JPA entity / persistence model, Spring Data adapter, QueryDSL/Kotlin JDSL query 구현체, domain repository interface 구현체, 외부 adapter와 기술 bootstrap을 소유한다. | [`infra/README.md`](infra/README.md) |
+| `global-utils` | shared-kernel 제약과 저수준 공통 유틸리티를 담당한다. | [`global-utils/README.md`](global-utils/README.md) |
+| `module-contracts` | auth, notification, schedule, SMS, storage 등 cross-module port/transfer contract를 담당한다. | [`module-contracts/README.md`](module-contracts/README.md) |
+| `observability` | logging, metrics, tracing, actuator 관련 shared observability 설정을 담당한다. | [`observability/README.md`](observability/README.md) |
+
+## domain / infra 목표 경계
+
+Kotlin migration의 최종 방향은 domain과 infra의 책임을 아래처럼 분리하는 것입니다.
+
+| 모듈 | 최종 소유 책임 | 소유하지 않는 것 |
+| --- | --- | --- |
+| `domain` | 도메인 모델, 값 객체, enum, 도메인 서비스, repository interface | JPA entity, Spring Data repository adapter, QueryDSL/Kotlin JDSL 구현, DB/Redis/외부 API 구현 |
+| `infra` | JPA entity / persistence model, Spring Data adapter, QueryDSL/Kotlin JDSL query 구현체, domain repository interface 구현체, 외부 API adapter, 기술 bootstrap | 유스케이스 정책, controller/request/response DTO, 도메인 규칙 자체 |
+
+현재는 migration 중이라 일부 JPA entity와 Spring Data repository concern이 `domain` 안에 남아 있습니다. 이 정리는 #380과 #381에서 다루며, #384는 현재 상태와 목표 경계를 문서로 명확히 구분하는 데 집중합니다.
+
+## root project 계약
+
+root project는 실행 모듈이 아니라 조정/검증 모듈입니다.
+
+- `bootJar`: disabled
+- `bootRun`: disabled
+- 실제 실행 모듈: `apis`, `admin`, `batch`
+
+root verification task:
+
+- `transitionBoundaryTest`: root transition boundary guard test만 실행
+- `verifyV2WebBaseline`: `:apis:test`, `:apis:bootJar`, `transitionBoundaryTest`
+- `verifyModuleBootJars`: `apis`, `admin`, `batch` boot jar build
+
+## Kotlin migration 단계 지도
+
+#384는 README/CI migration gate baseline 이슈입니다. 실제 구조 변경이 아니라, 현재 상태와 검증 기준을 문서로 고정하는 작업입니다.
+
+| 이슈 | 후속 작업 범위 |
+| --- | --- |
+| #378 | shared module ownership/package closeout, dormant cache ownership 결정 |
+| #379 | gateway public/internal surface tightening |
+| #380 | domain model / repository interface와 infra persistence model / repository implementation 분리 전략 |
+| #381 | infra QueryDSL → Kotlin JDSL 경계, `JpaConfig` scan 결정 |
+| #382 | `apis`, `admin`, `batch` 내부 CQRS/package rule 정리 |
+| #383 | async boundary와 coroutine 도입 범위 확정 |
+| #384 | README/CI migration gate baseline 정리 |
+
+이 문서는 package 이동, query 기술 교체, gateway scan 축소, domain repository interface와 infra persistence implementation 분리, coroutine 도입을 승인하는 문서가 아닙니다. 그런 작업은 위 후속 이슈에서 다룹니다.
+
+## CI와 로컬 검증 기준
+
+application PR gate는 [`.github/workflows/ci-pr.yml`](.github/workflows/ci-pr.yml)에 정의되어 있습니다.
+
+현재 흐름:
+
+1. PR 대상: `develop`, `main`
+2. JDK 25 setup
+3. Gradle baseline command 실행
+4. module Docker image build
+5. Trivy image scan
+
+로컬에서 같은 핵심 검증을 수행하려면 아래 명령을 사용합니다.
+
+```bash
+git diff --check
+```
+
+```bash
+./gradlew tasks --all --console=plain | rg -i 'kover|sonar|verifyV2WebBaseline|verifyModuleBootJars|transitionBoundaryTest'
+```
+
+```bash
+./gradlew verifyV2WebBaseline :admin:test :batch:test verifyModuleBootJars --parallel --build-cache
+```
+
+로컬에서 Docker/Testcontainers provider를 초기화할 수 없어 전체 baseline이 실패할 수 있습니다. 이 경우 compile/bootJar 경로가 통과했는지 확인한 뒤, Docker provider 초기화 실패는 코드 회귀가 아니라 환경 gap으로 기록합니다.
+
+## Sonar / Kover 방향
+
+root build에는 SonarQube와 Kover plugin이 적용되어 있습니다.
+
+확인 명령:
+
+```bash
+./gradlew tasks --all --console=plain | rg -i 'kover|sonar'
+```
+
+#384 기준 정책:
+
+- SonarCloud organization/project/token/quality gate 설정이 끝나기 전까지 `./gradlew sonar`를 PR 필수 gate로 요구하지 않는다.
+- #384에서 strict Kover threshold를 새로 추가하지 않는다. coverage baseline과 threshold 정책이 아직 합의되지 않았기 때문이다.
+- Kover report visibility는 추후 작은 후속 작업으로 추가할 수 있다. 단, 먼저 local `koverXmlReport` / `koverLog` 성공을 확인해야 한다.
+
+## 배포 인프라 검증
+
+배포 운영 세부 내용은 [`infra/README.md`](infra/README.md)와 `infra/ansible/` 아래에 둡니다.
+
+secret-aware 검증 workflow:
+
+- [`.github/workflows/ansible-secret-aware-verify.yml`](.github/workflows/ansible-secret-aware-verify.yml)
+
+역할:
+
+- SOPS 기반 inventory 복호화 검증
+- resolver를 통한 SSH metadata 추출 검증
+- dev/prod 환경별 `ansible-lint`
+- infra/ansible 또는 관련 workflow/action/script 변경 시 실행
+
+workflow YAML을 수정했다면 가능하면 아래를 실행합니다.
+
+```bash
+actionlint .github/workflows/*.yml
+```
+
+`actionlint`가 없다면 최소한 YAML parse를 수행합니다.
+
+```bash
+ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' \
+  .github/workflows/ci-pr.yml \
+  .github/workflows/ansible-secret-aware-verify.yml
+```
+
+## 문서 리뷰 체크리스트
+
+README 계열만 변경한 경우:
+
+- root `README.md`는 제품/프로젝트 소개 문서로 남아 있는가?
+- migration/backend 기준 내용은 `MIGRATION.md`에 있는가?
+- 변경한 module README가 현재 상태 / 목표 상태 / 후속 이슈를 명확히 구분하는가?
+- To-Be를 이미 완료된 현재 상태처럼 표현하지 않았는가?
+- #378~#383에서 다룰 구조 변경을 #384에서 완료한 것처럼 쓰지 않았는가?
+- module README 링크와 이슈 번호가 깨지지 않았는가?

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,6 +17,30 @@
 | 배포 검증 | `infra/ansible` 기준 Ansible/SOPS secret-aware GitHub Actions 검증 |
 | 품질 도구 | SonarQube / Kover Gradle plugin은 존재하지만, SonarCloud 설정과 hard coverage threshold는 #384 범위가 아님 |
 
+### 빌드 설정 동기화 근거
+
+위 기준값은 아래 Gradle 설정과 대조한 값입니다. 버전이나 toolchain을 변경할 때는 이 표와 빌드 설정을 함께 갱신해야 합니다.
+
+| 기준 | 빌드 설정 source of truth | 현재 값 |
+| --- | --- | --- |
+| Spring Boot | `gradle/libs.versions.toml`의 `spring-boot` | `4.0.3` |
+| Kotlin | `gradle/libs.versions.toml`의 `kotlin` | `2.2.20` |
+| Java toolchain | root `build.gradle.kts`와 `build-logic/build.gradle.kts`의 `JavaLanguageVersion.of(25)` | JDK `25` |
+| Java bytecode target | root `build.gradle.kts`와 `build-logic/build.gradle.kts`의 `options.release.set(21)` | release `21` |
+| Kotlin JVM target | root `build.gradle.kts`와 `build-logic/build.gradle.kts`의 `JvmTarget.JVM_21` | JVM `21` |
+
+확인 명령:
+
+```bash
+find . \
+  \( -name build.gradle.kts -o -name gradle.properties -o -path './gradle/libs.versions.toml' \) \
+  -not -path './.git/*' \
+  -print0 \
+  | xargs -0 rg -n -C2 'spring|boot|kotlin|toolchain|JvmTarget|options\.release|java\s*\{'
+
+rg -n -C2 'Spring Boot|Kotlin|JDK|JVM target|compile release' MIGRATION.md
+```
+
 Jenkins 관련 내용은 과거 운영 이력으로는 의미가 있을 수 있지만, 현재 이 저장소의 기준 CI/CD gate는 GitHub Actions입니다.
 
 ## 모듈 지도

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BEAT - 소규모 공연을 등록하고 관리할 수 있는 티켓 예매 플랫폼
 
+> 백엔드 Java → Kotlin 마이그레이션 기준과 CI gate 정리는 [`MIGRATION.md`](MIGRATION.md)를 참고하세요.
+
 # BEAT <a href="https://www.beatlive.kr"><img src="https://github.com/user-attachments/assets/49b52b5a-1859-486e-aaf5-e8bee25f64ca" align="left" width="100"></a>
 
 <a href="https://hits.seeyoufarm.com">

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,6 +1,12 @@
 # admin module
 
-> 이 문서는 admin root dependency removal 이후 `admin` 모듈의 현재 bootstrap 계약과 남아 있는 transitional debt를 설명한다. `admin`은 이제 root project 의존 없이 자체 classpath로 build/boot/test 되어야 한다.
+> 이 문서는 `admin` 모듈의 현재 bootstrap 계약, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. `admin`은 root project 의존 없이 자체 classpath로 build/boot/test 되어야 한다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Detached admin executable lane with `AdminApplication`, admin-owned HTTP security/CORS/converter policy, admin-facing DTOs/Swagger, and explicit gateway/infra/observability bootstrap imports. | Admin-owned internal package and service organization that keeps backoffice policy separate from user API policy. | Adapter/facade/port/application cleanup and executable package/CQRS rules -> #382. |
 
 ## 역할
 
@@ -70,12 +76,26 @@ admin/
 - `admin`은 async/scheduler shared runtime bean을 직접 import하지 않는다.
 - `admin` resources는 `beat.scheduler.owner=false`를 유지하고, scheduler owner bean이나 non-owner bridge를 따로 소유하지 않는다.
 
-## What changed in this issue
+## Previous detached-bootstrap changes
 
 - `admin/build.gradle.kts`에서 `implementation(project(":"))`를 제거했다.
 - `admin`은 root project classpath 없이 build/boot/test 되는 방향으로 고정됐다.
 - 테스트 계약과 architecture guard를 추가해 root dependency 재도입, root bootstrap import, gateway 내부 패키지 직접 참조를 막는다.
-- `admin/README.md`를 detached bootstrap 상태 기준으로 갱신했다.
+- `admin/README.md`는 detached bootstrap 상태 기준으로 유지한다.
+
+## Current / Target / Deferred-to-issue clarity for #384
+
+Issue #384는 README/CI gate baseline만 문서화한다. 아래 표는 현재 실행 가능한 `admin` 계약과 목표 방향을 분리하고, 실제 구조 변경은 후속 이슈로 미룬다.
+
+| Area | Current in `admin` | Target direction | Deferred-to-issue |
+| --- | --- | --- | --- |
+| Executable lane ownership | 관리자 HTTP API lane은 root bootstrap 없이 `AdminApplication`과 module-local config로 실행된다. | 계속 `admin`이 admin-facing controller/DTO/security/OpenAPI와 운영 워크플로 entrypoint를 소유한다. | #384 gate baseline only |
+| Shared module ownership | `domain`, `module-contracts`, `global-utils`, `observability`, `gateway`, `infra`의 현재 공개 계약을 사용한다. | shared module ownership/package closeout 이후 공개 계약만 더 좁게 사용한다. | #378 |
+| CQRS/package normalization | `adapter`, `application`, `facade`, `port` 중심 Java package가 남아 있고 context별 계층이 균일하지 않다. | `com.beat.admin.<context>` 아래 controller/facade/application/service/dto 기준으로 정리한다. | #382 |
+| Gateway boundary | `GatewayModuleConfig`와 `gateway.annotation.CurrentMember` 같은 공개 표면만 직접 참조한다. | gateway 내부 security/filter/config 패키지 직접 참조 없이 admin 인증 경계를 유지한다. | #379 |
+| Domain/persistence boundary | admin API DTO는 JPA Entity/QueryDSL Q type/Redis document를 직접 노출하지 않는 guard를 유지한다. | domain persistence 전략 정리 후에도 admin boundary는 transfer DTO와 domain contract 중심으로 유지한다. | #380 |
+| Infra/query boundary | `InfraConfig`가 필요한 infra base config group만 명시적으로 import하고 async/scheduler bean은 직접 소유하지 않는다. | QueryDSL/JDSL 전환과 scan 결정은 infra-owned boundary에서 정한다. | #381 |
+| Async/scheduler handoff | `admin`은 scheduler owner도 non-owner schedule bridge owner도 아니다. | async/coroutine 도입 범위가 결정될 때까지 admin lane의 runtime boundary를 넓히지 않는다. | #383 |
 
 ## Current ownership notes
 
@@ -90,9 +110,8 @@ admin/
 
 ### Outside `admin`
 
-- `gateway`: JWT, auth filter, current-member resolver, 인증/인가 shared primitives
+- `gateway`: JWT, auth filter, current-member resolver, refresh-token storage boundary, 인증/인가 shared primitives
 - `infra`: JPA, QueryDSL, async, external-client bootstrap
-- `gateway`: JWT, auth filter, current-member resolver, gateway-owned Redis beans, 인증/인가 shared primitives
 - `domain`: admin이 사용하는 domain model / repository / port contracts
 - `module-contracts`: storage, auth, schedule 같은 cross-module port contracts
 - `global-utils`: shared response DTO와 공통 예외 계층

--- a/apis/README.md
+++ b/apis/README.md
@@ -1,7 +1,13 @@
 # apis module
 
-> 이 문서는 issue #360 반영 후 `apis` 모듈의 현재 bootstrap 계약과 남아 있는 transitional debt를 설명한다. `apis`는 사용자 API 실행 모듈이며, 이제 root
+> 이 문서는 `apis` 모듈의 현재 bootstrap 계약, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. `apis`는 사용자 API 실행 모듈이며, root
 > project 의존 없이 자체 classpath로 build/boot/test 되어야 한다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Detached user API executable lane with `ApisApplication`, module-local HTTP security policy, user-facing controllers/DTOs/Swagger, and a non-owner `ApisScheduleJobPortConfig` bridge while `batch` owns scheduler runtime. | Stable user API lane with cleaner internal package and CQRS boundaries under `com.beat.apis.<context>`. | Internal CQRS/package rules and `ApisScheduleJobPortConfig` closeout -> #382. |
 
 ## 역할
 
@@ -80,6 +86,20 @@ apis/
 - scheduler handoff 이후에도 `ApisScheduleJobPortConfig`는 module-local non-owner bridge로 유지된다.
 - 테스트 계약을 갱신해 root dependency 재도입, root bootstrap import, root scheduler owner 재연결을 막는다.
 
+## Current / Target / Deferred-to-issue clarity for #384
+
+Issue #384는 README/CI gate baseline만 문서화한다. 아래 표는 현재 실행 가능한 `apis` 계약과 목표 방향을 분리하고, 실제 구조 변경은 후속 이슈로 미룬다.
+
+| Area | Current in `apis` | Target direction | Deferred-to-issue |
+| --- | --- | --- | --- |
+| Executable lane ownership | 사용자 API lane은 root bootstrap 없이 `ApisApplication`과 module-local config로 실행된다. | 계속 `apis`가 user-facing controller/DTO/security/OpenAPI를 소유한다. | #384 gate baseline only |
+| Shared module ownership | `domain`, `module-contracts`, `global-utils`, `observability`, `gateway`, `infra`의 현재 공개 계약을 사용한다. | shared module ownership/package closeout 이후 공개 계약만 더 좁게 사용한다. | #378 |
+| CQRS/package normalization | context별 `controller`, `api`, `application`, `dto` 세분화가 아직 균일하지 않다. | `com.beat.apis.<context>` 아래 controller/facade/application/service/dto 기준으로 정리한다. | #382 |
+| Gateway boundary | `GatewayModuleConfig`와 공개 annotation/contract를 통해 인증 경계를 사용한다. | gateway 내부 패키지 직접 참조 없이 공개 표면만 유지한다. | #379 |
+| Domain/persistence boundary | API DTO는 JPA Entity/QueryDSL Q type/Redis document를 직접 노출하지 않는 guard를 유지한다. | domain persistence 전략 정리 후에도 API boundary는 transfer DTO 중심으로 유지한다. | #380 |
+| Infra/query boundary | `InfraConfig`가 JPA, QueryDSL, async, external-client group을 명시적으로 import한다. | QueryDSL/JDSL 전환과 scan 결정은 infra-owned boundary에서 정한다. | #381 |
+| Async/scheduler handoff | `apis`는 scheduler owner가 아니며 non-owner `ScheduleJobPort` bridge만 가진다. | async/coroutine 도입 범위가 결정될 때까지 HTTP lane의 비동기 경계를 넓히지 않는다. | #383 |
+
 ## Current ownership notes
 
 ### In `apis`
@@ -93,9 +113,8 @@ apis/
 
 ### Outside `apis`
 
-- `gateway`: JWT, auth filter, current-member resolver, refresh-token redis repository, auth/security shared primitives
+- `gateway`: JWT, auth filter, current-member resolver, refresh-token redis repository, refresh-token storage boundary, auth/security shared primitives
 - `infra`: JPA, QueryDSL, async/external-client bootstrap
-- `gateway`: JWT, auth filter, current-member resolver, refresh-token redis repository, gateway-owned Redis beans
 - `domain`: repository/domain/exception/port contracts used by `apis`
 - `global-utils`: shared response DTO and common exception hierarchy
 - `observability`: logging/metrics/tracing aspects

--- a/apis/README.md
+++ b/apis/README.md
@@ -113,7 +113,7 @@ Issue #384는 README/CI gate baseline만 문서화한다. 아래 표는 현재 �
 
 ### Outside `apis`
 
-- `gateway`: JWT, auth filter, current-member resolver, refresh-token redis repository, refresh-token storage boundary, auth/security shared primitives
+- `gateway`: JWT, auth filter, current-member resolver, refresh-token storage boundary, auth/security shared primitives
 - `infra`: JPA, QueryDSL, async/external-client bootstrap
 - `domain`: repository/domain/exception/port contracts used by `apis`
 - `global-utils`: shared response DTO and common exception hierarchy

--- a/batch/README.md
+++ b/batch/README.md
@@ -1,6 +1,12 @@
 # batch module
 
-> 이 문서는 batch root dependency removal 이후 `batch` 모듈의 현재 detached bootstrap 계약과 남아 있는 transitional debt를 설명한다. `batch`는 이제 root project 의존 없이 자체 classpath로 build/boot/test 되어야 한다.
+> 이 문서는 `batch` 모듈의 현재 detached bootstrap 계약, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. `batch`는 root project 의존 없이 자체 classpath로 build/boot/test 되어야 한다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Batch owns scheduler runtime after detach/root dependency removal; `BatchApplication` imports infra scheduler/async support and observability while `beat.scheduler.owner=true` in runtime resources. | Cleaner job/application/service/dto organization for scheduler, maintenance, and batch flows. | Internal package/CQRS cleanup for executable modules -> #382. |
 
 ## 역할
 
@@ -61,13 +67,27 @@ batch/
 - test profile은 `beat.scheduler.owner=false`로 내려서 detached smoke boot를 검증하고, owner-enabled contract는 별도 테스트로 검증한다.
 - scheduler/service 코드는 `batch` owner namespace 기준으로 정렬됐다.
 
-## What changed in this issue
+## Previous detached-bootstrap changes
 
 - `batch/build.gradle.kts`에서 `implementation(project(":"))`를 제거했다.
 - `batch`는 root project classpath 없이 build/boot/test 되는 방향으로 고정됐다.
 - 테스트 계약을 갱신해 detached bootstrap, non-owner smoke profile, owner-enabled schedule contract를 고정했다.
 - batch architecture guard를 추가해 root dependency 재도입과 forbidden runtime lane 참조를 막는다.
-- `batch/README.md`를 detached bootstrap 상태 기준으로 갱신했다.
+- `batch/README.md`는 detached bootstrap 상태 기준으로 유지한다.
+
+## Current / Target / Deferred-to-issue clarity for #384
+
+Issue #384는 README/CI gate baseline만 문서화한다. 아래 표는 현재 실행 가능한 `batch` 계약과 목표 방향을 분리하고, 실제 구조 변경은 후속 이슈로 미룬다.
+
+| Area | Current in `batch` | Target direction | Deferred-to-issue |
+| --- | --- | --- | --- |
+| Executable lane ownership | scheduler/batch lane은 root bootstrap 없이 `BatchApplication`과 module-local config로 실행된다. | 계속 `batch`가 scheduler runtime, scheduled jobs, maintenance flows를 소유한다. | #384 gate baseline only |
+| Shared module ownership | `domain`, `module-contracts`, `global-utils`, `observability`, `infra`의 현재 공개 계약을 사용하고 `gateway`는 직접 의존하지 않는다. | shared module ownership/package closeout 이후 batch가 필요한 공개 계약만 더 좁게 사용한다. | #378 |
+| CQRS/package normalization | `scheduler`, `booking`, `promotion` application package와 job/service 계층이 최소 정리 상태로 남아 있다. | `com.beat.batch.<context>` 아래 job/facade/application/service/dto 기준으로 정리한다. | #382 |
+| Gateway boundary | `batch`는 gateway에 직접 의존하지 않고 사용자/관리자 HTTP lane과 분리되어 있다. | scheduler lane은 gateway 인증 구현과 계속 분리한다. | #379 |
+| Domain/persistence boundary | batch job은 domain repository/model contract와 infra bootstrap을 통해 persistence를 사용한다. | domain entity/persistence 전략 정리 후에도 batch는 domain contract 중심으로 접근한다. | #380 |
+| Infra/query boundary | `InfraConfig`가 JPA, QueryDSL, async, scheduler group을 명시적으로 import한다. | QueryDSL/JDSL 전환과 `JpaConfig` scan 결정은 infra-owned boundary에서 정한다. | #381 |
+| Async/scheduler handoff | 실행 모듈 중 유일하게 `@EnableScheduling`을 유지하고 `ScheduleJobPort` owner를 제공한다. | coroutine/async 확장 여부가 결정될 때까지 scheduler owner 계약을 넓히지 않는다. | #383 |
 
 ## Current ownership notes
 
@@ -90,7 +110,7 @@ batch/
 ## Remaining transitional debt
 
 - owner namespace normalization은 끝났지만 `job/application/service` 내부 세분화는 아직 최소 수준으로만 정리돼 있다.
-- 일부 legacy domain entity가 여전히 Spring Security 타입(`GrantedAuthority`)을 참조해 `domain` 모듈에 transitional runtime support가 남아 있다.
+- `domain` 모듈은 아직 JPA entity/repository 같은 persistence concern을 포함하는 transitional state이며, `Role`은 현재 `ROLE_*` 문자열만 소유하고 Spring Security `GrantedAuthority` bridge는 갖지 않는다. domain persistence 전략은 #380에서 다룬다.
 - root executable lane은 retire되었고, scheduler runtime owner는 `batch`로 고정됐다.
 - CQRS/service layer normalization과 batch 전용 package 정리는 다음 단계에서 다룬다.
 

--- a/domain/README.md
+++ b/domain/README.md
@@ -1,12 +1,18 @@
 # domain module
 
-> 이 문서는 `domain` 모듈의 최종 To-Be 계약을 정의한다. `domain`은 비즈니스 규칙의 중심이며, 실행 모듈/인프라/웹을 모르는 상태를 목표로 한다.
+> 이 문서는 `domain` 모듈의 현재 상태, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. `domain`은 도메인 모델과 repository interface의 중심을 목표로 하지만, 현재는 아직 JPA/persistence concern을 포함한다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| 현재 `domain/src/main/java/com/beat/domain/**` 안에 JPA entity와 Spring Data repository concern이 남아 있다. 예: `Users`는 `@Entity`이고 `UserRepository`는 `JpaRepository`를 확장한다. `Role.java`는 `ROLE_*` 문자열만 소유하고 `GrantedAuthority` / `SimpleGrantedAuthority` bridge는 없다. | `domain`에는 도메인 모델, 값 객체, 도메인 서비스, repository interface만 남긴다. JPA entity / persistence model, Spring Data adapter, QueryDSL/Kotlin JDSL 구현체, repository 구현체는 `infra`가 소유한다. | domain model / persistence model separation -> #380. infra query/implementation 경계 -> #381. Security authority conversion은 domain 밖에 둔다. |
 
 ## 역할
 
-- 핵심 도메인 모델, 값 객체, 도메인 서비스, Repository Interface를 소유한다.
+- 핵심 도메인 모델, 값 객체, 도메인 서비스, repository interface를 소유한다.
 - 유스케이스와 무관하게 재사용되는 순수 비즈니스 규칙을 제공한다.
-- 영속성, 웹, 보안, 외부 API의 구현 세부사항을 모른다.
+- JPA entity, Spring Data repository adapter, query 구현체, 웹, 보안, 외부 API의 구현 세부사항을 모른다.
 
 ## 허용 의존성
 
@@ -21,25 +27,22 @@
 - JPA Entity, QueryDSL Q type, Redis document, 외부 API DTO 보유 금지
 - Controller 요청/응답 DTO 보유 금지
 
-## As-Is 패키지 구조
+## Current 패키지 구조
 
 ```text
-domain module:
-  (현재는 거의 placeholder에 가까움)
-
-legacy root:
+domain/
   src/main/java/com/beat/domain/<context>/
-    api/
-    application/
-    dao/
-    domain/
+    dao/          # 현재는 Spring Data repository concern이 남아 있음
+    domain/       # 현재는 JPA entity와 domain enum이 함께 남아 있음
     exception/
     port/
 ```
 
 설명:
-- 현재 진짜 도메인 코드는 아직 root legacy `src/main/java/com/beat/domain/**` 아래에 많이 남아 있다.
-- `domain` 모듈은 최종 목적지이지만, 아직 패키지 이관이 본격화되기 전 단계다.
+- 현재 도메인 모듈은 최종 순수 도메인 형태가 아니라 migration landing zone이다.
+- `Users` 같은 타입은 아직 `@Entity`이고, `UserRepository` 같은 repository는 `JpaRepository`를 확장한다.
+- 최종 목표에서는 JPA entity / persistence model / Spring Data adapter / query 구현체가 `infra`로 이동하고, `domain`에는 repository interface만 남는다.
+- `Role`은 현재 `ROLE_USER`, `ROLE_MEMBER`, `ROLE_ADMIN` 문자열만 소유하며, Spring Security authority adapter 책임은 domain 밖에 둔다.
 
 ## To-Be 패키지 구조
 
@@ -53,7 +56,7 @@ com.beat.domain.<context>/
 ```
 
 설명:
-- `domain/`에는 aggregate, entity, enum 같은 핵심 도메인 모델을 둔다.
+- `domain/`에는 aggregate, domain entity, enum 같은 핵심 도메인 모델을 둔다. 여기서 entity는 JPA entity가 아니라 도메인 모델을 의미한다.
 - `service/`에는 cross-aggregate 규칙 중심의 domain service를 둔다.
 - `repository/`에는 **interface only** 저장소 계약만 둔다.
 - `vo/`에는 진짜 값 객체만 둔다.
@@ -63,6 +66,7 @@ com.beat.domain.<context>/
 
 - Domain 규칙은 우선 Entity/Value Object에 둔다.
 - `Domain Service`는 CRUD wrapper가 아니라 cross-aggregate 규칙 중심으로 정리한다.
-- Repository 시그니처는 도메인 중립적으로 유지한다.
-- Spring Web/Data 의존성이 제거된다.
+- Repository 시그니처는 도메인 중립적인 interface로 유지한다.
+- Spring Web/Data/JPA/QueryDSL 같은 구현 기술 의존성이 제거된다.
+- JPA entity, Spring Data repository adapter, query 구현체, repository implementation은 `infra`가 소유한다.
 - `Role` 같은 도메인 enum은 권한 문자열만 소유하고, `GrantedAuthority` 변환 같은 security adapter 책임은 `gateway`나 실행 모듈 경계에 둔다.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,6 +1,12 @@
 # gateway module
 
-> 이 문서는 `gateway` 모듈의 최종 To-Be 계약을 정의한다. `gateway`는 인증/인가/JWT와 공통 보안 부품을 소유하되, 실행 모듈의 비즈니스 정책까지 가져가면 안 된다.
+> 이 문서는 `gateway` 모듈의 현재 보안/JWT/bootstrap surface, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. `gateway`는 인증/인가/JWT와 공통 보안 부품을 소유하되, 실행 모듈의 비즈니스 정책까지 가져가면 안 된다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Gateway module provides the current security/JWT/bootstrap surface through `GatewayModuleConfig`; executable modules still rely on a mix of public marker config and legacy implementation packages. | Tighter public/internal surface where executable modules depend only on explicit gateway contracts/enable boundaries. | `GatewayModuleConfig` scan narrowing and public/internal contract closeout -> #379. |
 
 ## 역할
 

--- a/global-utils/README.md
+++ b/global-utils/README.md
@@ -1,6 +1,12 @@
 # global-utils module
 
-> 이 문서는 `global-utils` 모듈의 최종 To-Be 계약을 정의한다. 이 모듈은 편한 공용 창고가 아니라, 가장 보수적으로 관리되는 shared-kernel 성격의 공용 모듈이어야 한다.
+> 이 문서는 `global-utils` 모듈의 현재 shared-kernel guard, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. 이 모듈은 편한 공용 창고가 아니라, 가장 보수적으로 관리되는 shared-kernel 성격의 공용 모듈이어야 한다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Shared-kernel constraints are documented and guarded; current shared code is still being normalized from legacy common packages and must stay standalone from runtime lanes. | Framework/layer-neutral shared kernel with strict admission rules and no presentation/runtime ownership. | Shared ownership/package closeout -> #378. |
 
 ## 역할
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,11 +1,18 @@
 # infra module
 
-> 이 문서는 `infra` 모듈의 최종 To-Be 계약을 정의한다. `infra`는 구현 기술과 외부 adapter의 집합소이며, 상위 유스케이스를 알면 안 된다.
+> 이 문서는 `infra` 모듈의 현재 application-infra/deployment-docs 상태, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. `infra`는 구현 기술과 외부 adapter의 집합소이며, 상위 유스케이스를 알면 안 된다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Application infra bootstrap (`EnableInfraBaseConfig`, JPA, QueryDSL, async, scheduler groups, external clients) and deployment/Ansible docs coexist in this module. QueryDSL/JPA configuration and dormant `RedisCacheConfig` remain current migration surfaces. | `infra` owns JPA entity / persistence model, Spring Data adapter, QueryDSL/Kotlin JDSL query implementation, and implementation of domain repository interfaces. Deployment docs stay separated from application infra contracts. | QueryDSL/JDSL and `JpaConfig` scan decisions -> #381; dormant `RedisCacheConfig` / `REDIS_CACHE` owner/activation -> #378; domain persistence split -> #380. |
 
 ## 역할
 
 - JPA/QueryDSL/async 등 기술 설정을 소유한다.
-- `domain` Repository Interface의 구현체를 제공한다.
+- JPA entity / persistence model, Spring Data adapter, QueryDSL/Kotlin JDSL query 구현체를 소유한다.
+- `domain` repository interface의 구현체를 제공한다.
 - 외부 API client, 파일 저장소, 메시징, 서드파티 adapter를 구현한다.
 - 실행 모듈이 필요한 기술 설정만 명시적으로 import할 수 있는 부트스트랩 진입점을 제공한다.
 
@@ -18,7 +25,7 @@
 
 - `apis`, `admin`, `batch`, `gateway` 의존 금지
 - UseCase, Controller, 앱 전용 DTO 보유 금지
-- `domain` 모델 대신 infra entity/adapter 타입을 외부에 직접 노출 금지
+- infra persistence model / adapter 타입을 실행 모듈 API나 domain 계약으로 직접 노출 금지
 
 ## As-Is 패키지 구조
 
@@ -41,8 +48,9 @@ infra/
   src/main/kotlin/com/beat/infra/
     InfraModuleConfig.kt
 
-legacy root:
-  src/main/java/com/beat/domain/**/dao/
+current transitional sources:
+  domain/src/main/java/com/beat/domain/**/dao/       # Spring Data repository concern that should move behind infra boundary
+  domain/src/main/java/com/beat/domain/**/domain/    # JPA entity / persistence concern that should be split from domain model
   src/main/java/com/beat/global/common/config/**
 ```
 
@@ -52,29 +60,34 @@ legacy root:
 - scheduler bean은 `TaskSchedulerConfig` + `InfraBaseConfigGroup.SCHEDULER`로 분리되어 batch에서만 명시적으로 가져간다.
 - Redis runtime wiring은 Spring Boot auto-configuration과 gateway-owned config가 담당하고, infra는 더 이상 gateway-specific Redis bean을 소유하지 않는다.
 - future shared caching은 dormant `RedisCacheConfig` + `InfraBaseConfigGroup.REDIS_CACHE`에서 시작하고, 현재 실행 모듈은 아직 이를 import하지 않는다.
-- 일부 공통 config는 `infra`로 이동했지만, repository/JPA/query 구현 상당수는 아직 legacy root `dao` 패키지에 남아 있다.
-- 즉 `infra`도 아직 최종형이 아니라 **이관 진행 중인 landing zone**이다.
+- 일부 공통 config는 `infra`로 이동했지만, JPA entity / Spring Data repository adapter / query 구현 상당수는 아직 `domain` 쪽 transitional package에 남아 있다.
+- 즉 `infra`도 아직 최종형이 아니라 **persistence 구현 책임을 받아오는 이관 진행 중인 landing zone**이다.
 
 ## To-Be 패키지 구조
 
 ```text
 com.beat.infra.config.*
 com.beat.infra.external.<provider>
-com.beat.infra.<context>.repository.jpa
+com.beat.infra.<context>.persistence.entity
+com.beat.infra.<context>.repository.springdata
 com.beat.infra.<context>.repository.impl
 com.beat.infra.<context>.repository.query   # 필요 시만
 ```
 
 설명:
-- `domain.<context>.repository.XxxRepository` 구현은 `infra.<context>.repository.impl`이 맡는다.
-- Spring Data JPA 인터페이스는 `infra.<context>.repository.jpa`에 둔다.
-- query 전용 구현은 지금 기본값이 아니고, 조회 복잡도 증가나 jOOQ 도입이 필요할 때만 `repository.query`를 추가한다.
+- `domain.<context>.repository.XxxRepository` 같은 repository interface는 `domain`이 소유한다.
+- 그 interface의 구현체는 `infra.<context>.repository.impl`이 맡는다.
+- JPA entity / persistence model은 `infra.<context>.persistence.entity`가 소유한다.
+- Spring Data JPA adapter는 `infra.<context>.repository.springdata`에 두되, domain repository interface가 아니라 infra 내부 구현 세부사항으로 취급한다.
+- query 전용 구현은 지금 기본값이 아니고, 조회 복잡도 증가나 jOOQ/Kotlin JDSL 도입이 필요할 때만 `repository.query`를 추가한다.
 
 ## 최종 목표
 
 - `infra.external.*` 타입을 상위 실행 모듈이 직접 import하지 않는다.
 - `InfraModuleConfig`가 실제 기술 import를 모으는 진입점으로 성장한다.
-- JPA/QueryDSL/async 부트스트랩이 명시적으로 조립되고, shared cache가 필요해질 때 `REDIS_CACHE` 그룹으로 확장한다.
+- JPA/QueryDSL/async 부트스트랩이 명시적으로 조립된다.
+- JPA entity / Spring Data adapter / query 구현체 / domain repository 구현체는 infra 책임으로 모인다.
+- shared cache가 필요해질 때 `REDIS_CACHE` 그룹으로 확장한다.
 
 ---
 

--- a/module-contracts/README.md
+++ b/module-contracts/README.md
@@ -1,6 +1,12 @@
 # module-contracts module
 
-> 이 문서는 `module-contracts` 모듈의 최종 To-Be 계약을 정의한다. `module-contracts`는 실행 모듈과 인프라가 공유하는 경량 계약 경계이며, 구현 대신 인터페이스와 전달 모델만 소유한다.
+> 이 문서는 `module-contracts` 모듈의 현재 계약 surface, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. `module-contracts`는 실행 모듈과 인프라가 공유하는 경량 계약 경계이며, 구현 대신 인터페이스와 전달 모델만 소유한다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Contract surface remains Java source in places and currently exposes auth, notification, schedule, SMS, and storage ports/transfer models. | Explicit decision whether contracts stay Java or become Kotlin while preserving a stable implementation-free API. | Java-vs-Kotlin contract decision and shared module closeout -> #378. |
 
 ## 역할
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,6 +1,12 @@
 # observability module
 
-> 이 문서는 `observability` 모듈의 최종 To-Be 계약을 정의한다. 관측성은 모든 실행 모듈이 쓰지만, 어느 비즈니스 모듈의 일부가 되어서는 안 된다.
+> 이 문서는 `observability` 모듈의 현재 logging/metrics/tracing surface, 목표 계약, 그리고 #384에서 수행하지 않는 후속 작업을 구분한다. 관측성은 모든 실행 모듈이 쓰지만, 어느 비즈니스 모듈의 일부가 되어서는 안 된다.
+
+## Migration status
+
+| Current | Target | Deferred-to-issue |
+| --- | --- | --- |
+| Observability module owns marker config and shared logging resource config, while some AOP/common observability concerns may still reflect legacy package debt. | Logging, metrics, tracing, actuator configuration, and shared runtime observability conventions are owned by the observability module. | Legacy observability package ownership closeout -> #378. |
 
 ## 역할
 


### PR DESCRIPTION
## Related issue 🛠

- closes #384

## Work Description ✏️

- Kotlin migration 전에 참고할 백엔드 기준 문서 MIGRATION.md를 추가했습니다.
- 기존 root README.md는 제품/프로젝트 소개 역할을 유지하고, 상단에 MIGRATION.md 링크만 추가했습니다.
- 각 모듈 README에 현재 상태 / 목표 상태 / 후속 이슈를 구분하는 migration status를 정리했습니다.
- domain / infra 목표 경계를 명확히 정리했습니다.
    - domain: 도메인 모델, 값 객체, 도메인 서비스, repository interface
    - infra: JPA entity, persistence model, Spring Data adapter, query 구현체, domain repository interface 구현체
- domain/README.md의 Role / GrantedAuthority 설명을 현재 구현과 동기화했습니다.
    - 현재 Role.java는 ROLE_* 문자열만 소유
    - GrantedAuthority 변환 책임은 domain 밖의 gateway 또는 실행 모듈 경계로 명시

## Trouble Shooting ⚽️

- 기존 README.md는 제품 소개 성격이 강해, migration 기준 문서를 직접 덮어쓰지 않고 MIGRATION.md로 분리했습니다.
- 전체 baseline 검증은 로컬 Docker/Testcontainers provider 초기화 문제로 일부 테스트가 실패할 수 있어, 문서에는 이를 환경 gap으로 기록하도록 안내했습니다.
- Sonar/Kover는 plugin/task가 존재하지만, SonarCloud 설정과 coverage threshold 정책은 아직 합의되지 않아 hard gate로 추가하지 않고 방향만 문서화했습니다.

## Related ScreenShot 📷

- N/A

## Uncompleted Tasks 😅

- SonarCloud 조직/프로젝트/token/quality gate 설정은 진행하지 않았습니다.
- Kover coverage threshold 설정은 진행하지 않았습니다.
- 실제 package 이동, QueryDSL → Kotlin JDSL 전환, domain persistence 분리, coroutine 도입은 진행하지 않았습니다.
- 위 작업들은 각각 후속 migration 이슈에서 다룹니다.

## To Reviewers 📢

- README.md는 제품/프로젝트 소개 문서로 유지하고, migration 관련 기준은 MIGRATION.md에서 관리하는 방향이 적절한지 확인 부탁드립니다.
- module README의 Current / Target / Deferred-to-issue 구분이 실제 현재 구조와 맞는지 확인 부탁드립니다.
- domain / infra 경계 설명이 팀이 의도한 최종 구조와 일치하는지 확인 부탁드립니다.