### PR TITLE
fix: nginx upstream ownership decoupling으로 shared deploy coupling 완화

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -78,20 +78,21 @@ jobs:
 
           event_name = os.environ["EVENT_NAME"]
           requested = os.environ.get("INPUT_MODULE") or "all"
+          preferred_order = ["admin", "apis", "batch"]
           modules = []
 
           if event_name == "workflow_dispatch":
-              modules = ["apis", "admin", "batch"] if requested == "all" else [requested]
+              modules = preferred_order if requested == "all" else [requested]
           else:
               if os.environ["SHARED"] == "true":
-                  modules = ["apis", "admin", "batch"]
+                  modules = preferred_order
               else:
-                  if os.environ["APIS"] == "true":
-                      modules.append("apis")
-                  if os.environ["ADMIN"] == "true":
-                      modules.append("admin")
-                  if os.environ["BATCH"] == "true":
-                      modules.append("batch")
+                  selected_modules = {
+                      "admin": os.environ["ADMIN"] == "true",
+                      "apis": os.environ["APIS"] == "true",
+                      "batch": os.environ["BATCH"] == "true",
+                  }
+                  modules = [module for module in preferred_order if selected_modules[module]]
 
           matrix = {"include": [{"module": module} for module in modules]}
           github_output = os.environ["GITHUB_OUTPUT"]

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
             exit 1
           fi
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-          echo 'module_matrix={"include":[{"module":"apis"},{"module":"admin"},{"module":"batch"}]}' >> "$GITHUB_OUTPUT"
+          echo 'module_matrix={"include":[{"module":"admin"},{"module":"apis"},{"module":"batch"}]}' >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/infra/README.md
+++ b/infra/README.md
@@ -496,10 +496,10 @@ flowchart LR
         Root["location / { proxy_pass backend }"]
     end
 
-    subgraph Upstreams["00-managed.conf"]
-        B["upstream backend { apis-blue:4001 }"]
-        AB["upstream admin_backend { admin:4000 }"]
-        AC["upstream actuator { apis-blue:port }"]
+    subgraph Upstreams["generated/upstreams/*.conf"]
+        B["backend.conf -> upstream backend { apis-blue:4001 }"]
+        AB["admin_backend.conf -> upstream admin_backend { admin:4000 }"]
+        AC["actuator.conf -> upstream actuator { apis-blue:port }"]
     end
 
     subgraph Routes["10-managed.conf"]
@@ -527,13 +527,17 @@ flowchart LR
 └── nginx/
     ├── default.conf                        # 후보 설정 (source, 다음 promotion 입력)
     └── generated/
-        ├── upstreams/00-managed.conf       # upstream fragment (source, helper가 갱신)
+        ├── upstreams/backend.conf          # backend upstream fragment (source)
+        ├── upstreams/admin_backend.conf    # admin upstream fragment (source)
+        ├── upstreams/actuator.conf         # actuator upstream fragment (source)
         └── routes/10-managed.conf          # route fragment (source, helper가 갱신)
 
 /var/lib/docker/volumes/nginx-config-volume/_data/
 ├── conf.d/default.conf                     # 실제 적용 설정 (target, 현재 live)
 └── generated/
-    ├── upstreams/00-managed.conf           # upstream fragment (target, 현재 live)
+    ├── upstreams/backend.conf              # backend upstream fragment (target, 현재 live)
+    ├── upstreams/admin_backend.conf        # admin upstream fragment (target, 현재 live)
+    ├── upstreams/actuator.conf             # actuator upstream fragment (target, 현재 live)
     └── routes/10-managed.conf              # route fragment (target, 현재 live)
 
 /opt/beat/

--- a/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
+++ b/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
@@ -3,6 +3,11 @@
   ansible.builtin.import_role:
     name: nginx_config_helper
 
+- name: Migrate legacy shared upstream fragment before blue-green switch
+  ansible.builtin.import_role:
+    name: nginx_config_helper
+    tasks_from: migrate_legacy_upstreams.yml
+
 - name: Resolve blue-green rollout paths
   ansible.builtin.set_fact:
     app_bluegreen_active_slot_file: "{{ release_dir }}/current-slot"

--- a/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
+++ b/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
@@ -335,13 +335,13 @@
 
     - name: Restore previous managed upstream target from backup
       ansible.builtin.copy:
-        src: "{{ item.path }}.bak"
-        dest: "{{ item.path }}"
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
         remote_src: true
         mode: "0644"
       loop:
-        - { path: "{{ app_bluegreen_backend_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[0].stat.exists }}" }
-        - { path: "{{ app_bluegreen_actuator_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[1].stat.exists }}" }
+        - { src: "{{ app_bluegreen_backend_upstream_source_path }}.bak", dest: "{{ app_bluegreen_backend_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[0].stat.exists }}" }
+        - { src: "{{ app_bluegreen_actuator_upstream_source_path }}.bak", dest: "{{ app_bluegreen_actuator_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[1].stat.exists }}" }
       when: item.stat_exists | bool
 
     - name: Remove managed upstream fragment if no backup existed

--- a/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
+++ b/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
@@ -6,10 +6,11 @@
 - name: Resolve blue-green rollout paths
   ansible.builtin.set_fact:
     app_bluegreen_active_slot_file: "{{ release_dir }}/current-slot"
-    app_bluegreen_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
-    app_bluegreen_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+    app_bluegreen_backend_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/backend.conf"
+    app_bluegreen_backend_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/backend.conf"
+    app_bluegreen_actuator_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/actuator.conf"
+    app_bluegreen_actuator_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/actuator.conf"
     app_bluegreen_conf_backup_path: "{{ nginx_conf_source_path }}.bak"
-    app_bluegreen_upstream_backup_path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
 
 - name: Ensure release directory exists for blue-green rollout
   ansible.builtin.file:
@@ -88,22 +89,27 @@
 
 - name: Check existing managed upstream fragment
   ansible.builtin.stat:
-    path: "{{ app_bluegreen_upstream_source_path }}"
-  register: app_bluegreen_upstream_source_stat
+    path: "{{ item }}"
+  loop:
+    - "{{ app_bluegreen_backend_upstream_source_path }}"
+    - "{{ app_bluegreen_actuator_upstream_source_path }}"
+  register: app_bluegreen_upstream_source_stats
 
 - name: Backup current managed upstream fragment
   ansible.builtin.copy:
-    src: "{{ app_bluegreen_upstream_source_path }}"
-    dest: "{{ app_bluegreen_upstream_backup_path }}"
+    src: "{{ item.path }}"
+    dest: "{{ item.path }}.bak"
     remote_src: true
     mode: "0644"
-  when: app_bluegreen_upstream_source_stat.stat.exists
+  when: item.stat.exists
+  loop: "{{ app_bluegreen_upstream_source_stats.results }}"
 
 - name: Clear stale managed upstream backup when source missing
   ansible.builtin.file:
-    path: "{{ app_bluegreen_upstream_backup_path }}"
+    path: "{{ item.path }}.bak"
     state: absent
-  when: not app_bluegreen_upstream_source_stat.stat.exists
+  when: not item.stat.exists
+  loop: "{{ app_bluegreen_upstream_source_stats.results }}"
 
 - name: Run blue-green rollout
   block:
@@ -181,7 +187,7 @@
           - "{{ deployment_dir }}/update-nginx-config.py"
           - upsert-upstream
           - --path
-          - "{{ app_bluegreen_upstream_source_path }}"
+          - "{{ app_bluegreen_backend_upstream_source_path }}"
           - --upstream-name
           - "{{ module_cfg.backend_upstream_name }}"
           - --container-name
@@ -198,7 +204,7 @@
           - "{{ deployment_dir }}/update-nginx-config.py"
           - upsert-upstream
           - --path
-          - "{{ app_bluegreen_upstream_source_path }}"
+          - "{{ app_bluegreen_actuator_upstream_source_path }}"
           - --upstream-name
           - "{{ actuator_upstream_name }}"
           - --container-name
@@ -208,13 +214,16 @@
       register: app_bluegreen_actuator_upstream_result
       changed_when: "'changed=true' in app_bluegreen_actuator_upstream_result.stdout"
 
-    - name: Sync managed backend upstream fragment to target
+    - name: Sync managed upstream fragments to target
       ansible.builtin.copy:
-        src: "{{ app_bluegreen_upstream_source_path }}"
-        dest: "{{ app_bluegreen_upstream_target_path }}"
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
         remote_src: true
         mode: "0644"
-      register: app_bluegreen_upstream_target_sync_result
+      loop:
+        - { src: "{{ app_bluegreen_backend_upstream_source_path }}", dest: "{{ app_bluegreen_backend_upstream_target_path }}" }
+        - { src: "{{ app_bluegreen_actuator_upstream_source_path }}", dest: "{{ app_bluegreen_actuator_upstream_target_path }}" }
+      register: app_bluegreen_upstream_target_sync_results
 
     - name: Validate nginx config after upstream switch
       ansible.builtin.command:
@@ -235,7 +244,7 @@
             or app_bluegreen_nginx_target_sync_result.changed
             or app_bluegreen_backend_upstream_result.changed
             or app_bluegreen_actuator_upstream_result.changed
-            or app_bluegreen_upstream_target_sync_result.changed
+            or (app_bluegreen_upstream_target_sync_results.results | selectattr('changed') | list | length > 0)
           }}
 
     - name: Reload nginx after upstream switch
@@ -317,28 +326,34 @@
 
     - name: Restore previous managed upstream fragment from backup
       ansible.builtin.copy:
