### PR TITLE
refactor: shared module ownership closeout 정리

### DIFF
--- a/.github/actions/setup-ansible-tooling/action.yml
+++ b/.github/actions/setup-ansible-tooling/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Cosign
-      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       with:
         cosign-release: v3.0.3
 
@@ -41,7 +41,7 @@ runs:
         rm -f "sops-${SOPS_VERSION}.checksums.txt" "sops-${SOPS_VERSION}.checksums.pem" "sops-${SOPS_VERSION}.checksums.sig"
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.12"
 

--- a/.github/workflows/_ansible-exec.yml
+++ b/.github/workflows/_ansible-exec.yml
@@ -72,11 +72,11 @@ jobs:
     steps:
       - name: Checkout code (current ref)
         if: inputs.checkout_ref == ''
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout code (requested ref)
         if: inputs.checkout_ref != ''
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.checkout_ref }}
 

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling

--- a/.github/workflows/ansible-secret-aware-verify.yml
+++ b/.github/workflows/ansible-secret-aware-verify.yml
@@ -42,7 +42,7 @@ jobs:
           - batch
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling
@@ -85,7 +85,7 @@ jobs:
           - batch
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,18 +15,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up JDK 25
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "25"
           distribution: "temurin"
 
       - name: Gradle caching
-        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: on-success
 
       - name: Verify baseline
         run: |