-        src: "{{ app_bluegreen_upstream_backup_path }}"
-        dest: "{{ app_bluegreen_upstream_source_path }}"
+        src: "{{ item.path }}.bak"
+        dest: "{{ item.path }}"
         remote_src: true
         mode: "0644"
-      when: app_bluegreen_upstream_source_stat.stat.exists
+      when: item.stat.exists
+      loop: "{{ app_bluegreen_upstream_source_stats.results }}"
 
     - name: Restore previous managed upstream target from backup
       ansible.builtin.copy:
-        src: "{{ app_bluegreen_upstream_backup_path }}"
-        dest: "{{ app_bluegreen_upstream_target_path }}"
+        src: "{{ item.path }}.bak"
+        dest: "{{ item.path }}"
         remote_src: true
         mode: "0644"
-      when: app_bluegreen_upstream_source_stat.stat.exists
+      loop:
+        - { path: "{{ app_bluegreen_backend_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[0].stat.exists }}" }
+        - { path: "{{ app_bluegreen_actuator_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[1].stat.exists }}" }
+      when: item.stat_exists | bool
 
     - name: Remove managed upstream fragment if no backup existed
       ansible.builtin.file:
-        path: "{{ item }}"
+        path: "{{ item.path }}"
         state: absent
       loop:
-        - "{{ app_bluegreen_upstream_source_path }}"
-        - "{{ app_bluegreen_upstream_target_path }}"
-      when: not app_bluegreen_upstream_source_stat.stat.exists
+        - { path: "{{ app_bluegreen_backend_upstream_source_path }}", exists: "{{ app_bluegreen_upstream_source_stats.results[0].stat.exists }}" }
+        - { path: "{{ app_bluegreen_backend_upstream_target_path }}", exists: "{{ app_bluegreen_upstream_source_stats.results[0].stat.exists }}" }
+        - { path: "{{ app_bluegreen_actuator_upstream_source_path }}", exists: "{{ app_bluegreen_upstream_source_stats.results[1].stat.exists }}" }
+        - { path: "{{ app_bluegreen_actuator_upstream_target_path }}", exists: "{{ app_bluegreen_upstream_source_stats.results[1].stat.exists }}" }
+      when: not (item.exists | bool)
 
     - name: Validate restored nginx config
       ansible.builtin.command:

--- a/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
+++ b/infra/ansible/roles/app_bluegreen/tasks/run_switch.yml
@@ -340,8 +340,12 @@
         remote_src: true
         mode: "0644"
       loop:
-        - { src: "{{ app_bluegreen_backend_upstream_source_path }}.bak", dest: "{{ app_bluegreen_backend_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[0].stat.exists }}" }
-        - { src: "{{ app_bluegreen_actuator_upstream_source_path }}.bak", dest: "{{ app_bluegreen_actuator_upstream_target_path }}", stat_exists: "{{ app_bluegreen_upstream_source_stats.results[1].stat.exists }}" }
+        - src: "{{ app_bluegreen_backend_upstream_source_path }}.bak"
+          dest: "{{ app_bluegreen_backend_upstream_target_path }}"
+          stat_exists: "{{ app_bluegreen_upstream_source_stats.results[0].stat.exists }}"
+        - src: "{{ app_bluegreen_actuator_upstream_source_path }}.bak"
+          dest: "{{ app_bluegreen_actuator_upstream_target_path }}"
+          stat_exists: "{{ app_bluegreen_upstream_source_stats.results[1].stat.exists }}"
       when: item.stat_exists | bool
 
     - name: Remove managed upstream fragment if no backup existed

--- a/infra/ansible/roles/app_stopstart/tasks/admin_nginx_route.yml
+++ b/infra/ansible/roles/app_stopstart/tasks/admin_nginx_route.yml
@@ -3,14 +3,21 @@
   ansible.builtin.import_role:
     name: nginx_config_helper
 
+- name: Resolve admin nginx fragment paths
+  ansible.builtin.set_fact:
+    app_stopstart_admin_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/admin_backend.conf"
+    app_stopstart_admin_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/admin_backend.conf"
+    app_stopstart_admin_route_source_path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+    app_stopstart_admin_route_target_path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+
 - name: Check current admin upstream source fragment
   ansible.builtin.stat:
-    path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+    path: "{{ app_stopstart_admin_upstream_source_path }}"
   register: app_stopstart_upstream_source_stat
 
 - name: Check current admin route source fragment
   ansible.builtin.stat:
-    path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+    path: "{{ app_stopstart_admin_route_source_path }}"
   register: app_stopstart_route_source_stat
 
 - name: Check current live nginx source config
@@ -20,12 +27,12 @@
 
 - name: Check current admin upstream target fragment
   ansible.builtin.stat:
-    path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+    path: "{{ app_stopstart_admin_upstream_target_path }}"
   register: app_stopstart_upstream_target_stat
 
 - name: Check current admin route target fragment
   ansible.builtin.stat:
-    path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+    path: "{{ app_stopstart_admin_route_target_path }}"
   register: app_stopstart_route_target_stat
 
 - name: Check current live nginx target config
@@ -35,29 +42,29 @@
 
 - name: Backup current admin upstream source fragment
   ansible.builtin.copy:
-    src: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
-    dest: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
+    src: "{{ app_stopstart_admin_upstream_source_path }}"
+    dest: "{{ app_stopstart_admin_upstream_source_path }}.bak"
     remote_src: true
     mode: "0644"
   when: app_stopstart_upstream_source_stat.stat.exists
 
 - name: Clear stale admin upstream source backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
+    path: "{{ app_stopstart_admin_upstream_source_path }}.bak"
     state: absent
   when: not app_stopstart_upstream_source_stat.stat.exists
 
 - name: Backup current admin route source fragment
   ansible.builtin.copy:
-    src: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
-    dest: "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
+    src: "{{ app_stopstart_admin_route_source_path }}"
+    dest: "{{ app_stopstart_admin_route_source_path }}.bak"
     remote_src: true
     mode: "0644"
   when: app_stopstart_route_source_stat.stat.exists
 
 - name: Clear stale admin route source backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
+    path: "{{ app_stopstart_admin_route_source_path }}.bak"
     state: absent
   when: not app_stopstart_route_source_stat.stat.exists
 
@@ -77,29 +84,29 @@
 
 - name: Backup current admin upstream target fragment
   ansible.builtin.copy:
-    src: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
-    dest: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
+    src: "{{ app_stopstart_admin_upstream_target_path }}"
+    dest: "{{ app_stopstart_admin_upstream_target_path }}.bak"
     remote_src: true
     mode: "0644"
   when: app_stopstart_upstream_target_stat.stat.exists
 
 - name: Clear stale admin upstream target backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
+    path: "{{ app_stopstart_admin_upstream_target_path }}.bak"
     state: absent
   when: not app_stopstart_upstream_target_stat.stat.exists
 
 - name: Backup current admin route target fragment
   ansible.builtin.copy:
-    src: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
-    dest: "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
+    src: "{{ app_stopstart_admin_route_target_path }}"
+    dest: "{{ app_stopstart_admin_route_target_path }}.bak"
     remote_src: true
     mode: "0644"
   when: app_stopstart_route_target_stat.stat.exists
 
 - name: Clear stale admin route target backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
+    path: "{{ app_stopstart_admin_route_target_path }}.bak"
     state: absent
   when: not app_stopstart_route_target_stat.stat.exists
 
@@ -141,7 +148,7 @@
           - "{{ deployment_dir }}/update-nginx-config.py"
           - upsert-upstream
           - --path
-          - "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+          - "{{ app_stopstart_admin_upstream_source_path }}"
           - --upstream-name
           - "{{ module_cfg.nginx_route.upstream_name }}"
           - --container-name
@@ -158,7 +165,7 @@
           - "{{ deployment_dir }}/update-nginx-config.py"
           - ensure-route
           - --path
-          - "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+          - "{{ app_stopstart_admin_route_source_path }}"
           - --upstream-name
           - "{{ module_cfg.nginx_route.upstream_name }}"
           - --external-path
@@ -170,16 +177,16 @@
 
     - name: Sync generated nginx upstream fragment to target
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
-        dest: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+        src: "{{ app_stopstart_admin_upstream_source_path }}"
+        dest: "{{ app_stopstart_admin_upstream_target_path }}"
         remote_src: true
         mode: "0644"
       register: app_stopstart_upstream_sync_result
 
     - name: Sync generated nginx route fragment to target
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
-        dest: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+        src: "{{ app_stopstart_admin_route_source_path }}"
+        dest: "{{ app_stopstart_admin_route_target_path }}"
         remote_src: true
         mode: "0644"
       register: app_stopstart_route_sync_result
@@ -233,44 +240,44 @@
 
     - name: Restore previous admin upstream source fragment
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
-        dest: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+        src: "{{ app_stopstart_admin_upstream_source_path }}.bak"
+        dest: "{{ app_stopstart_admin_upstream_source_path }}"
         remote_src: true
         mode: "0644"
       when: app_stopstart_upstream_source_stat.stat.exists
 
     - name: Restore previous admin route source fragment
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
-        dest: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+        src: "{{ app_stopstart_admin_route_source_path }}.bak"
+        dest: "{{ app_stopstart_admin_route_source_path }}"
         remote_src: true
         mode: "0644"
       when: app_stopstart_route_source_stat.stat.exists
 
     - name: Remove admin upstream source fragment if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+        path: "{{ app_stopstart_admin_upstream_source_path }}"
         state: absent
       when: not app_stopstart_upstream_source_stat.stat.exists
 
     - name: Remove admin route source fragment if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+        path: "{{ app_stopstart_admin_route_source_path }}"
         state: absent
       when: not app_stopstart_route_source_stat.stat.exists
 
     - name: Restore previous admin upstream target fragment
       ansible.builtin.copy:
-        src: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
-        dest: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+        src: "{{ app_stopstart_admin_upstream_target_path }}.bak"
+        dest: "{{ app_stopstart_admin_upstream_target_path }}"
         remote_src: true
         mode: "0644"
       when: app_stopstart_upstream_target_stat.stat.exists
 
     - name: Restore previous admin route target fragment
       ansible.builtin.copy:
-        src: "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
-        dest: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+        src: "{{ app_stopstart_admin_route_target_path }}.bak"
+        dest: "{{ app_stopstart_admin_route_target_path }}"
         remote_src: true
         mode: "0644"
       when: app_stopstart_route_target_stat.stat.exists
@@ -285,13 +292,13 @@
 
     - name: Remove admin upstream target fragment if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+        path: "{{ app_stopstart_admin_upstream_target_path }}"
         state: absent
       when: not app_stopstart_upstream_target_stat.stat.exists
 
     - name: Remove admin route target fragment if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+        path: "{{ app_stopstart_admin_route_target_path }}"
         state: absent
       when: not app_stopstart_route_target_stat.stat.exists
 
@@ -321,9 +328,9 @@
     path: "{{ item }}"
     state: absent
   loop:
-    - "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
-    - "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
+    - "{{ app_stopstart_admin_upstream_source_path }}.bak"
+    - "{{ app_stopstart_admin_route_source_path }}.bak"
     - "{{ nginx_conf_source_path }}.bak"
-    - "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
-    - "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
+    - "{{ app_stopstart_admin_upstream_target_path }}.bak"
+    - "{{ app_stopstart_admin_route_target_path }}.bak"
     - "{{ nginx_conf_target_path }}.bak"

--- a/infra/ansible/roles/app_stopstart/tasks/admin_nginx_route.yml
+++ b/infra/ansible/roles/app_stopstart/tasks/admin_nginx_route.yml
@@ -3,6 +3,11 @@
   ansible.builtin.import_role:
     name: nginx_config_helper
 
+- name: Migrate legacy shared upstream fragment before admin route update
+  ansible.builtin.import_role:
+    name: nginx_config_helper
+    tasks_from: migrate_legacy_upstreams.yml
+
 - name: Resolve admin nginx fragment paths
   ansible.builtin.set_fact:
     app_stopstart_admin_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/admin_backend.conf"

--- a/infra/ansible/roles/nginx_base_config/tasks/main.yml
+++ b/infra/ansible/roles/nginx_base_config/tasks/main.yml
@@ -11,6 +11,8 @@
     nginx_backend_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/backend.conf"
     nginx_admin_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/admin_backend.conf"
     nginx_actuator_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/actuator.conf"
+    nginx_legacy_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+    nginx_legacy_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
     nginx_route_source_path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
     nginx_route_target_path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
 
@@ -63,6 +65,11 @@
     - { name: "actuator", path: "{{ nginx_actuator_upstream_source_path }}" }
   register: nginx_base_config_upstream_source_stats
 
+- name: Check current legacy upstream fragment source
+  ansible.builtin.stat:
+    path: "{{ nginx_legacy_upstream_source_path }}"
+  register: nginx_base_config_legacy_upstream_source_stat
+
 - name: Check if route fragment already exists (deployed server)
   ansible.builtin.stat:
     path: "{{ nginx_route_source_path }}"
@@ -76,6 +83,11 @@
     - { name: "admin", path: "{{ nginx_admin_upstream_target_path }}" }
     - { name: "actuator", path: "{{ nginx_actuator_upstream_target_path }}" }
   register: nginx_base_config_upstream_target_stats
+
+- name: Check current legacy upstream fragment target
+  ansible.builtin.stat:
+    path: "{{ nginx_legacy_upstream_target_path }}"
+  register: nginx_base_config_legacy_upstream_target_stat
 
 - name: Check current route fragment target
   ansible.builtin.stat:
@@ -101,12 +113,16 @@
       - "Would backup {{ nginx_backend_upstream_source_path }} to {{ nginx_backend_upstream_source_path }}.bak"
       - "Would backup {{ nginx_admin_upstream_source_path }} to {{ nginx_admin_upstream_source_path }}.bak"
       - "Would backup {{ nginx_actuator_upstream_source_path }} to {{ nginx_actuator_upstream_source_path }}.bak"
+      - "Would backup {{ nginx_legacy_upstream_source_path }} to {{ nginx_legacy_upstream_source_path }}.bak"
       - "Would backup {{ nginx_route_source_path }} to {{ nginx_route_source_path }}.bak"
       - "Would backup {{ nginx_backend_upstream_target_path }} to {{ nginx_backend_upstream_target_path }}.bak"
       - "Would backup {{ nginx_admin_upstream_target_path }} to {{ nginx_admin_upstream_target_path }}.bak"
       - "Would backup {{ nginx_actuator_upstream_target_path }} to {{ nginx_actuator_upstream_target_path }}.bak"
+      - "Would backup {{ nginx_legacy_upstream_target_path }} to {{ nginx_legacy_upstream_target_path }}.bak"
       - "Would backup {{ nginx_route_target_path }} to {{ nginx_route_target_path }}.bak"
       - "Would backup {{ nginx_conf_target_path }} to {{ nginx_conf_target_path }}.bak"
+      - "Would split legacy upstreams/00-managed.conf into per-upstream fragments when present"
+      - "Would remove legacy upstreams/00-managed.conf before nginx validation"
       - "Would render {{ deployment_dir }}/nginx/default.conf and sync generated fragments to target"
       - "Would validate with docker exec {{ nginx_container_name }} nginx -t"
       - "Would reload nginx on validation success"
@@ -150,6 +166,24 @@
     - not item.stat.exists
   loop: "{{ nginx_base_config_upstream_source_stats.results }}"
 
+- name: Backup current legacy upstream fragment source
+  ansible.builtin.copy:
+    src: "{{ nginx_legacy_upstream_source_path }}"
+    dest: "{{ nginx_legacy_upstream_source_path }}.bak"
+    remote_src: true
+    mode: "0644"
+  when:
+    - not ansible_check_mode
+    - nginx_base_config_legacy_upstream_source_stat.stat.exists
+
+- name: Clear stale legacy upstream fragment source backup when file missing
+  ansible.builtin.file:
+    path: "{{ nginx_legacy_upstream_source_path }}.bak"
+    state: absent
+  when:
+    - not ansible_check_mode
+    - not nginx_base_config_legacy_upstream_source_stat.stat.exists
+
 - name: Backup current route fragment source
   ansible.builtin.copy:
     src: "{{ nginx_route_source_path }}"
@@ -188,6 +222,24 @@
     - not item.stat.exists
   loop: "{{ nginx_base_config_upstream_target_stats.results }}"
 
+- name: Backup current legacy upstream fragment target
+  ansible.builtin.copy:
+    src: "{{ nginx_legacy_upstream_target_path }}"
+    dest: "{{ nginx_legacy_upstream_target_path }}.bak"
+    remote_src: true
+    mode: "0644"
+  when:
+    - not ansible_check_mode
+    - nginx_base_config_legacy_upstream_target_stat.stat.exists
+
+- name: Clear stale legacy upstream fragment target backup when file missing
+  ansible.builtin.file:
+    path: "{{ nginx_legacy_upstream_target_path }}.bak"
+    state: absent
+  when:
+    - not ansible_check_mode
+    - not nginx_base_config_legacy_upstream_target_stat.stat.exists
+
 - name: Backup current route fragment target
   ansible.builtin.copy:
     src: "{{ nginx_route_target_path }}"
@@ -223,8 +275,73 @@
         dest: "{{ deployment_dir }}/nginx/default.conf"
         mode: "0644"
 
+    - name: Split legacy upstream source into per-upstream fragments
+      ansible.builtin.command:
+        argv:
+          - python3
+          - "{{ deployment_dir }}/update-nginx-config.py"
+          - split-upstreams
+          - --source
+          - "{{ nginx_legacy_upstream_source_path }}"
+          - --output-dir
+          - "{{ nginx_generated_source_dir }}/upstreams"
+          - --mapping
+          - "{{ backend_upstream_name | default('backend') }}=backend.conf"
+          - --mapping
+          - "{{ admin_upstream_name | default('admin_backend') }}=admin_backend.conf"
+          - --mapping
+          - "{{ actuator_upstream_name | default('actuator') }}=actuator.conf"
+          - --require-all
+          - --skip-existing
+      register: nginx_base_config_split_legacy_upstream_result
+      changed_when: "'changed=true' in nginx_base_config_split_legacy_upstream_result.stdout"
+      when: nginx_base_config_legacy_upstream_source_stat.stat.exists
+
+    - name: Remove legacy upstream source after split migration
+      ansible.builtin.file:
+        path: "{{ nginx_legacy_upstream_source_path }}"
+        state: absent
+      register: nginx_base_config_legacy_upstream_source_remove_result
+      when: nginx_base_config_legacy_upstream_source_stat.stat.exists
+
+    - name: Check upstream fragments after legacy migration
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      loop:
+        - { name: "backend", path: "{{ nginx_backend_upstream_source_path }}" }
+        - { name: "admin", path: "{{ nginx_admin_upstream_source_path }}" }
+        - { name: "actuator", path: "{{ nginx_actuator_upstream_source_path }}" }
+      register: nginx_base_config_upstream_source_current_stats
+
+    - name: Resolve upstream source existence after migration
+      ansible.builtin.set_fact:
+        nginx_base_config_backend_source_exists: >-
+          {{
+            nginx_base_config_upstream_source_current_stats.results
+            | selectattr('item.name', 'equalto', 'backend')
+            | map(attribute='stat.exists')
+            | first
+            | default(false)
+          }}
+        nginx_base_config_admin_source_exists: >-
+          {{
+            nginx_base_config_upstream_source_current_stats.results
+            | selectattr('item.name', 'equalto', 'admin')
+            | map(attribute='stat.exists')
+            | first
+            | default(false)
+          }}
+        nginx_base_config_actuator_source_exists: >-
+          {{
+            nginx_base_config_upstream_source_current_stats.results
+            | selectattr('item.name', 'equalto', 'actuator')
+            | map(attribute='stat.exists')
+            | first
+            | default(false)
+          }}
+
     - name: Seed backend upstream fragment when missing