@@ -46,7 +46,7 @@ jobs:
           - batch
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build scan image
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,9 +24,9 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       has_modules: ${{ steps.matrix.outputs.has_modules }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -108,16 +108,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "25"
           distribution: "temurin"
 
-      - uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: on-success
 
       - name: Verify baseline
         run: |
@@ -144,10 +144,10 @@ jobs:
       max-parallel: 3
       matrix: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DEV_DOCKER_LOGIN_USERNAME }}
           password: ${{ secrets.DEV_DOCKER_LOGIN_ACCESSTOKEN }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -29,7 +29,7 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo 'module_matrix={"include":[{"module":"apis"},{"module":"admin"},{"module":"batch"}]}' >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: refs/tags/${{ steps.release.outputs.release_tag }}
 
@@ -47,18 +47,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
-      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "25"
           distribution: "temurin"
 
-      - uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: on-success
 
       - name: Verify baseline
         run: |
@@ -84,12 +84,12 @@ jobs:
       max-parallel: 3
       matrix: ${{ fromJSON(needs.resolve-release.outputs.module_matrix) }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.PROD_DOCKER_LOGIN_USERNAME }}
           password: ${{ secrets.PROD_DOCKER_LOGIN_ACCESSTOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@a6a982fee9675c45c1765e9fa5308f7d6c3ecbd4 # v7.2.0
         with:
           config-name: release-drafter-config.yml
         env:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -95,7 +95,7 @@ root verification task:
 
 | 이슈 | 후속 작업 범위 |
 | --- | --- |
-| #378 | shared module ownership/package closeout, dormant cache ownership 결정 |
+| #378 | shared module ownership/package closeout, observability AOP package closeout, dormant cache ownership 결정 |
 | #379 | gateway public/internal surface tightening |
 | #380 | domain model / repository interface와 infra persistence model / repository implementation 분리 전략 |
 | #381 | infra QueryDSL → Kotlin JDSL 경계, `JpaConfig` scan 결정 |
@@ -104,6 +104,16 @@ root verification task:
 | #384 | README/CI migration gate baseline 정리 |
 
 이 문서는 package 이동, query 기술 교체, gateway scan 축소, domain repository interface와 infra persistence implementation 분리, coroutine 도입을 승인하는 문서가 아닙니다. 그런 작업은 위 후속 이슈에서 다룹니다.
+
+## #378 shared module closeout baseline
+
+#378 기준 shared module closeout은 아래 결정을 고정한다.
+
+- `observability` AOP source package는 `com.beat.observability.aop`가 소유한다. `ObservabilityModuleConfig`는 기존 activation semantics를 보존하기 위해 아직 component-scan/import를 넓히지 않는다.
+- `infra`의 `RedisCacheConfig` / `InfraBaseConfigGroup.REDIS_CACHE`는 infra-owned dormant shared cache extension point로 유지하고, 실행 모듈은 아직 opt-in하지 않는다.
+- `infra` 안의 `com.beat.domain.*` package residue는 두 QueryDSL custom repository implementation만 known deferred exception으로 허용하며 #380/#381에서 처리한다.
+- `module-contracts`는 Java source를 유지하고 implementation-free contract module로 guard한다.
+- `global-utils`는 `com.beat.global.common.*` package를 즉시 rename하지 않고 framework/layer-neutral shared-kernel guard를 우선한다.
 
 ## CI와 로컬 검증 기준
 

--- a/apis/src/test/kotlin/com/beat/apis/ApisApplicationTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/ApisApplicationTest.kt
@@ -84,7 +84,7 @@ class ApisApplicationTest {
                 .filter { path ->
                     val source = Files.readString(path)
                     source.startsWith("package com.beat.domain.")
-                        || source.startsWith("package com.beat.global.")
+                            || source.startsWith("package com.beat.global.")
                 }
                 .map(Path::toString)
                 .toList()
@@ -154,6 +154,7 @@ class ApisApplicationTest {
     @Test
     fun `controller logging aspect is owned by observability module`() {
         assertFalse(Files.exists(Path.of("../src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java")))
-        assertTrue(Files.exists(Path.of("../observability/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java")))
+        assertFalse(Files.exists(Path.of("../observability/src/main/java/com/beat/global/common/aop/ControllerLoggingAspect.java")))
+        assertTrue(Files.exists(Path.of("../observability/src/main/java/com/beat/observability/aop/ControllerLoggingAspect.java")))
     }
 }

--- a/domain/README.md
+++ b/domain/README.md
@@ -70,3 +70,9 @@ com.beat.domain.<context>/
 - Spring Web/Data/JPA/QueryDSL 같은 구현 기술 의존성이 제거된다.
 - JPA entity, Spring Data repository adapter, query 구현체, repository implementation은 `infra`가 소유한다.
 - `Role` 같은 도메인 enum은 권한 문자열만 소유하고, `GrantedAuthority` 변환 같은 security adapter 책임은 `gateway`나 실행 모듈 경계에 둔다.
+
+## #378 deferred persistence/query boundary
+
+#378에서는 `domain` 안에 남아 있는 JPA entity / Spring Data repository concern을 이동하지 않는다. 실제 domain model / persistence model separation은 #380, infra query implementation boundary와 QueryDSL/Kotlin JDSL scan 결정은 #381에서 함께 처리한다.
+
+현재 `domain`은 최종 순수 domain 모듈이 아니라 migration landing zone이며, 이 문서는 To-Be를 현재 완료 상태처럼 표현하지 않기 위해 current/deferred 상태를 명시한다.

--- a/global-utils/README.md
+++ b/global-utils/README.md
@@ -6,7 +6,7 @@
 
 | Current | Target | Deferred-to-issue |
 | --- | --- | --- |
-| Shared-kernel constraints are documented and guarded; current shared code is still being normalized from legacy common packages and must stay standalone from runtime lanes. | Framework/layer-neutral shared kernel with strict admission rules and no presentation/runtime ownership. | Shared ownership/package closeout -> #378. |
+| Shared-kernel constraints are documented and guarded. Current package names remain `com.beat.global.common.*`, but the module must stay standalone from runtime lanes. | Framework/layer-neutral shared kernel with strict admission rules and no presentation/runtime ownership. | Package rename, if ever needed, requires a dedicated compatibility review after #378. |
 
 ## 역할
 
@@ -28,16 +28,14 @@
 ## As-Is 패키지 구조
 
 ```text
-global-utils module:
-  (현재는 거의 placeholder)
-
-legacy root:
-  src/main/java/com/beat/global/common/**
+global-utils/
+  src/main/java/com/beat/global/common/dto/**
+  src/main/java/com/beat/global/common/exception/**
 ```
 
 설명:
-- 현재 shared code 대부분은 아직 root legacy `com.beat.global.common` 아래에 남아 있다.
-- `global-utils` 모듈은 최종 목적지이지만 아직 거의 비어 있는 상태다.
+- #378 기준 `com.beat.global.common.*` package 이름은 legacy-looking이지만 그대로 유지한다. rename churn보다 shared-kernel guard가 우선이다.
+- `ErrorResponse` / `SuccessResponse`는 presentation DTO 성격 논의 여지가 있지만, 현 범위에서는 shared-kernel current state로 문서화하고 runtime lane 의존이 들어오지 않도록 guard한다.
 
 ## To-Be 패키지 구조
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,7 +6,7 @@
 
 | Current | Target | Deferred-to-issue |
 | --- | --- | --- |
-| Application infra bootstrap (`EnableInfraBaseConfig`, JPA, QueryDSL, async, scheduler groups, external clients) and deployment/Ansible docs coexist in this module. QueryDSL/JPA configuration and dormant `RedisCacheConfig` remain current migration surfaces. | `infra` owns JPA entity / persistence model, Spring Data adapter, QueryDSL/Kotlin JDSL query implementation, and implementation of domain repository interfaces. Deployment docs stay separated from application infra contracts. | QueryDSL/JDSL and `JpaConfig` scan decisions -> #381; dormant `RedisCacheConfig` / `REDIS_CACHE` owner/activation -> #378; domain persistence split -> #380. |
+| Application infra bootstrap (`EnableInfraBaseConfig`, JPA, QueryDSL, async, scheduler groups, external clients) and deployment/Ansible docs coexist in this module. QueryDSL/JPA configuration remain current migration surfaces. Dormant `RedisCacheConfig` / `REDIS_CACHE` is retained as an infra-owned future shared cache extension point. | `infra` owns JPA entity / persistence model, Spring Data adapter, QueryDSL/Kotlin JDSL query implementation, and implementation of domain repository interfaces. Deployment docs stay separated from application infra contracts. | QueryDSL/JDSL and `JpaConfig` scan decisions -> #381; shared cache concrete activation policy -> future cache issue; domain persistence split -> #380. |
 
 ## 역할
 
@@ -59,9 +59,21 @@ current transitional sources:
 - `AsyncConfig`는 `@Import(TaskExecutorConfig.class)`로 executor 빈만 전이 로드하고, infra는 security-aware wrapper를 직접 소유하지 않는다.
 - scheduler bean은 `TaskSchedulerConfig` + `InfraBaseConfigGroup.SCHEDULER`로 분리되어 batch에서만 명시적으로 가져간다.
 - Redis runtime wiring은 Spring Boot auto-configuration과 gateway-owned config가 담당하고, infra는 더 이상 gateway-specific Redis bean을 소유하지 않는다.
-- future shared caching은 dormant `RedisCacheConfig` + `InfraBaseConfigGroup.REDIS_CACHE`에서 시작하고, 현재 실행 모듈은 아직 이를 import하지 않는다.
+- future shared caching은 dormant `RedisCacheConfig` + `InfraBaseConfigGroup.REDIS_CACHE`에서 시작하고, 현재 실행 모듈은 아직 이를 import하지 않는다. 활성화 전에는 cache name, TTL, serializer, namespace, invalidation policy, owner module, runtime opt-in이 먼저 정해져야 한다.
+- #378 기준 `RedisCacheConfig`는 삭제하지도 활성화하지도 않는 infra-owned dormant extension point다. gateway refresh-token Redis storage와 shared cache bootstrap은 별도 경계다.
 - 일부 공통 config는 `infra`로 이동했지만, JPA entity / Spring Data repository adapter / query 구현 상당수는 아직 `domain` 쪽 transitional package에 남아 있다.
 - 즉 `infra`도 아직 최종형이 아니라 **persistence 구현 책임을 받아오는 이관 진행 중인 landing zone**이다.
+
+## #378 known deferred package exceptions
+
+아래 두 파일은 physical module은 `infra`지만 Spring Data custom repository fragment discovery와 현재 `JpaConfig`/domain repository 구조에 묶여 있어 #378에서 package move하지 않는다. 누락이 아니라 #380/#381로 넘기는 명시적 예외다.
+
+| File | Current package | Deferred reason | Follow-up |
+| --- | --- | --- | --- |
+| `infra/src/main/java/com/beat/domain/booking/dao/TicketRepositoryCustomImpl.java` | `com.beat.domain.booking.dao` | Spring Data custom fragment discovery가 domain repository interface package와 결합되어 있음 | #380/#381 |
+| `infra/src/main/java/com/beat/domain/schedule/dao/ScheduleRepositoryCustomImpl.java` | `com.beat.domain.schedule.dao` | QueryDSL implementation boundary와 `JpaConfig` scan 결정이 함께 필요함 | #381 |
+
+`SharedBoundaryContractTest`는 infra source에서 `com.beat.domain.*` package residue가 위 두 파일을 넘지 않도록 고정한다.
 
 ## To-Be 패키지 구조
 

--- a/module-contracts/README.md
+++ b/module-contracts/README.md
@@ -6,7 +6,7 @@
 
 | Current | Target | Deferred-to-issue |
 | --- | --- | --- |
-| Contract surface remains Java source in places and currently exposes auth, notification, schedule, SMS, and storage ports/transfer models. | Explicit decision whether contracts stay Java or become Kotlin while preserving a stable implementation-free API. | Java-vs-Kotlin contract decision and shared module closeout -> #378. |
+| Contract surface intentionally remains Java source and currently exposes auth, notification, schedule, SMS, and storage ports/transfer models. `domain` / `global-utils` are compileOnly references for transitional contract types. | Stable implementation-free API; language conversion only after API shape and Java/Kotlin consumer compatibility are reviewed. | Domain-coupled contract type reduction -> follow-up after #378. |
 
 ## 역할
 
@@ -64,7 +64,9 @@ module-contracts/
 
 - 현재 `module-contracts`는 `auth`, `notification`, `schedule`, `sms`, `storage` 계약을 모아두는 얇은 공유 모듈이다.
 - 구현체는 다른 모듈에 있고, 이 모듈은 계약 타입만 제공한다.
-- `build.gradle.kts`에서 `domain`, `global-utils`를 `compileOnly`로만 참조한다.
+- #378 결정: Java source를 유지한다. cross Java/Kotlin consumer API 안정성이 언어 전환보다 우선이므로 Kotlin 변환은 하지 않는다.
+- `build.gradle.kts`에서 `domain`, `global-utils`를 `compileOnly`로만 참조한다. `SocialType`, `Schedule`, `BaseErrorCode` 같은 domain/global-utils-coupled contract type은 후속에서 contract-local value/ID로 줄일지 검토한다.
+- `SharedBoundaryContractTest`는 Spring/JPA/Redis stereotype이나 infra/executable/gateway 구현 참조가 들어오지 않도록 guard한다.
 
 ## To-Be 패키지 구조
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -6,7 +6,7 @@
 
 | Current | Target | Deferred-to-issue |
 | --- | --- | --- |
-| Observability module owns marker config and shared logging resource config, while some AOP/common observability concerns may still reflect legacy package debt. | Logging, metrics, tracing, actuator configuration, and shared runtime observability conventions are owned by the observability module. | Legacy observability package ownership closeout -> #378. |
+| Observability module owns marker config, shared logging resource config, and AOP sources under `com.beat.observability.aop`. `ObservabilityModuleConfig` remains a marker import and does not component-scan AOP yet. | Logging, metrics, tracing, actuator configuration, and shared runtime observability conventions are owned by the observability module. | Intentional AOP activation/import policy and boot-context coverage, if needed -> follow-up after #378. |
 
 ## 역할
 
@@ -31,20 +31,26 @@
 ```text
 observability/
   src/main/kotlin/com/beat/observability/
-    ObservabilityModuleConfig.kt
-
-legacy root:
-  src/main/java/com/beat/global/common/aop/**
+    ObservabilityModuleConfig.kt              # marker import; no component scan yet
+  src/main/java/com/beat/observability/aop/
+    ControllerLoggingAspect.java
+    ServiceLoggingAspect.java
+    TxAspect.java
+    ExecutionTimeLoggerAspect.java
+    Pointcuts.java
 ```
 
 설명:
 - 현재 `observability` 모듈은 marker config + shared resource ownership 단계이다.
-- AOP와 일부 공통 관측성 관심사는 아직 legacy root 패키지에 남아 있다.
+- #378에서 AOP source package는 legacy global-common AOP package에서 `com.beat.observability.aop`로 closeout했다.
+- `ObservabilityModuleConfig`는 아직 AOP package를 component-scan/import하지 않는다. 실행 모듈의 기존 activation semantics를 바꾸지 않기 위해, AOP runtime 활성화는 explicit import와 boot/context test가 생길 때 별도로 진행한다.
+- `Pointcuts.allApplicationLogic()`는 기존 `com.beat.global..*` 제외를 유지하면서 observability 자기 자신(`com.beat.observability..*`)도 advise하지 않는다.
 - executable-lane notification event listener는 package normalization closeout 이후 `apis` owner namespace(`com.beat.apis.external.notification.slack.event`)로 정렬됐다.
 
 ## To-Be 패키지 구조
 
 ```text
+com.beat.observability.aop
 com.beat.observability.logging
 com.beat.observability.metrics
 com.beat.observability.tracing

--- a/observability/src/main/java/com/beat/observability/aop/ControllerLoggingAspect.java
+++ b/observability/src/main/java/com/beat/observability/aop/ControllerLoggingAspect.java
@@ -1,4 +1,4 @@
-package com.beat.global.common.aop;
+package com.beat.observability.aop;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -48,7 +48,7 @@ public class ControllerLoggingAspect {
 	);
 
 	/** Controller 요청 로깅 */
-	@Before("com.beat.global.common.aop.Pointcuts.allController()")
+	@Before("com.beat.observability.aop.Pointcuts.allController()")
 	public void logControllerRequest(JoinPoint joinPoint) {
 		ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 		if (attributes == null) {
@@ -80,7 +80,7 @@ public class ControllerLoggingAspect {
 	}
 
 	/** Controller 정상 반환 로깅 */
-	@AfterReturning(value = "com.beat.global.common.aop.Pointcuts.allController()", returning = "result")
+	@AfterReturning(value = "com.beat.observability.aop.Pointcuts.allController()", returning = "result")
 	public void logControllerResponse(JoinPoint joinPoint, Object result) {
 		log.debug("[Controller 정상 반환] {}.{}() | 반환 타입: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
@@ -89,7 +89,7 @@ public class ControllerLoggingAspect {
 	}
 
 	/** Controller 예외 발생 시 로깅 */
-	@AfterThrowing(value = "com.beat.global.common.aop.Pointcuts.allController()", throwing = "ex")
+	@AfterThrowing(value = "com.beat.observability.aop.Pointcuts.allController()", throwing = "ex")
 	public void logControllerException(JoinPoint joinPoint, Exception ex) {
 		log.error("[Controller 예외 발생] {}.{}() | 예외 메시지: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),

--- a/observability/src/main/java/com/beat/observability/aop/ExecutionTimeLoggerAspect.java
+++ b/observability/src/main/java/com/beat/observability/aop/ExecutionTimeLoggerAspect.java
@@ -1,4 +1,4 @@
-package com.beat.global.common.aop;
+package com.beat.observability.aop;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -6,6 +6,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -22,7 +23,7 @@ public class ExecutionTimeLoggerAspect {
 	@Component
 	@Profile("prod")
 	public static class ExecutionTimeLoggerForProd {
-		@Around("com.beat.global.common.aop.Pointcuts.allService()")
+		@Around("com.beat.observability.aop.Pointcuts.allService()")
 		public Object logServiceExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
 			return measureExecutionTime(joinPoint);
 		}
@@ -33,7 +34,7 @@ public class ExecutionTimeLoggerAspect {
 	@Component
 	@Profile({"local", "dev"})
 	public static class ExecutionTimeLoggerForLocalDev {
-		@Around("com.beat.global.common.aop.Pointcuts.allApplicationLogic()")
+		@Around("com.beat.observability.aop.Pointcuts.allApplicationLogic()")
 		public Object logApplicationExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
 			return measureExecutionTime(joinPoint);
 		}

--- a/observability/src/main/java/com/beat/observability/aop/Pointcuts.java
+++ b/observability/src/main/java/com/beat/observability/aop/Pointcuts.java
@@ -1,15 +1,19 @@
-package com.beat.global.common.aop;
+package com.beat.observability.aop;
 
 import org.aspectj.lang.annotation.Pointcut;
 
 public class Pointcuts {
 	@Pointcut("execution(* com.beat..*Controller.*(..))")
-	public void allController() {}
+	public void allController() {
+	}
 
 	@Pointcut("execution(* com.beat..*Service.*(..)) || execution(* com.beat..*UseCase.*(..)) || execution(* com.beat..*Facade.*(..))")
-	public void allService() {}
+	public void allService() {
+	}
 
 	@Pointcut("execution(* com.beat..*(..))" +
-		" && !within(com.beat.global..*)")
-	public void allApplicationLogic() {}
+		" && !within(com.beat.global..*)" +
+		" && !within(com.beat.observability..*)")
+	public void allApplicationLogic() {
+	}
 }

--- a/observability/src/main/java/com/beat/observability/aop/ServiceLoggingAspect.java
+++ b/observability/src/main/java/com/beat/observability/aop/ServiceLoggingAspect.java
@@ -1,17 +1,14 @@
-package com.beat.global.common.aop;
+package com.beat.observability.aop;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.AfterThrowing;
-import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.reflect.CodeSignature;
@@ -39,7 +36,7 @@ public class ServiceLoggingAspect {
 	);
 
 	/** Service 메서드 실행 전 로깅 */
-	@Before("com.beat.global.common.aop.Pointcuts.allService()")
+	@Before("com.beat.observability.aop.Pointcuts.allService()")
 	public void doLog(JoinPoint joinPoint) {
 		log.info("[메서드 실행] {}.{}() | 인자: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
@@ -48,7 +45,7 @@ public class ServiceLoggingAspect {
 	}
 
 	/** Service 정상 반환 로깅 */
-	@AfterReturning(value = "com.beat.global.common.aop.Pointcuts.allService()", returning = "result")
+	@AfterReturning(value = "com.beat.observability.aop.Pointcuts.allService()", returning = "result")
 	public void logReturn(JoinPoint joinPoint, Object result) {
 		log.debug("[Service 정상 반환] {}.{}() | 반환 타입: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
@@ -57,7 +54,7 @@ public class ServiceLoggingAspect {
 	}
 
 	/** 예외 발생 시 로깅 */
-	@AfterThrowing(value = "com.beat.global.common.aop.Pointcuts.allService()", throwing = "ex")
+	@AfterThrowing(value = "com.beat.observability.aop.Pointcuts.allService()", throwing = "ex")
 	public void logException(JoinPoint joinPoint, Exception ex) {
 		log.error("[예외 발생] {}.{}() | 예외 메시지: {}",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
@@ -66,7 +63,7 @@ public class ServiceLoggingAspect {
 	}
 
 	/** 메서드 실행 후 로깅 */
-	@After("com.beat.global.common.aop.Pointcuts.allService()")
+	@After("com.beat.observability.aop.Pointcuts.allService()")
 	public void doAfter(JoinPoint joinPoint) {
 		log.info("[메서드 종료] {}.{}()",
 			joinPoint.getSignature().getDeclaringType().getSimpleName(),
@@ -74,7 +71,7 @@ public class ServiceLoggingAspect {
 	}
 
 	private Map<String, Object> buildMaskedArgs(JoinPoint joinPoint) {
-		CodeSignature codeSignature = (CodeSignature) joinPoint.getSignature();
+		CodeSignature codeSignature = (CodeSignature)joinPoint.getSignature();
 		String[] parameterNames = codeSignature.getParameterNames();
 		Object[] args = joinPoint.getArgs();
 

--- a/observability/src/main/java/com/beat/observability/aop/TxAspect.java
+++ b/observability/src/main/java/com/beat/observability/aop/TxAspect.java
@@ -1,6 +1,7 @@
-package com.beat.global.common.aop;
+package com.beat.observability.aop;
 
 import java.lang.reflect.Method;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -21,10 +22,10 @@ import lombok.extern.slf4j.Slf4j;
 @Profile("!test")
 public class TxAspect {
 
-	@Around("com.beat.global.common.aop.Pointcuts.allService()")
+	@Around("com.beat.observability.aop.Pointcuts.allService()")
 	public Object doTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
 		// 메서드 정보를 추출
-		MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+		MethodSignature methodSignature = (MethodSignature)joinPoint.getSignature();
 		Method method = methodSignature.getMethod();
 
 		// @Transactional 애너테이션 정보 확인 (메서드 혹은 클래스 레벨)

--- a/observability/src/main/kotlin/com/beat/observability/ObservabilityModuleConfig.kt
+++ b/observability/src/main/kotlin/com/beat/observability/ObservabilityModuleConfig.kt
@@ -3,7 +3,10 @@ package com.beat.observability
 import org.springframework.context.annotation.Configuration
 
 // Marker config for the observability module.
-// Next step: collect logging, metrics, tracing, and actuator-related imports here
-// so runtimes can opt into a single observability boundary explicitly.
+//
+// This import keeps the existing activation semantics: executable modules opt into
+// the observability module boundary, but this config does not component-scan the
+// AOP package yet. When runtime logging aspects are intentionally activated,
+// import that surface here together with a boot/context test.
 @Configuration(proxyBeanMethods = false)
 class ObservabilityModuleConfig

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -198,7 +198,7 @@ class RootRetirementContractTest {
 		assertFalse(ansibleExecWorkflow.contains(
 			"inputs.environment_name == 'dev' && secrets.DEV_SSH_HOST || secrets.PROD_SSH_HOST"));
 		assertFalse(ansibleExecWorkflow.contains("PROD_DOCKER_LOGIN_USERNAME"));
-		assertTrue(setupAnsibleTooling.contains("sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad"));
+		assertTrue(setupAnsibleTooling.contains("sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003"));
 		assertTrue(setupAnsibleTooling.contains("Install verified age"));
 		assertTrue(setupAnsibleTooling.contains("cosign verify-blob"));
 		assertTrue(setupAnsibleTooling.contains("sha256sum -c"));

--- a/src/test/java/com/beat/SharedBoundaryContractTest.java
+++ b/src/test/java/com/beat/SharedBoundaryContractTest.java
@@ -1,12 +1,16 @@
 package com.beat;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +43,8 @@ class SharedBoundaryContractTest {
 
 		assertFalse(Files.exists(Path.of("infra/src/main/java/com/beat/infra/config/RedisConfig.java")));
 		assertFalse(Files.exists(Path.of("gateway/src/main/java/com/beat/gateway/redis/LettuceLockRepository.java")));
-		assertTrue(gatewayRedisConfig.contains("@EnableRedisRepositories(basePackageClasses = RefreshTokenRepository.class)"));
+		assertTrue(
+			gatewayRedisConfig.contains("@EnableRedisRepositories(basePackageClasses = RefreshTokenRepository.class)"));
 		assertFalse(gatewayRedisConfig.contains("@Primary"));
 		assertFalse(gatewayRedisConfig.contains("beatRedisTemplate"));
 		assertTrue(refreshToken.contains("@RedisHash(value = \"refreshToken\", timeToLive = 1209600)"));
@@ -48,16 +53,135 @@ class SharedBoundaryContractTest {
 
 	@Test
 	void infraKeepsDormantRedisCacheSkeletonForFutureSharedCaching() throws Exception {
-		String infraConfigGroup = Files.readString(Path.of("infra/src/main/java/com/beat/infra/InfraBaseConfigGroup.java"));
-		String apisInfraConfig = Files.readString(Path.of("apis/src/main/kotlin/com/beat/apis/config/InfraConfig.kt"));
-		String adminInfraConfig = Files.readString(Path.of("admin/src/main/kotlin/com/beat/admin/config/InfraConfig.kt"));
-		String batchInfraConfig = Files.readString(Path.of("batch/src/main/kotlin/com/beat/batch/config/InfraConfig.kt"));
+		String infraConfigGroup = Files.readString(
+			Path.of("infra/src/main/java/com/beat/infra/InfraBaseConfigGroup.java"));
+		String redisCacheConfig = Files.readString(
+			Path.of("infra/src/main/java/com/beat/infra/config/RedisCacheConfig.java"));
 
 		assertTrue(Files.exists(Path.of("infra/src/main/java/com/beat/infra/config/RedisCacheConfig.java")));
 		assertTrue(infraConfigGroup.contains("REDIS_CACHE(RedisCacheConfig.class)"));
-		assertFalse(apisInfraConfig.contains("InfraBaseConfigGroup.REDIS_CACHE"));
-		assertFalse(adminInfraConfig.contains("InfraBaseConfigGroup.REDIS_CACHE"));
-		assertFalse(batchInfraConfig.contains("InfraBaseConfigGroup.REDIS_CACHE"));
+		assertFalse(redisCacheConfig.contains("@EnableCaching"));
+		assertFalse(redisCacheConfig.contains("org.springframework.cache.CacheManager"));
+		assertFalse(redisCacheConfig.contains("@Bean"));
+
+		List<Path> executableSources = sourceFiles(
+			Path.of("apis/src/main"),
+			Path.of("admin/src/main"),
+			Path.of("batch/src/main")
+		);
+		List<String> violations = executableSources.stream()
+			.filter(path -> contains(path, "InfraBaseConfigGroup.REDIS_CACHE"))
+			.map(Path::toString)
+			.toList();
+
+		assertTrue(
+			violations.isEmpty(),
+			"Executable modules must not opt into dormant REDIS_CACHE yet:\n" + String.join("\n", violations)
+		);
+	}
+
+	@Test
+	void observabilityAopSourcesNoLongerUseLegacyGlobalCommonPackage() throws Exception {
+		Set<String> expectedAopFiles = Set.of(
+			"observability/src/main/java/com/beat/observability/aop/ControllerLoggingAspect.java",
+			"observability/src/main/java/com/beat/observability/aop/ExecutionTimeLoggerAspect.java",
+			"observability/src/main/java/com/beat/observability/aop/Pointcuts.java",
+			"observability/src/main/java/com/beat/observability/aop/ServiceLoggingAspect.java",
+			"observability/src/main/java/com/beat/observability/aop/TxAspect.java"
+		);
+		List<Path> observabilitySources = sourceFiles(Path.of("observability/src/main"));
+		List<String> violations = observabilitySources.stream()
+			.filter(path -> contains(path, "com.beat.global.common.aop"))
+			.map(Path::toString)
+			.toList();
+		Set<String> actualAopFiles = sourceFiles(
+			Path.of("observability/src/main/java/com/beat/observability/aop")).stream()
+			.map(path -> path.toString().replace('\\', '/'))
+			.collect(Collectors.toSet());
+		String pointcuts = Files.readString(
+			Path.of("observability/src/main/java/com/beat/observability/aop/Pointcuts.java"));
+
+		assertFalse(Files.exists(Path.of("observability/src/main/java/com/beat/global/common/aop")));
+		assertEquals(expectedAopFiles, actualAopFiles);
+		assertTrue(violations.isEmpty(),
+			"Found legacy observability AOP package references:\n" + String.join("\n", violations));
+		assertTrue(pointcuts.contains("!within(com.beat.global..*)"));
+		assertTrue(pointcuts.contains("!within(com.beat.observability..*)"));
+	}
+
+	@Test
+	void observabilityModuleConfigDoesNotActivateAopSurfaceImplicitly() throws Exception {
+		String moduleConfig = Files.readString(
+			Path.of("observability/src/main/kotlin/com/beat/observability/ObservabilityModuleConfig.kt"));
+		String uncommentedModuleConfig = stripComments(moduleConfig);
+
+		assertFalse(uncommentedModuleConfig.contains("@ComponentScan"));
+		assertFalse(uncommentedModuleConfig.contains("@Import"));
+	}
+
+	@Test
+	void infraDomainPackageResidueIsLimitedToKnownDeferredQueryImplementations() throws Exception {
+		Set<String> allowedResidue = Set.of(
+			"infra/src/main/java/com/beat/domain/booking/dao/TicketRepositoryCustomImpl.java",
+			"infra/src/main/java/com/beat/domain/schedule/dao/ScheduleRepositoryCustomImpl.java"
+		);
+
+		Set<String> actualResidue = sourceFiles(Path.of("infra/src/main")).stream()
+			.filter(path -> contains(path, "package com.beat.domain."))
+			.map(path -> path.toString().replace('\\', '/'))
+			.collect(Collectors.toSet());
+
+		assertEquals(allowedResidue, actualResidue);
+	}
+
+	@Test
+	void moduleContractsStayImplementationFreeJavaContracts() throws Exception {
+		String buildFile = Files.readString(Path.of("module-contracts/build.gradle.kts"));
+		List<String> forbiddenReferences = List.of(
+			"@Component",
+			"@Service",
+			"@Repository",
+			"@Configuration",
+			"jakarta.persistence.",
+			"org.springframework.data.redis.",
+			"com.beat.apis.",
+			"com.beat.admin.",
+			"com.beat.batch.",
+			"com.beat.infra.",
+			"com.beat.gateway."
+		);
+
+		List<String> violations = sourceFiles(Path.of("module-contracts/src/main")).stream()
+			.flatMap(path -> forbiddenReferences.stream()
+				.filter(pattern -> contains(path, pattern))
+				.map(pattern -> path + ": " + pattern))
+			.toList();
+
+		assertTrue(buildFile.contains("compileOnly(project(\":domain\"))"));
+		assertTrue(buildFile.contains("compileOnly(project(\":global-utils\"))"));
+		assertFalse(buildFile.contains("implementation(project(\":domain\"))"));
+		assertFalse(buildFile.contains("implementation(project(\":global-utils\"))"));
+		assertTrue(
+			violations.isEmpty(),
+			"Found forbidden module-contracts implementation references:\n" + String.join("\n", violations)
+		);
+	}
+
+	@Test
+	void moduleContractsDomainTypeCouplingIsExplicitAndBounded() throws Exception {
+		Set<String> allowedDomainImports = Set.of(
+			"module-contracts/src/main/java/com/beat/contracts/auth/social/SocialLoginCommand.java: import com.beat.domain.member.domain.SocialType;",
+			"module-contracts/src/main/java/com/beat/contracts/auth/social/SocialMemberInfo.java: import com.beat.domain.member.domain.SocialType;",
+			"module-contracts/src/main/java/com/beat/contracts/schedule/ScheduleJobPort.java: import com.beat.domain.schedule.domain.Schedule;"
+		);
+
+		Set<String> actualDomainImports = sourceFiles(Path.of("module-contracts/src/main")).stream()
+			.flatMap(path -> readLines(path).stream()
+				.filter(line -> line.startsWith("import com.beat.domain."))
+				.map(line -> path.toString().replace('\\', '/') + ": " + line))
+			.collect(Collectors.toSet());
+
+		assertEquals(allowedDomainImports, actualDomainImports);
 	}
 
 	@Test
@@ -107,5 +231,35 @@ class SharedBoundaryContractTest {
 		} catch (IOException exception) {
 			throw new IllegalStateException("Failed to read " + path, exception);
 		}
+	}
+
+	private List<String> readLines(Path path) {
+		try {
+			return Files.readAllLines(path);
+		} catch (IOException exception) {
+			throw new IllegalStateException("Failed to read " + path, exception);
+		}
+	}
+
+	private String stripComments(String source) {
+		return source
+			.replaceAll("(?s)/\\*.*?\\*/", "")
+			.replaceAll("(?m)//.*$", "");
+	}
+
+	private List<Path> sourceFiles(Path... roots) throws IOException {
+		List<Path> result = new ArrayList<>();
+		for (Path root : roots) {
+			if (!Files.exists(root)) {
+				continue;
+			}
+			try (var paths = Files.walk(root)) {
+				paths
+					.filter(Files::isRegularFile)
+					.filter(path -> path.toString().endsWith(".java") || path.toString().endsWith(".kt"))
+					.forEach(result::add);
+			}
+		}
+		return result;
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

- closes #378

## Work Description ✏️

- Kotlin migration 전에 shared module의 ownership/package 기준을 정리했습니다.
- observability AOP 파일을 com.beat.global.common.aop에서 com.beat.observability.aop로 이동했습니다.
- infra 내부 com.beat.domain.*.dao query impl 2개는 #380/#381에서 처리할 deferred exception으로 문서화했습니다.
- RedisCacheConfig / REDIS_CACHE는 infra 소유 dormant shared cache extension point로 유지하고, 활성화 조건을 문서화했습니다.
- module-contracts는 Kotlin 전환하지 않고 Java contract source로 유지하기로 결정했습니다.
- MIGRATION.md와 shared module README들을 현재 상태 / 목표 / 후속 이슈 기준으로 동기화했습니다.
- SharedBoundaryContractTest에 shared boundary guard를 추가/강화했습니다.

## Trouble Shooting ⚽️

- observability AOP package rename이 runtime activation semantics를 바꿀 수 있어, ObservabilityModuleConfig는 marker-only로 유지했습니다.
- infra query impl package move는 Spring Data custom fragment discovery / JpaConfig scan과 결합되어 있어 이번 PR에서 이동하지 않았습니다.
- module-contracts는 일부 domain type을 compileOnly로 참조하고 있어, 현재 허용 import를 allowlist로 고정하고 후속에서 contract-local type 전환을 검토하도록 남겼습니다.

## Related ScreenShot 📷

- 없음

## Uncompleted Tasks 😅

- infra query impl package 실제 이동은 #380/#381에서 처리합니다.
- observability AOP runtime activation/import 정책은 별도 boot/context test와 함께 후속에서 다룹니다.
- shared Redis cache 실제 활성화 정책은 구체적인 cache name / TTL / serializer / namespace / invalidation policy가 정해질 때 후속으로 진행합니다.
- module-contracts의 domain-coupled type 축소는 후속으로 검토합니다.

## To Reviewers 📢

- 이번 PR은 Kotlin 전환 자체가 아니라, Kotlin migration 전에 shared module ownership/package 기준을 고정하는 작업입니다.
- infra query impl package move는 의도적으로 defer했습니다. 단순 package move가 아니라 Spring Data repository discovery와 함께 봐야 해서 #380/#381 범위로 남겼습니다.
- .github/workflows/* 액션 버전 갱신 커밋도 포함되어 있습니다.