-      when: not nginx_base_config_upstream_source_stats.results[0].stat.exists
+      when: not (nginx_base_config_backend_source_exists | bool)
       block:
         - name: Seed backend upstream marker in source fragment
           ansible.builtin.command:
@@ -244,7 +361,7 @@
           changed_when: "'changed=true' in nginx_base_config_seed_backend_upstream_result.stdout"
 
     - name: Seed admin upstream fragment when missing
-      when: not nginx_base_config_upstream_source_stats.results[1].stat.exists
+      when: not (nginx_base_config_admin_source_exists | bool)
       block:
         - name: Seed admin upstream marker in source fragment
           ansible.builtin.command:
@@ -264,7 +381,7 @@
           changed_when: "'changed=true' in nginx_base_config_seed_admin_upstream_result.stdout"
 
     - name: Seed actuator upstream fragment when missing
-      when: not nginx_base_config_upstream_source_stats.results[2].stat.exists
+      when: not (nginx_base_config_actuator_source_exists | bool)
       block:
         - name: Seed actuator upstream marker in source fragment
           ansible.builtin.command:
@@ -315,6 +432,13 @@
         - { src: "{{ nginx_actuator_upstream_source_path }}", dest: "{{ nginx_actuator_upstream_target_path }}" }
       register: nginx_base_config_upstream_target_sync_results
 
+    - name: Remove legacy upstream target before nginx validation
+      ansible.builtin.file:
+        path: "{{ nginx_legacy_upstream_target_path }}"
+        state: absent
+      register: nginx_base_config_legacy_upstream_target_remove_result
+      when: nginx_base_config_legacy_upstream_target_stat.stat.exists
+
     - name: Sync route fragment to target
       ansible.builtin.copy:
         src: "{{ nginx_route_source_path }}"
@@ -350,6 +474,10 @@
             or (
               nginx_base_config_upstream_target_sync_results is defined
               and (nginx_base_config_upstream_target_sync_results.results | selectattr('changed') | list | length > 0)
+            )
+            or (
+              nginx_base_config_legacy_upstream_target_remove_result is defined
+              and nginx_base_config_legacy_upstream_target_remove_result.changed
             )
             or (
               nginx_base_config_route_target_sync_result is defined
@@ -394,6 +522,14 @@
       when: item.stat.exists
       loop: "{{ nginx_base_config_upstream_source_stats.results }}"
 
+    - name: Restore previous legacy upstream fragment source from backup
+      ansible.builtin.copy:
+        src: "{{ nginx_legacy_upstream_source_path }}.bak"
+        dest: "{{ nginx_legacy_upstream_source_path }}"
+        remote_src: true
+        mode: "0644"
+      when: nginx_base_config_legacy_upstream_source_stat.stat.exists
+
     - name: Restore previous route fragment source from backup
       ansible.builtin.copy:
         src: "{{ nginx_route_source_path }}.bak"
@@ -408,6 +544,12 @@
         state: absent
       when: not item.stat.exists
       loop: "{{ nginx_base_config_upstream_source_stats.results }}"
+
+    - name: Remove legacy upstream fragment source if no backup existed
+      ansible.builtin.file:
+        path: "{{ nginx_legacy_upstream_source_path }}"
+        state: absent
+      when: not nginx_base_config_legacy_upstream_source_stat.stat.exists
 
     - name: Remove route fragment source if no backup existed
       ansible.builtin.file:
@@ -424,6 +566,14 @@
       when: item.stat.exists
       loop: "{{ nginx_base_config_upstream_target_stats.results }}"
 
+    - name: Restore previous legacy upstream fragment target from backup
+      ansible.builtin.copy:
+        src: "{{ nginx_legacy_upstream_target_path }}.bak"
+        dest: "{{ nginx_legacy_upstream_target_path }}"
+        remote_src: true
+        mode: "0644"
+      when: nginx_base_config_legacy_upstream_target_stat.stat.exists
+
     - name: Restore previous route fragment target from backup
       ansible.builtin.copy:
         src: "{{ nginx_route_target_path }}.bak"
@@ -438,6 +588,12 @@
         state: absent
       when: not item.stat.exists
       loop: "{{ nginx_base_config_upstream_target_stats.results }}"
+
+    - name: Remove legacy upstream fragment target if no backup existed
+      ansible.builtin.file:
+        path: "{{ nginx_legacy_upstream_target_path }}"
+        state: absent
+      when: not nginx_base_config_legacy_upstream_target_stat.stat.exists
 
     - name: Remove route fragment target if no backup existed
       ansible.builtin.file:
@@ -476,10 +632,12 @@
     - "{{ nginx_backend_upstream_source_path }}.bak"
     - "{{ nginx_admin_upstream_source_path }}.bak"
     - "{{ nginx_actuator_upstream_source_path }}.bak"
+    - "{{ nginx_legacy_upstream_source_path }}.bak"
     - "{{ nginx_route_source_path }}.bak"
     - "{{ nginx_backend_upstream_target_path }}.bak"
     - "{{ nginx_admin_upstream_target_path }}.bak"
     - "{{ nginx_actuator_upstream_target_path }}.bak"
+    - "{{ nginx_legacy_upstream_target_path }}.bak"
     - "{{ nginx_route_target_path }}.bak"
     - "{{ nginx_conf_target_path }}.bak"
   when: not ansible_check_mode

--- a/infra/ansible/roles/nginx_base_config/tasks/main.yml
+++ b/infra/ansible/roles/nginx_base_config/tasks/main.yml
@@ -3,6 +3,17 @@
   ansible.builtin.import_role:
     name: nginx_config_helper
 
+- name: Resolve generated nginx fragment paths
+  ansible.builtin.set_fact:
+    nginx_backend_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/backend.conf"
+    nginx_admin_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/admin_backend.conf"
+    nginx_actuator_upstream_source_path: "{{ nginx_generated_source_dir }}/upstreams/actuator.conf"
+    nginx_backend_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/backend.conf"
+    nginx_admin_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/admin_backend.conf"
+    nginx_actuator_upstream_target_path: "{{ nginx_generated_target_dir }}/upstreams/actuator.conf"
+    nginx_route_source_path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+    nginx_route_target_path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+
 - name: Ensure nginx candidate directory exists
   ansible.builtin.file:
     path: "{{ deployment_dir }}/nginx"
@@ -45,22 +56,30 @@
 
 - name: Check if upstream fragment already exists (deployed server)
   ansible.builtin.stat:
-    path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
-  register: nginx_base_config_upstream_fragment_stat
+    path: "{{ item.path }}"
+  loop:
+    - { name: "backend", path: "{{ nginx_backend_upstream_source_path }}" }
+    - { name: "admin", path: "{{ nginx_admin_upstream_source_path }}" }
+    - { name: "actuator", path: "{{ nginx_actuator_upstream_source_path }}" }
+  register: nginx_base_config_upstream_source_stats
 
 - name: Check if route fragment already exists (deployed server)
   ansible.builtin.stat:
-    path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+    path: "{{ nginx_route_source_path }}"
   register: nginx_base_config_route_fragment_stat
 
 - name: Check current upstream fragment target
   ansible.builtin.stat:
-    path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
-  register: nginx_base_config_upstream_target_stat
+    path: "{{ item.path }}"
+  loop:
+    - { name: "backend", path: "{{ nginx_backend_upstream_target_path }}" }
+    - { name: "admin", path: "{{ nginx_admin_upstream_target_path }}" }
+    - { name: "actuator", path: "{{ nginx_actuator_upstream_target_path }}" }
+  register: nginx_base_config_upstream_target_stats
 
 - name: Check current route fragment target
   ansible.builtin.stat:
-    path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+    path: "{{ nginx_route_target_path }}"
   register: nginx_base_config_route_target_stat
 
 - name: Ensure live nginx config exists before promotion
@@ -79,10 +98,14 @@
   ansible.builtin.debug:
     msg:
       - "Would backup {{ deployment_dir }}/nginx/default.conf to {{ deployment_dir }}/nginx/default.conf.bak"
-      - "Would backup {{ nginx_generated_source_dir }}/upstreams/00-managed.conf to {{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
-      - "Would backup {{ nginx_generated_source_dir }}/routes/10-managed.conf to {{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
-      - "Would backup {{ nginx_generated_target_dir }}/upstreams/00-managed.conf to {{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
-      - "Would backup {{ nginx_generated_target_dir }}/routes/10-managed.conf to {{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
+      - "Would backup {{ nginx_backend_upstream_source_path }} to {{ nginx_backend_upstream_source_path }}.bak"
+      - "Would backup {{ nginx_admin_upstream_source_path }} to {{ nginx_admin_upstream_source_path }}.bak"
+      - "Would backup {{ nginx_actuator_upstream_source_path }} to {{ nginx_actuator_upstream_source_path }}.bak"
+      - "Would backup {{ nginx_route_source_path }} to {{ nginx_route_source_path }}.bak"
+      - "Would backup {{ nginx_backend_upstream_target_path }} to {{ nginx_backend_upstream_target_path }}.bak"
+      - "Would backup {{ nginx_admin_upstream_target_path }} to {{ nginx_admin_upstream_target_path }}.bak"
+      - "Would backup {{ nginx_actuator_upstream_target_path }} to {{ nginx_actuator_upstream_target_path }}.bak"
+      - "Would backup {{ nginx_route_target_path }} to {{ nginx_route_target_path }}.bak"
       - "Would backup {{ nginx_conf_target_path }} to {{ nginx_conf_target_path }}.bak"
       - "Would render {{ deployment_dir }}/nginx/default.conf and sync generated fragments to target"
       - "Would validate with docker exec {{ nginx_container_name }} nginx -t"
@@ -109,26 +132,28 @@
 
 - name: Backup current upstream fragment source
   ansible.builtin.copy:
-    src: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
-    dest: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
+    src: "{{ item.path }}"
+    dest: "{{ item.path }}.bak"
     remote_src: true
     mode: "0644"
+  loop: "{{ nginx_base_config_upstream_source_stats.results }}"
   when:
     - not ansible_check_mode
-    - nginx_base_config_upstream_fragment_stat.stat.exists
+    - item.stat.exists
 
 - name: Clear stale upstream fragment source backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
+    path: "{{ item.path }}.bak"
     state: absent
   when:
     - not ansible_check_mode
-    - not nginx_base_config_upstream_fragment_stat.stat.exists
+    - not item.stat.exists
+  loop: "{{ nginx_base_config_upstream_source_stats.results }}"
 
 - name: Backup current route fragment source
   ansible.builtin.copy:
-    src: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
-    dest: "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
+    src: "{{ nginx_route_source_path }}"
+    dest: "{{ nginx_route_source_path }}.bak"
     remote_src: true
     mode: "0644"
   when:
@@ -137,7 +162,7 @@
 
 - name: Clear stale route fragment source backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
+    path: "{{ nginx_route_source_path }}.bak"
     state: absent
   when:
     - not ansible_check_mode
@@ -145,26 +170,28 @@
 
 - name: Backup current upstream fragment target
   ansible.builtin.copy:
-    src: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
-    dest: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
+    src: "{{ item.path }}"
+    dest: "{{ item.path }}.bak"
     remote_src: true
     mode: "0644"
   when:
     - not ansible_check_mode
-    - nginx_base_config_upstream_target_stat.stat.exists
+    - item.stat.exists
+  loop: "{{ nginx_base_config_upstream_target_stats.results }}"
 
 - name: Clear stale upstream fragment target backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
+    path: "{{ item.path }}.bak"
     state: absent
   when:
     - not ansible_check_mode
-    - not nginx_base_config_upstream_target_stat.stat.exists
+    - not item.stat.exists
+  loop: "{{ nginx_base_config_upstream_target_stats.results }}"
 
 - name: Backup current route fragment target
   ansible.builtin.copy:
-    src: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
-    dest: "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
+    src: "{{ nginx_route_target_path }}"
+    dest: "{{ nginx_route_target_path }}.bak"
     remote_src: true
     mode: "0644"
   when:
@@ -173,7 +200,7 @@
 
 - name: Clear stale route fragment target backup when file missing
   ansible.builtin.file:
-    path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
+    path: "{{ nginx_route_target_path }}.bak"
     state: absent
   when:
     - not ansible_check_mode
@@ -196,8 +223,8 @@
         dest: "{{ deployment_dir }}/nginx/default.conf"
         mode: "0644"
 
-    - name: Seed upstream fragments when missing
-      when: not nginx_base_config_upstream_fragment_stat.stat.exists
+    - name: Seed backend upstream fragment when missing
+      when: not nginx_base_config_upstream_source_stats.results[0].stat.exists
       block:
         - name: Seed backend upstream marker in source fragment
           ansible.builtin.command:
@@ -206,7 +233,7 @@
               - "{{ deployment_dir }}/update-nginx-config.py"
               - upsert-upstream
               - --path
-              - "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+              - "{{ nginx_backend_upstream_source_path }}"
               - --upstream-name
               - "{{ backend_upstream_name | default('backend') }}"
               - --container-name
@@ -216,6 +243,9 @@
           register: nginx_base_config_seed_backend_upstream_result
           changed_when: "'changed=true' in nginx_base_config_seed_backend_upstream_result.stdout"
 
+    - name: Seed admin upstream fragment when missing
+      when: not nginx_base_config_upstream_source_stats.results[1].stat.exists
+      block:
         - name: Seed admin upstream marker in source fragment
           ansible.builtin.command:
             argv:
@@ -223,7 +253,7 @@
               - "{{ deployment_dir }}/update-nginx-config.py"
               - upsert-upstream
               - --path
-              - "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+              - "{{ nginx_admin_upstream_source_path }}"
               - --upstream-name
               - "{{ admin_upstream_name | default('admin_backend') }}"
               - --container-name
@@ -233,6 +263,9 @@
           register: nginx_base_config_seed_admin_upstream_result
           changed_when: "'changed=true' in nginx_base_config_seed_admin_upstream_result.stdout"
 
+    - name: Seed actuator upstream fragment when missing
+      when: not nginx_base_config_upstream_source_stats.results[2].stat.exists
+      block:
         - name: Seed actuator upstream marker in source fragment
           ansible.builtin.command:
             argv:
@@ -240,7 +273,7 @@
               - "{{ deployment_dir }}/update-nginx-config.py"
               - upsert-upstream
               - --path
-              - "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+              - "{{ nginx_actuator_upstream_source_path }}"
               - --upstream-name
               - "{{ actuator_upstream_name | default('actuator') }}"
               - --container-name
@@ -260,7 +293,7 @@
               - "{{ deployment_dir }}/update-nginx-config.py"
               - ensure-route
               - --path
-              - "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+              - "{{ nginx_route_source_path }}"
               - --upstream-name
               - "{{ admin_upstream_name | default('admin_backend') }}"
               - --external-path
@@ -270,18 +303,22 @@
           register: nginx_base_config_seed_route_result
           changed_when: "'changed=true' in nginx_base_config_seed_route_result.stdout"
 
-    - name: Sync upstream fragment to target
+    - name: Sync upstream fragments to target
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
-        dest: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
         remote_src: true
         mode: "0644"
-      register: nginx_base_config_upstream_target_sync_result
+      loop:
+        - { src: "{{ nginx_backend_upstream_source_path }}", dest: "{{ nginx_backend_upstream_target_path }}" }
+        - { src: "{{ nginx_admin_upstream_source_path }}", dest: "{{ nginx_admin_upstream_target_path }}" }
+        - { src: "{{ nginx_actuator_upstream_source_path }}", dest: "{{ nginx_actuator_upstream_target_path }}" }
+      register: nginx_base_config_upstream_target_sync_results
 
     - name: Sync route fragment to target
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
-        dest: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+        src: "{{ nginx_route_source_path }}"
+        dest: "{{ nginx_route_target_path }}"
         remote_src: true
         mode: "0644"
       register: nginx_base_config_route_target_sync_result
@@ -311,8 +348,8 @@
           {{
             nginx_base_config_live_config_sync_result.changed
             or (
-              nginx_base_config_upstream_target_sync_result is defined
-              and nginx_base_config_upstream_target_sync_result.changed
+              nginx_base_config_upstream_target_sync_results is defined
+              and (nginx_base_config_upstream_target_sync_results.results | selectattr('changed') | list | length > 0)
             )
             or (
               nginx_base_config_route_target_sync_result is defined
@@ -350,57 +387,61 @@
 
     - name: Restore previous upstream fragment source from backup
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
-        dest: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+        src: "{{ item.path }}.bak"
+        dest: "{{ item.path }}"
         remote_src: true
         mode: "0644"
-      when: nginx_base_config_upstream_fragment_stat.stat.exists
+      when: item.stat.exists
+      loop: "{{ nginx_base_config_upstream_source_stats.results }}"
 
     - name: Restore previous route fragment source from backup
       ansible.builtin.copy:
-        src: "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
-        dest: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+        src: "{{ nginx_route_source_path }}.bak"
+        dest: "{{ nginx_route_source_path }}"
         remote_src: true
         mode: "0644"
       when: nginx_base_config_route_fragment_stat.stat.exists
 
     - name: Remove upstream fragment source if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+        path: "{{ item.path }}"
         state: absent
-      when: not nginx_base_config_upstream_fragment_stat.stat.exists
+      when: not item.stat.exists
+      loop: "{{ nginx_base_config_upstream_source_stats.results }}"
 
     - name: Remove route fragment source if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_source_dir }}/routes/10-managed.conf"
+        path: "{{ nginx_route_source_path }}"
         state: absent
       when: not nginx_base_config_route_fragment_stat.stat.exists
 
     - name: Restore previous upstream fragment target from backup
       ansible.builtin.copy:
-        src: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
-        dest: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+        src: "{{ item.path }}.bak"
+        dest: "{{ item.path }}"
         remote_src: true
         mode: "0644"
-      when: nginx_base_config_upstream_target_stat.stat.exists
+      when: item.stat.exists
+      loop: "{{ nginx_base_config_upstream_target_stats.results }}"
 
     - name: Restore previous route fragment target from backup
       ansible.builtin.copy:
-        src: "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
-        dest: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+        src: "{{ nginx_route_target_path }}.bak"
+        dest: "{{ nginx_route_target_path }}"
         remote_src: true
         mode: "0644"
       when: nginx_base_config_route_target_stat.stat.exists
 
     - name: Remove upstream fragment target if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+        path: "{{ item.path }}"
         state: absent
-      when: not nginx_base_config_upstream_target_stat.stat.exists
+      when: not item.stat.exists
+      loop: "{{ nginx_base_config_upstream_target_stats.results }}"
 
     - name: Remove route fragment target if no backup existed
       ansible.builtin.file:
-        path: "{{ nginx_generated_target_dir }}/routes/10-managed.conf"
+        path: "{{ nginx_route_target_path }}"
         state: absent
       when: not nginx_base_config_route_target_stat.stat.exists
 
@@ -432,9 +473,13 @@
     state: absent
   loop:
     - "{{ deployment_dir }}/nginx/default.conf.bak"
-    - "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf.bak"
-    - "{{ nginx_generated_source_dir }}/routes/10-managed.conf.bak"
-    - "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf.bak"
-    - "{{ nginx_generated_target_dir }}/routes/10-managed.conf.bak"
+    - "{{ nginx_backend_upstream_source_path }}.bak"
+    - "{{ nginx_admin_upstream_source_path }}.bak"
+    - "{{ nginx_actuator_upstream_source_path }}.bak"
+    - "{{ nginx_route_source_path }}.bak"
+    - "{{ nginx_backend_upstream_target_path }}.bak"
+    - "{{ nginx_admin_upstream_target_path }}.bak"
+    - "{{ nginx_actuator_upstream_target_path }}.bak"
+    - "{{ nginx_route_target_path }}.bak"
     - "{{ nginx_conf_target_path }}.bak"
   when: not ansible_check_mode

--- a/infra/ansible/roles/nginx_config_helper/files/update-nginx-config.py
+++ b/infra/ansible/roles/nginx_config_helper/files/update-nginx-config.py
@@ -123,6 +123,61 @@ def ensure_route(path: Path, upstream_name: str, external_path: str, upstream_pa
     return write_normalized(path, text)
 
 
+
+def parse_mapping(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("mapping must be formatted as upstream_name=fragment_file")
+    upstream_name, fragment_file = value.split("=", 1)
+    if not upstream_name or not fragment_file:
+        raise argparse.ArgumentTypeError("mapping must include both upstream_name and fragment_file")
+    return upstream_name, fragment_file
+
+
+def extract_managed_or_upstream_block(text: str, upstream_name: str) -> str | None:
+    marker = f"BEAT MANAGED UPSTREAM {upstream_name}"
+    managed_pattern = re.compile(
+        rf"# BEGIN {re.escape(marker)}\n.*?# END {re.escape(marker)}",
+        flags=re.S,
+    )
+    managed_match = managed_pattern.search(text)
+    if managed_match:
+        return managed_match.group(0).strip() + "\n"
+
+    upstream_pattern = re.compile(
+        rf"(^|\n)(upstream\s+{re.escape(upstream_name)}\s*\{{.*?\n\s*\}})",
+        flags=re.S,
+    )
+    upstream_match = upstream_pattern.search(text)
+    if upstream_match:
+        return upstream_match.group(2).strip() + "\n"
+    return None
+
+
+def split_upstreams(
+    source: Path,
+    output_dir: Path,
+    mappings: list[tuple[str, str]],
+    require_all: bool,
+    skip_existing: bool,
+) -> bool:
+    if not source.exists():
+        return False
+
+    text = source.read_text()
+    changed = False
+    for upstream_name, fragment_file in mappings:
+        fragment_path = output_dir / fragment_file
+        if skip_existing and fragment_path.exists():
+            continue
+        block = extract_managed_or_upstream_block(text, upstream_name)
+        if block is None:
+            if require_all:
+                raise SystemExit(f"Required upstream '{upstream_name}' was not found in {source}")
+            continue
+        changed = write_normalized(fragment_path, block) or changed
+    return changed
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     subcommands = parser.add_subparsers(dest="command", required=True)
@@ -144,31 +199,45 @@ def build_parser() -> argparse.ArgumentParser:
     ensure_route_parser.add_argument("--external-path", required=True)
     ensure_route_parser.add_argument("--upstream-path", required=True)
 
+    split_upstreams_parser = subcommands.add_parser("split-upstreams")
+    split_upstreams_parser.add_argument("--source", required=True)
+    split_upstreams_parser.add_argument("--output-dir", required=True)
+    split_upstreams_parser.add_argument("--mapping", action="append", type=parse_mapping, required=True)
+    split_upstreams_parser.add_argument("--require-all", action="store_true")
+    split_upstreams_parser.add_argument("--skip-existing", action="store_true")
+
     return parser
 
 
 def main() -> None:
     args = build_parser().parse_args()
-    path = Path(args.path)
     if args.command == "bootstrap-includes":
         changed = bootstrap_includes(
-            path,
+            Path(args.path),
             args.upstream_include_glob,
             args.route_include_glob,
         )
     elif args.command == "upsert-upstream":
         changed = upsert_upstream(
-            path,
+            Path(args.path),
             args.upstream_name,
             args.container_name,
             args.backend_port,
         )
-    else:
+    elif args.command == "ensure-route":
         changed = ensure_route(
-            path,
+            Path(args.path),
             args.upstream_name,
             args.external_path,
             args.upstream_path,
+        )
+    else:
+        changed = split_upstreams(
+            Path(args.source),
+            Path(args.output_dir),
+            args.mapping,
+            args.require_all,
+            args.skip_existing,
         )
     print(f"changed={'true' if changed else 'false'}")
 

--- a/infra/ansible/roles/nginx_config_helper/tasks/migrate_legacy_upstreams.yml
+++ b/infra/ansible/roles/nginx_config_helper/tasks/migrate_legacy_upstreams.yml
@@ -1,0 +1,88 @@
+---
+- name: Resolve legacy nginx upstream migration paths
+  ansible.builtin.set_fact:
+    nginx_legacy_migration_backend_source_path: "{{ nginx_generated_source_dir }}/upstreams/backend.conf"
+    nginx_legacy_migration_admin_source_path: "{{ nginx_generated_source_dir }}/upstreams/admin_backend.conf"
+    nginx_legacy_migration_actuator_source_path: "{{ nginx_generated_source_dir }}/upstreams/actuator.conf"
+    nginx_legacy_migration_backend_target_path: "{{ nginx_generated_target_dir }}/upstreams/backend.conf"
+    nginx_legacy_migration_admin_target_path: "{{ nginx_generated_target_dir }}/upstreams/admin_backend.conf"
+    nginx_legacy_migration_actuator_target_path: "{{ nginx_generated_target_dir }}/upstreams/actuator.conf"
+    nginx_legacy_migration_source_path: "{{ nginx_generated_source_dir }}/upstreams/00-managed.conf"
+    nginx_legacy_migration_target_path: "{{ nginx_generated_target_dir }}/upstreams/00-managed.conf"
+
+- name: Check legacy upstream source
+  ansible.builtin.stat:
+    path: "{{ nginx_legacy_migration_source_path }}"
+  register: nginx_legacy_migration_source_stat
+
+- name: Check legacy upstream target
+  ansible.builtin.stat:
+    path: "{{ nginx_legacy_migration_target_path }}"
+  register: nginx_legacy_migration_target_stat
+
+- name: Split legacy upstream source into owned fragments
+  ansible.builtin.command:
+    argv:
+      - python3
+      - "{{ deployment_dir }}/update-nginx-config.py"
+      - split-upstreams
+      - --source
+      - "{{ nginx_legacy_migration_source_path }}"
+      - --output-dir
+      - "{{ nginx_generated_source_dir }}/upstreams"
+      - --mapping
+      - "{{ backend_upstream_name | default('backend') }}=backend.conf"
+      - --mapping
+      - "{{ admin_upstream_name | default('admin_backend') }}=admin_backend.conf"
+      - --mapping
+      - "{{ actuator_upstream_name | default('actuator') }}=actuator.conf"
+      - --require-all
+      - --skip-existing
+  register: nginx_legacy_migration_split_result
+  changed_when: "'changed=true' in nginx_legacy_migration_split_result.stdout"
+  when: nginx_legacy_migration_source_stat.stat.exists
+
+- name: Check split upstream sources before removing legacy target
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - "{{ nginx_legacy_migration_backend_source_path }}"
+    - "{{ nginx_legacy_migration_admin_source_path }}"
+    - "{{ nginx_legacy_migration_actuator_source_path }}"
+  register: nginx_legacy_migration_source_fragment_stats
+  when:
+    - nginx_legacy_migration_source_stat.stat.exists
+      or nginx_legacy_migration_target_stat.stat.exists
+
+- name: Abort legacy upstream migration if split fragments are incomplete
+  ansible.builtin.assert:
+    that:
+      - nginx_legacy_migration_source_fragment_stats.results | map(attribute='stat.exists') | min
+    fail_msg: "Cannot remove legacy upstreams/00-managed.conf until backend/admin/actuator fragments exist"
+  when:
+    - nginx_legacy_migration_source_stat.stat.exists
+      or nginx_legacy_migration_target_stat.stat.exists
+
+- name: Sync split upstream fragments before removing legacy target
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    remote_src: true
+    mode: "0644"
+  loop:
+    - { src: "{{ nginx_legacy_migration_backend_source_path }}", dest: "{{ nginx_legacy_migration_backend_target_path }}" }
+    - { src: "{{ nginx_legacy_migration_admin_source_path }}", dest: "{{ nginx_legacy_migration_admin_target_path }}" }
+    - { src: "{{ nginx_legacy_migration_actuator_source_path }}", dest: "{{ nginx_legacy_migration_actuator_target_path }}" }
+  when: nginx_legacy_migration_target_stat.stat.exists
+
+- name: Remove legacy upstream target before nginx validation
+  ansible.builtin.file:
+    path: "{{ nginx_legacy_migration_target_path }}"
+    state: absent
+  when: nginx_legacy_migration_target_stat.stat.exists
+
+- name: Remove legacy upstream source after migration
+  ansible.builtin.file:
+    path: "{{ nginx_legacy_migration_source_path }}"
+    state: absent
+  when: nginx_legacy_migration_source_stat.stat.exists

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -234,6 +234,7 @@ class RootRetirementContractTest {
 		assertFalse(deployProd.contains("github.event.inputs.version"));
 		assertFalse(deployProd.contains("github.event.inputs.module"));
 		assertFalse(deployProd.contains("checkout_ref=refs/tags/"));
+		assertTrue(deployProd.contains("module_matrix={\"include\":[{\"module\":\"admin\"},{\"module\":\"apis\"},{\"module\":\"batch\"}]}"));
 
 		assertTrue(secretAwareVerify.contains("module: ${{ matrix.module }}"));
 		assertTrue(secretAwareVerify.contains("Verified resolver for module=${MODULE}"));
@@ -257,6 +258,7 @@ class RootRetirementContractTest {
 		String appStopStartRole = read("infra/ansible/roles/app_stopstart/tasks/main.yml");
 		String appStopStartRunContainer = read("infra/ansible/roles/app_stopstart/tasks/run_container.yml");
 		String appHealthcheckRole = read("infra/ansible/roles/app_healthcheck/tasks/main.yml");
+		String nginxBaseConfig = read("infra/ansible/roles/nginx_base_config/tasks/main.yml");
 		String adminNginxRoute = read("infra/ansible/roles/app_stopstart/tasks/admin_nginx_route.yml");
 		String deployDev = read(".github/workflows/deploy-dev.yml");
 		String deployProd = read(".github/workflows/deploy-prod.yml");
@@ -346,6 +348,9 @@ class RootRetirementContractTest {
 			assertFalse(deployDev.contains("inventory_label:"));
 			assertFalse(deployProd.contains("inventory_label:"));
 			assertFalse(rollbackProd.contains("inventory_label:"));
+			assertTrue(deployDev.contains("preferred_order = [\"admin\", \"apis\", \"batch\"]"));
+			assertTrue(deployDev.contains("modules = preferred_order if requested == \"all\" else [requested]"));
+			assertTrue(deployDev.contains("modules = [module for module in preferred_order if selected_modules[module]]"));
 			assertTrue(deployDev.contains("IMAGE_TAG=\"dev-${GITHUB_SHA}\""));
 			assertTrue(deployDev.contains("image: ${{ vars.DEV_DOCKER_LOGIN_USERNAME }}/beat-${{ matrix.module }}:dev-${{ github.sha }}"));
 			assertTrue(deployProd.contains("IMAGE_TAG=\"${RELEASE_TAG}\""));
@@ -361,9 +366,11 @@ class RootRetirementContractTest {
 		assertTrue(appHealthcheckRole.contains("module_cfg.blue_container_name"));
 		assertTrue(appHealthcheckRole.contains("module_cfg.green_container_name"));
 		assertFalse(appHealthcheckRole.contains("target=\"apis-$slot\""));
+		assertTrue(nginxBaseConfig.contains("nginx_base_config_upstream_target_sync_results is defined"));
+		assertFalse(nginxBaseConfig.contains("nginx_base_config_upstream_target_sync_result is defined"));
 		assertTrue(adminNginxRoute.contains("bootstrap-includes"));
 		assertTrue(adminNginxRoute.contains("routes/10-managed.conf"));
-		assertTrue(adminNginxRoute.contains("upstreams/00-managed.conf"));
+		assertTrue(adminNginxRoute.contains("upstreams/admin_backend.conf"));
 		assertFalse(adminNginxRoute.contains("/api/admin/"));
 	}
 

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -1,9 +1,11 @@
 package com.beat;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -243,6 +245,131 @@ class RootRetirementContractTest {
 	}
 
 	@Test
+	void nginxHelperSplitsLegacyManagedUpstreamsIntoOwnedFragments() throws Exception {
+		Path script = Path.of("infra/ansible/roles/nginx_config_helper/files/update-nginx-config.py").toAbsolutePath();
+		Path tempDir = Files.createTempDirectory("beat-nginx-upstreams-");
+		Path upstreamDir = tempDir.resolve("upstreams");
+		Path legacy = upstreamDir.resolve("00-managed.conf");
+		Files.createDirectories(upstreamDir);
+		Files.writeString(legacy, """
+			# BEGIN BEAT MANAGED UPSTREAM backend
+			upstream backend {
+			    server apis-blue:4001;
+			}
+			# END BEAT MANAGED UPSTREAM backend
+
+			# BEGIN BEAT MANAGED UPSTREAM admin_backend
+			upstream admin_backend {
+			    server admin:4000;
+			}
+			# END BEAT MANAGED UPSTREAM admin_backend
+
+			# BEGIN BEAT MANAGED UPSTREAM actuator
+			upstream actuator {
+			    server apis-blue:9000;
+			}
+			# END BEAT MANAGED UPSTREAM actuator
+			""");
+
+		String firstRun = run(
+			"python3",
+			script.toString(),
+			"split-upstreams",
+			"--source",
+			legacy.toString(),
+			"--output-dir",
+			upstreamDir.toString(),
+			"--mapping",
+			"backend=backend.conf",
+			"--mapping",
+			"admin_backend=admin_backend.conf",
+			"--mapping",
+			"actuator=actuator.conf",
+			"--require-all");
+
+		assertTrue(firstRun.contains("changed=true"));
+		assertTrue(Files.readString(upstreamDir.resolve("backend.conf")).contains("server apis-blue:4001;"));
+		assertTrue(Files.readString(upstreamDir.resolve("admin_backend.conf")).contains("server admin:4000;"));
+		assertTrue(Files.readString(upstreamDir.resolve("actuator.conf")).contains("server apis-blue:9000;"));
+
+		String secondRun = run(
+			"python3",
+			script.toString(),
+			"split-upstreams",
+			"--source",
+			legacy.toString(),
+			"--output-dir",
+			upstreamDir.toString(),
+			"--mapping",
+			"backend=backend.conf",
+			"--mapping",
+			"admin_backend=admin_backend.conf",
+			"--mapping",
+			"actuator=actuator.conf",
+			"--require-all");
+
+		assertTrue(secondRun.contains("changed=false"));
+	}
+
+	@Test
+	void nginxHelperKeepsExistingOwnedFragmentsWhenSplittingLegacyUpstreams() throws Exception {
+		Path script = Path.of("infra/ansible/roles/nginx_config_helper/files/update-nginx-config.py").toAbsolutePath();
+		Path tempDir = Files.createTempDirectory("beat-nginx-upstream-preserve-");
+		Path upstreamDir = tempDir.resolve("upstreams");
+		Path legacy = upstreamDir.resolve("00-managed.conf");
+		Files.createDirectories(upstreamDir);
+		Files.writeString(upstreamDir.resolve("backend.conf"), """
+			# BEGIN BEAT MANAGED UPSTREAM backend
+			upstream backend {
+			    server apis-live:4001;
+			}
+			# END BEAT MANAGED UPSTREAM backend
+			""");
+		Files.writeString(legacy, """
+			# BEGIN BEAT MANAGED UPSTREAM backend
+			upstream backend {
+			    server apis-stale:4001;
+			}
+			# END BEAT MANAGED UPSTREAM backend
+
+			# BEGIN BEAT MANAGED UPSTREAM admin_backend
+			upstream admin_backend {
+			    server admin-live:4000;
+			}
+			# END BEAT MANAGED UPSTREAM admin_backend
+
+			# BEGIN BEAT MANAGED UPSTREAM actuator
+			upstream actuator {
+			    server apis-live:9000;
+			}
+			# END BEAT MANAGED UPSTREAM actuator
+			""");
+
+		String output = run(
+			"python3",
+			script.toString(),
+			"split-upstreams",
+			"--source",
+			legacy.toString(),
+			"--output-dir",
+			upstreamDir.toString(),
+			"--mapping",
+			"backend=backend.conf",
+			"--mapping",
+			"admin_backend=admin_backend.conf",
+			"--mapping",
+			"actuator=actuator.conf",
+			"--require-all",
+			"--skip-existing");
+
+		assertTrue(output.contains("changed=true"));
+		assertTrue(Files.readString(upstreamDir.resolve("backend.conf")).contains("server apis-live:4001;"));
+		assertFalse(Files.readString(upstreamDir.resolve("backend.conf")).contains("server apis-stale:4001;"));
+		assertTrue(Files.readString(upstreamDir.resolve("admin_backend.conf")).contains("server admin-live:4000;"));
+		assertTrue(Files.readString(upstreamDir.resolve("actuator.conf")).contains("server apis-live:9000;"));
+	}
+
+	@Test
 	void deploymentInfraUsesRepoOwnedHelpersAndConfiguredModuleContracts() throws Exception {
 		String dockerfileModule = read("Dockerfile.module");
 		String dockerignore = read(".dockerignore");
@@ -259,6 +386,7 @@ class RootRetirementContractTest {
 		String appStopStartRunContainer = read("infra/ansible/roles/app_stopstart/tasks/run_container.yml");
 		String appHealthcheckRole = read("infra/ansible/roles/app_healthcheck/tasks/main.yml");
 		String nginxBaseConfig = read("infra/ansible/roles/nginx_base_config/tasks/main.yml");
+		String nginxLegacyMigration = read("infra/ansible/roles/nginx_config_helper/tasks/migrate_legacy_upstreams.yml");
 		String adminNginxRoute = read("infra/ansible/roles/app_stopstart/tasks/admin_nginx_route.yml");
 		String deployDev = read(".github/workflows/deploy-dev.yml");
 		String deployProd = read(".github/workflows/deploy-prod.yml");
@@ -274,6 +402,7 @@ class RootRetirementContractTest {
 			assertTrue(Files.exists(Path.of("infra/ansible/roles/nginx_config_helper/files/update-nginx-config.py")));
 			assertTrue(Files.exists(Path.of("infra/ansible/roles/foundation_stack/templates/foundation.compose.yml.j2")));
 			assertTrue(Files.exists(Path.of("infra/ansible/roles/nginx_base_config/templates/default.conf.j2")));
+			assertTrue(Files.exists(Path.of("infra/ansible/roles/nginx_config_helper/tasks/migrate_legacy_upstreams.yml")));
 		assertTrue(Files.exists(Path.of("scripts/generate-local-dev-secret.sh")));
 		assertTrue(Files.exists(Path.of("scripts/generate-local-prod-secret.sh")));
 		assertTrue(Files.exists(Path.of(".dockerignore")));
@@ -292,6 +421,7 @@ class RootRetirementContractTest {
 		assertTrue(dockerignore.contains(".omx"));
 		assertTrue(dockerignore.contains("src/"));
 		assertTrue(appBluegreenRunSwitch.contains("community.docker.docker_container"));
+		assertTrue(appBluegreenRunSwitch.contains("tasks_from: migrate_legacy_upstreams.yml"));
 		assertTrue(appBluegreenRunSwitch.contains("current-slot"));
 		assertTrue(appBluegreenRunSwitch.contains("upsert-upstream"));
 		assertTrue(appBluegreenRunSwitch.contains("public_smoke_url"));
@@ -318,6 +448,8 @@ class RootRetirementContractTest {
 		assertTrue(nginxUpdateScript.contains("BEAT MANAGED GENERATED ROUTE INCLUDES"));
 		assertTrue(nginxUpdateScript.contains("bootstrap-includes"));
 		assertTrue(nginxUpdateScript.contains("upsert-upstream"));
+		assertTrue(nginxUpdateScript.contains("split-upstreams"));
+		assertTrue(nginxUpdateScript.contains("skip_existing"));
 		assertTrue(deployPlaybook.contains("module_cfg.deploy_mode == 'blue_green'"));
 		assertTrue(deployPlaybook.contains("module_cfg.deploy_mode == 'stop_start'"));
 		assertTrue(deployPlaybook.contains("tags:"));
@@ -368,7 +500,23 @@ class RootRetirementContractTest {
 		assertFalse(appHealthcheckRole.contains("target=\"apis-$slot\""));
 		assertTrue(nginxBaseConfig.contains("nginx_base_config_upstream_target_sync_results is defined"));
 		assertFalse(nginxBaseConfig.contains("nginx_base_config_upstream_target_sync_result is defined"));
+		assertTrue(nginxBaseConfig.contains("nginx_legacy_upstream_source_path"));
+		assertTrue(nginxBaseConfig.contains("Split legacy upstream source into per-upstream fragments"));
+		assertTrue(nginxBaseConfig.contains("Remove legacy upstream target before nginx validation"));
+		assertTrue(nginxBaseConfig.contains("selectattr('item.name', 'equalto', 'backend')"));
+		assertFalse(nginxBaseConfig.contains("nginx_base_config_upstream_source_stats.results[0]"));
+		assertTrue(nginxLegacyMigration.contains("00-managed.conf"));
+		assertTrue(nginxLegacyMigration.contains("Sync split upstream fragments before removing legacy target"));
+		assertTrue(nginxLegacyMigration.contains("Remove legacy upstream target before nginx validation"));
+		assertBefore(nginxLegacyMigration, "Split legacy upstream source", "Check split upstream sources");
+		assertBefore(nginxLegacyMigration, "Check split upstream sources", "Abort legacy upstream migration");
+		assertBefore(nginxLegacyMigration, "Abort legacy upstream migration", "Sync split upstream fragments");
+		assertBefore(nginxLegacyMigration, "Sync split upstream fragments", "Remove legacy upstream target");
+		assertBefore(nginxLegacyMigration, "Remove legacy upstream target", "Remove legacy upstream source");
+		assertBefore(appBluegreenRunSwitch, "tasks_from: migrate_legacy_upstreams.yml", "Validate nginx config after upstream switch");
+		assertBefore(adminNginxRoute, "tasks_from: migrate_legacy_upstreams.yml", "Validate nginx config after admin route update");
 		assertTrue(adminNginxRoute.contains("bootstrap-includes"));
+		assertTrue(adminNginxRoute.contains("tasks_from: migrate_legacy_upstreams.yml"));
 		assertTrue(adminNginxRoute.contains("routes/10-managed.conf"));
 		assertTrue(adminNginxRoute.contains("upstreams/admin_backend.conf"));
 		assertFalse(adminNginxRoute.contains("/api/admin/"));
@@ -444,5 +592,23 @@ class RootRetirementContractTest {
 
 	private static String read(String path) throws IOException {
 		return Files.readString(Path.of(path));
+	}
+
+	private static String run(String... command) throws Exception {
+		Process process = new ProcessBuilder(command)
+			.redirectErrorStream(true)
+			.start();
+		String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+		int exitCode = process.waitFor();
+		assertEquals(0, exitCode, output);
+		return output;
+	}
+
+	private static void assertBefore(String content, String first, String second) {
+		int firstIndex = content.indexOf(first);
+		int secondIndex = content.indexOf(second);
+		assertTrue(firstIndex >= 0, first);
+		assertTrue(secondIndex >= 0, second);
+		assertTrue(firstIndex < secondIndex, first + " should appear before " + second);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

- closes #394

## Work Description ✏️

- `deploy-dev`, `deploy-prod`의 multi-module deploy 순서를 `admin -> apis -> batch`로 변경했습니다.
- shared upstream 상태를 단일 `upstreams/00-managed.conf`에서 분리해 module ownership을 나눴습니다.
  - `generated/upstreams/backend.conf`
  - `generated/upstreams/admin_backend.conf`
  - `generated/upstreams/actuator.conf`
- `app_bluegreen`은 `backend` / `actuator` fragment만 관리하도록 좁혔습니다.
- `admin_nginx_route`는 `admin_backend` fragment만 관리하도록 좁혔습니다.
- `nginx_base_config`의 seed / backup / restore / cleanup 흐름을 fragment 구조에 맞게 갱신했습니다.
- `infra/README.md`와 `RootRetirementContractTest`를 새 upstream fragment 계약에 맞게 갱신했습니다.
- 후속 수정으로, blue-green rescue 경로에서 target fragment를 복원할 때 잘못된 `.bak` 경로를 보던 rollback bug도 함께 수정했습니다.

## Trouble Shooting ⚽️

문제의 핵심은 `apis` 앱 자체가 아니라 shared nginx upstream ownership coupling 이었습니다.

기존 구조에서는:
- shared 변경 시 `apis -> admin -> batch` 순서로 deploy 되었고
- `apis` blue-green deploy는 자기 upstream만 바꾸면서도 `nginx -t`로 전체 shared upstream file을 검증했습니다.
- 그 shared file 안에는 `admin_backend -> admin:4000`가 남아 있었고,
- 아직 `admin`이 배포 시작 전이면 `admin:4000`이 unresolved 상태일 수 있어 `nginx -t`가 실패했습니다.

이번 PR은:
1. 순서 변경으로 즉시 차단하고
2. upstream ownership을 per-fragment로 분리해서
3. unrelated upstream가 다른 모듈 deploy를 깨지 않도록 blast radius를 줄이고
4. split 이후 rollback 경로도 실제 backup/restore semantics에 맞게 정리했습니다.

## Related ScreenShot 📷

- N/A

## Uncompleted Tasks 😅

- 로컬에서 `ansible-lint` binary가 없어 lint는 아직 직접 실행하지 못했습니다.
- 실제 dev/prod 인프라 대상 live deploy 검증은 아직 하지 않았습니다.

## To Reviewers 📢

최종 커밋 구성:
- `fix: decouple shared nginx upstream ownership from deploy order`
- `fix: blue-green fragment rollback restore paths`

로컬 검증:

```bash
git diff --check
```

```bash
./gradlew --no-daemon :test --tests com.beat.RootRetirementContractTest --rerun-tasks --console=plain
```

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-dev.yml"); YAML.load_file(".github/workflows/deploy-prod.yml")'
```

```bash
cd infra/ansible
ansible-playbook playbooks/deploy.yml -i inventories/dev/hosts.yml --syntax-check -e module=apis -e image=test -e image_tag=test
ansible-playbook playbooks/deploy.yml -i inventories/dev/hosts.yml --syntax-check -e module=admin -e image=test -e image_tag=test
ansible-playbook playbooks/rollback.yml -i inventories/dev/hosts.yml --syntax-check -e module=admin
```

추가로, `ansible-lint`는 하면 더 좋습니다. 이번 변경이 Ansible role/task 중심이라 CI 전에 한 번 더 돌리면 안전성이 올라갑니다. 다만 현재 로컬엔 binary가 없어서 이번 PR에는 미실행으로 남겨둡니다.