### PR TITLE
feat: 티켓 v2 API CQRS 구조 추가

### DIFF
--- a/apis/src/main/kotlin/com/beat/apis/booking/api/TicketV2Api.kt
+++ b/apis/src/main/kotlin/com/beat/apis/booking/api/TicketV2Api.kt
@@ -1,0 +1,160 @@
+package com.beat.apis.booking.api
+
+import com.beat.apis.booking.application.dto.TicketDeleteRequest
+import com.beat.apis.booking.application.dto.TicketRefundRequest
+import com.beat.apis.booking.application.dto.TicketRetrieveResponse
+import com.beat.apis.booking.application.dto.TicketUpdateRequest
+import com.beat.domain.booking.domain.BookingStatus
+import com.beat.domain.schedule.domain.ScheduleNumber
+import com.beat.gateway.annotation.CurrentMember
+import com.beat.global.common.dto.ErrorResponse
+import com.beat.global.common.dto.SuccessResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "Ticket", description = "티켓 관련 API")
+interface TicketV2Api {
+
+    @Operation(summary = "예매자 목록 조회 API", description = "메이커가 자신의 공연에 대한 예매자 목록을 조회하는 GET API입니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "예매자 목록 조회 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "입력하신 정보와 일치하는 예매자 목록이 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "공연 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회차 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+        ],
+    )
+    fun getTickets(
+        @CurrentMember memberId: Long,
+        @PathVariable performanceId: Long,
+        @RequestParam(required = false) scheduleNumbers: List<ScheduleNumber>?,
+        @RequestParam(required = false) bookingStatuses: List<BookingStatus>?,
+    ): ResponseEntity<SuccessResponse<TicketRetrieveResponse>>
+
+    @Operation(summary = "예매자 목록 검색 API", description = "메이커가 자신의 공연에 대한 예매자 목록을 검색하는 GET API입니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "예매자 목록 검색 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "입력하신 정보와 일치하는 예매자 목록이 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "공연 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회차 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+        ],
+    )
+    fun searchTickets(
+        @CurrentMember memberId: Long,
+        @PathVariable performanceId: Long,
+        @RequestParam searchWord: String,
+        @RequestParam(required = false) scheduleNumbers: List<ScheduleNumber>?,
+        @RequestParam(required = false) bookingStatuses: List<BookingStatus>?,
+    ): ResponseEntity<SuccessResponse<TicketRetrieveResponse>>
+
+    @Operation(summary = "예매자 입금여부 수정 및 웹발신 API", description = "메이커가 자신의 공연에 대한 예매자의 입금여부 정보를 수정한 뒤 예매확정 웹발신을 보내는 PUT API입니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "예매자 입금여부 수정 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "이미 결제가 완료된 티켓의 상태는 변경할 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "공연 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회차 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+        ],
+    )
+    fun updateTickets(
+        @CurrentMember memberId: Long,
+        @RequestBody request: TicketUpdateRequest,
+    ): ResponseEntity<SuccessResponse<Void>>
+
+    @Operation(summary = "예매자 환불처리 API", description = "메이커가 자신의 공연에 대한 1명 이상의 예매자의 정보를 환불완료 상태로 변경하는 PUT API입니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "예매자 환불처리 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "해당 예매 내역을 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "공연 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회차 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+        ],
+    )
+    fun refundTickets(
+        @CurrentMember memberId: Long,
+        @RequestBody ticketRefundRequest: TicketRefundRequest,
+    ): ResponseEntity<SuccessResponse<Void>>
+
+    @Operation(summary = "예매자 삭제 API", description = "메이커가 자신의 공연에 대한 1명 이상의 예매자의 정보를 삭제하는 PUT API입니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "예매자 삭제 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "해당 예매 내역을 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "공연 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회차 정보를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+        ],
+    )
+    fun deleteTickets(
+        @CurrentMember memberId: Long,
+        @RequestBody ticketDeleteRequest: TicketDeleteRequest,
+    ): ResponseEntity<SuccessResponse<Void>>
+}

--- a/apis/src/main/kotlin/com/beat/apis/booking/api/TicketV2Controller.kt
+++ b/apis/src/main/kotlin/com/beat/apis/booking/api/TicketV2Controller.kt
@@ -1,0 +1,114 @@
+package com.beat.apis.booking.api
+
+import com.beat.apis.booking.application.dto.TicketDeleteRequest
+import com.beat.apis.booking.application.dto.TicketRefundRequest
+import com.beat.apis.booking.application.dto.TicketRetrieveResponse
+import com.beat.apis.booking.application.dto.TicketUpdateRequest
+import com.beat.apis.booking.facade.TicketFacade
+import com.beat.domain.booking.domain.BookingStatus
+import com.beat.domain.booking.exception.TicketErrorCode
+import com.beat.domain.booking.exception.TicketSuccessCode
+import com.beat.domain.schedule.domain.ScheduleNumber
+import com.beat.gateway.annotation.CurrentMember
+import com.beat.global.common.dto.SuccessResponse
+import com.beat.global.common.exception.BadRequestException
+import org.springframework.http.CacheControl
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v2/tickets")
+class TicketV2Controller
+    private val ticketFacade: TicketFacade,
+) : TicketV2Api {
+
+    @GetMapping("/{performanceId}")
+    override fun getTickets(
+        @CurrentMember memberId: Long,
+        @PathVariable performanceId: Long,
+        @RequestParam(required = false) scheduleNumbers: List<ScheduleNumber>?,
+        @RequestParam(required = false) bookingStatuses: List<BookingStatus>?,
+    ): ResponseEntity<SuccessResponse<TicketRetrieveResponse>> {
+        validateDeletedTicketRetrieveNotAllowed(bookingStatuses)
+
+        val response = ticketFacade.findAllTicketsByConditions(
+            memberId = memberId,
+            performanceId = performanceId,
+            scheduleNumbers = scheduleNumbers,
+            bookingStatuses = bookingStatuses,
+        )
+
+        return ResponseEntity.ok(
+            SuccessResponse.of(TicketSuccessCode.TICKET_RETRIEVE_SUCCESS, response),
+        )
+    }
+
+    @GetMapping("/search/{performanceId}")
+    override fun searchTickets(
+        @CurrentMember memberId: Long,
+        @PathVariable performanceId: Long,
+        @RequestParam searchWord: String,
+        @RequestParam(required = false) scheduleNumbers: List<ScheduleNumber>?,
+        @RequestParam(required = false) bookingStatuses: List<BookingStatus>?,
+    ): ResponseEntity<SuccessResponse<TicketRetrieveResponse>> {
+        if (searchWord.length < MIN_SEARCH_WORD_LENGTH) {
+            throw BadRequestException(TicketErrorCode.SEARCH_WORD_TOO_SHORT)
+        }
+        validateDeletedTicketRetrieveNotAllowed(bookingStatuses)
+
+        val response = ticketFacade.searchAllTicketsByConditions(
+            memberId = memberId,
+            performanceId = performanceId,
+            searchWord = searchWord,
+            scheduleNumbers = scheduleNumbers,
+            bookingStatuses = bookingStatuses,
+        )
+
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.noCache())
+            .body(SuccessResponse.of(TicketSuccessCode.TICKET_SEARCH_SUCCESS, response))
+    }
+
+    @PutMapping("/update")
+    override fun updateTickets(
+        @CurrentMember memberId: Long,
+        @RequestBody ticketUpdateRequest: TicketUpdateRequest,
+    ): ResponseEntity<SuccessResponse<Void>> {
+        ticketFacade.updateTickets(memberId, ticketUpdateRequest)
+        return ResponseEntity.ok(SuccessResponse.from(TicketSuccessCode.TICKET_UPDATE_SUCCESS))
+    }
+
+    @PutMapping("/refund")
+    override fun refundTickets(
+        @CurrentMember memberId: Long,
+        @RequestBody ticketRefundRequest: TicketRefundRequest,
+    ): ResponseEntity<SuccessResponse<Void>> {
+        ticketFacade.refundTicketsByBookingIds(memberId, ticketRefundRequest)
+        return ResponseEntity.ok(SuccessResponse.from(TicketSuccessCode.TICKET_REFUND_SUCCESS))
+    }
+
+    @PutMapping("/delete")
+    override fun deleteTickets(
+        @CurrentMember memberId: Long,
+        @RequestBody ticketDeleteRequest: TicketDeleteRequest,
+    ): ResponseEntity<SuccessResponse<Void>> {
+        ticketFacade.deleteTicketsByBookingIds(memberId, ticketDeleteRequest)
+        return ResponseEntity.ok(SuccessResponse.from(TicketSuccessCode.TICKET_DELETE_SUCCESS))
+    }
+
+    private fun validateDeletedTicketRetrieveNotAllowed(bookingStatuses: List<BookingStatus>?) {
+        if (bookingStatuses?.contains(BookingStatus.BOOKING_DELETED) == true) {
+            throw BadRequestException(TicketErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED)
+        }
+    }
+
+    companion object {
+        private const val MIN_SEARCH_WORD_LENGTH = 2
+    }
+}

--- a/apis/src/main/kotlin/com/beat/apis/booking/api/TicketV2Controller.kt
+++ b/apis/src/main/kotlin/com/beat/apis/booking/api/TicketV2Controller.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v2/tickets")
-class TicketV2Controller
+class TicketV2Controller(
     private val ticketFacade: TicketFacade,
 ) : TicketV2Api {
 

--- a/apis/src/main/kotlin/com/beat/apis/booking/application/service/command/TicketCommandService.kt
+++ b/apis/src/main/kotlin/com/beat/apis/booking/application/service/command/TicketCommandService.kt
@@ -1,0 +1,156 @@
+package com.beat.apis.booking.application.service.command
+
+import com.beat.apis.booking.application.dto.TicketDeleteRequest
+import com.beat.apis.booking.application.dto.TicketRefundRequest
+import com.beat.apis.booking.application.dto.TicketUpdateRequest
+import com.beat.contracts.sms.SmsMessage
+import com.beat.contracts.sms.SmsPort
+import com.beat.domain.booking.dao.TicketRepository
+import com.beat.domain.booking.domain.Booking
+import com.beat.domain.booking.domain.BookingStatus
+import com.beat.domain.booking.exception.BookingErrorCode
+import com.beat.domain.booking.exception.TicketErrorCode
+import com.beat.domain.member.dao.MemberRepository
+import com.beat.domain.member.domain.Member
+import com.beat.domain.member.exception.MemberErrorCode
+import com.beat.domain.performance.dao.PerformanceRepository
+import com.beat.domain.performance.domain.Performance
+import com.beat.domain.performance.exception.PerformanceErrorCode
+import com.beat.domain.schedule.dao.ScheduleRepository
+import com.beat.domain.user.dao.UserRepository
+import com.beat.domain.user.domain.Users
+import com.beat.domain.user.exception.UserErrorCode
+import com.beat.global.common.exception.BadRequestException
+import com.beat.global.common.exception.ForbiddenException
+import com.beat.global.common.exception.NotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class TicketCommandService(
+    private val ticketRepository: TicketRepository,
+    private val performanceRepository: PerformanceRepository,
+    private val memberRepository: MemberRepository,
+    private val userRepository: UserRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val smsPort: SmsPort,
+) {
+
+    fun updateTickets(memberId: Long, request: TicketUpdateRequest) {
+        val member = findMember(memberId)
+        val user = findUser(member)
+        val performance = findPerformance(request.performanceId())
+        performance.validatePerformanceOwnership(user.id)
+
+        request.bookingList().forEach { detail ->
+            val booking = findBooking(detail.bookingId())
+
+            if (
+                booking.bookingStatus == BookingStatus.BOOKING_CONFIRMED &&
+                detail.bookingStatus() != BookingStatus.BOOKING_CONFIRMED
+            ) {
+                throw BadRequestException(TicketErrorCode.PAYMENT_COMPLETED_TICKET_UPDATE_NOT_ALLOWED)
+            }
+
+            if (
+                booking.bookingStatus == BookingStatus.CHECKING_PAYMENT &&
+                detail.bookingStatus() == BookingStatus.BOOKING_CONFIRMED
+            ) {
+                booking.updateBookingStatus(BookingStatus.BOOKING_CONFIRMED)
+                ticketRepository.save(booking)
+
+                sendBookingConfirmedSms(
+                    bookerName = detail.bookerName(),
+                    bookerPhoneNumber = detail.bookerPhoneNumber(),
+                    performanceTitle = request.performanceTitle(),
+                )
+            }
+        }
+    }
+
+    fun refundTicketsByBookingIds(memberId: Long, request: TicketRefundRequest) {
+        val member = findMember(memberId)
+        val user = findUser(member)
+        val performance = findPerformance(request.performanceId())
+        performance.validatePerformanceOwnership(user.id)
+
+        request.bookingList().forEach { bookingRequest ->
+            val booking = findBooking(bookingRequest.bookingId())
+
+            booking.updateBookingStatus(BookingStatus.BOOKING_CANCELLED)
+            ticketRepository.save(booking)
+
+            decreaseSoldTicketCountAndReopenBookingIfNeeded(booking)
+        }
+    }
+
+    fun deleteTicketsByBookingIds(memberId: Long, request: TicketDeleteRequest) {
+        val member = findMember(memberId)
+        val userId = findUser(member).id
+        val performance = findPerformance(request.performanceId())
+        performance.validatePerformanceOwnership(userId)
+
+        if (performance.users.id != userId) {
+            throw ForbiddenException(PerformanceErrorCode.NOT_PERFORMANCE_OWNER)
+        }
+
+        request.bookingList().forEach { bookingRequest ->
+            val booking = findBooking(bookingRequest.bookingId())
+
+            booking.updateBookingStatus(BookingStatus.BOOKING_DELETED)
+            ticketRepository.save(booking)
+
+            decreaseSoldTicketCountAndReopenBookingIfNeeded(booking)
+        }
+    }
+
+    private fun sendBookingConfirmedSms(
+        bookerName: String,
+        bookerPhoneNumber: String,
+        performanceTitle: String,
+    ) {
+        val message = "[BEAT] ${bookerName}님 $performanceTitle 예매 확정되었습니다."
+
+        try {
+            smsPort.sendSms(SmsMessage(bookerPhoneNumber, message))
+        } catch (exception: RuntimeException) {
+            log.error("SMS 전송 실패 - 예매자: {}, 공연: {}", bookerName, performanceTitle, exception)
+        }
+    }
+
+    private fun decreaseSoldTicketCountAndReopenBookingIfNeeded(booking: Booking) {
+        val schedule = booking.schedule
+        schedule.decreaseSoldTicketCount(booking.purchaseTicketCount)
+
+        if (!schedule.isBooking) {
+            schedule.updateIsBooking(true)
+            scheduleRepository.save(schedule)
+        }
+    }
+
+    private fun findMember(memberId: Long): Member {
+        return memberRepository.findById(memberId)
+            .orElseThrow { NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND) }
+    }
+
+    private fun findUser(member: Member): Users {
+        return userRepository.findById(member.user.id)
+            .orElseThrow { NotFoundException(UserErrorCode.USER_NOT_FOUND) }
+    }
+
+    private fun findPerformance(performanceId: Long): Performance {
+        return performanceRepository.findById(performanceId)
+            .orElseThrow { NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND) }
+    }
+
+    private fun findBooking(bookingId: Long): Booking {
+        return ticketRepository.findById(bookingId)
+            .orElseThrow { NotFoundException(BookingErrorCode.NO_BOOKING_FOUND) }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(TicketCommandService::class.java)
+    }
+}

--- a/apis/src/main/kotlin/com/beat/apis/booking/application/service/query/TicketQueryService.kt
+++ b/apis/src/main/kotlin/com/beat/apis/booking/application/service/query/TicketQueryService.kt
@@ -1,0 +1,184 @@
+package com.beat.apis.booking.application.service.query
+
+import com.beat.apis.booking.application.dto.TicketDetail
+import com.beat.apis.booking.application.dto.TicketRetrieveResponse
+import com.beat.domain.booking.dao.TicketRepository
+import com.beat.domain.booking.domain.Booking
+import com.beat.domain.booking.domain.BookingStatus
+import com.beat.domain.member.dao.MemberRepository
+import com.beat.domain.member.domain.Member
+import com.beat.domain.member.exception.MemberErrorCode
+import com.beat.domain.performance.dao.PerformanceRepository
+import com.beat.domain.performance.domain.BankName
+import com.beat.domain.performance.domain.Performance
+import com.beat.domain.performance.exception.PerformanceErrorCode
+import com.beat.domain.schedule.dao.ScheduleRepository
+import com.beat.domain.schedule.domain.Schedule
+import com.beat.domain.schedule.domain.ScheduleNumber
+import com.beat.domain.user.dao.UserRepository
+import com.beat.domain.user.domain.Users
+import com.beat.domain.user.exception.UserErrorCode
+import com.beat.global.common.exception.NotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class TicketQueryService(
+    private val ticketRepository: TicketRepository,
+    private val performanceRepository: PerformanceRepository,
+    private val memberRepository: MemberRepository,
+    private val userRepository: UserRepository,
+    private val scheduleRepository: ScheduleRepository,
+) {
+
+    fun findAllTicketsByConditions(
+        memberId: Long,
+        performanceId: Long,
+        scheduleNumbers: List<ScheduleNumber>?,
+        bookingStatuses: List<BookingStatus>?,
+    ): TicketRetrieveResponse {
+        val member = findMember(memberId)
+        val user = findUser(member)
+        val performance = findPerformance(performanceId)
+        performance.validatePerformanceOwnership(user.id)
+
+        val schedules = scheduleRepository.findAllByPerformanceId(performanceId)
+        val totalPerformanceTicketCount = calculateTotalTicketCount(schedules)
+        val totalPerformanceSoldTicketCount = calculateTotalSoldTicketCount(schedules)
+
+        log.info("performanceId: {}", performanceId)
+        log.info("scheduleNumbers: {}", scheduleNumbers)
+        log.info("bookingStatuses: {}", bookingStatuses)
+
+        val bookings = ticketRepository.findBookingsByPerformanceIdAndScheduleNumbersAndBookingStatuses(
+            performanceId,
+            scheduleNumbers,
+            bookingStatuses,
+        )
+
+        return toTicketRetrieveResponse(
+            performance = performance,
+            totalPerformanceTicketCount = totalPerformanceTicketCount,
+            totalPerformanceSoldTicketCount = totalPerformanceSoldTicketCount,
+            bookings = bookings,
+        )
+    }
+
+    fun searchAllTicketsByConditions(
+        memberId: Long,
+        performanceId: Long,
+        searchWord: String,
+        scheduleNumbers: List<ScheduleNumber>?,
+        bookingStatuses: List<BookingStatus>?,
+    ): TicketRetrieveResponse {
+        val member = findMember(memberId)
+        val user = findUser(member)
+        val performance = findPerformance(performanceId)
+        performance.validatePerformanceOwnership(user.id)
+
+        val schedules = scheduleRepository.findAllByPerformanceId(performanceId)
+        val totalPerformanceTicketCount = calculateTotalTicketCount(schedules)
+        val totalPerformanceSoldTicketCount = calculateTotalSoldTicketCount(schedules)
+
+        val selectedScheduleNumbers = scheduleNumbers
+            ?.takeIf { it.isNotEmpty() }
+            ?.map { it.name }
+            ?: schedules.map { it.scheduleNumber.name }
+
+        val selectedBookingStatuses = bookingStatuses
+            ?.takeIf { it.isNotEmpty() }
+            ?.map { it.name }
+            ?: DEFAULT_SEARCH_BOOKING_STATUSES.map { it.name }
+
+        log.info("performanceId: {}", performanceId)
+        log.info("searchWord: {}", searchWord)
+        log.info("selectedScheduleNumbers: {}", selectedScheduleNumbers)
+        log.info("selectedBookingStatuses: {}", selectedBookingStatuses)
+
+        val bookings = ticketRepository.searchBookingsByPerformanceIdAndSearchWordAndSchedulesNumbersAndBookingStatuses(
+            performanceId,
+            searchWord,
+            selectedScheduleNumbers,
+            selectedBookingStatuses,
+        )
+
+        log.info("searchTickets result: {}", bookings)
+
+        return toTicketRetrieveResponse(
+            performance = performance,
+            totalPerformanceTicketCount = totalPerformanceTicketCount,
+            totalPerformanceSoldTicketCount = totalPerformanceSoldTicketCount,
+            bookings = bookings,
+        )
+    }
+
+    private fun toTicketRetrieveResponse(
+        performance: Performance,
+        totalPerformanceTicketCount: Int,
+        totalPerformanceSoldTicketCount: Int,
+        bookings: List<Booking>,
+    ): TicketRetrieveResponse {
+        val bookingList = bookings.map { booking ->
+            TicketDetail.of(
+                booking.id,
+                booking.bookerName,
+                booking.bookerPhoneNumber,
+                booking.schedule.id,
+                booking.purchaseTicketCount,
+                booking.createdAt,
+                booking.bookingStatus,
+                booking.schedule.scheduleNumber.name,
+                booking.bankName?.name ?: BankName.NONE.displayName,
+                booking.accountNumber,
+                booking.accountHolder,
+            )
+        }
+
+        log.info("Converted TicketDetail list: {}", bookingList)
+
+        return TicketRetrieveResponse.of(
+            performance.performanceTitle,
+            performance.performanceTeamName,
+            performance.totalScheduleCount,
+            totalPerformanceTicketCount,
+            totalPerformanceSoldTicketCount,
+            bookingList,
+        )
+    }
+
+    private fun findMember(memberId: Long): Member {
+        return memberRepository.findById(memberId)
+            .orElseThrow { NotFoundException(MemberErrorCode.MEMBER_NOT_FOUND) }
+    }
+
+    private fun findUser(member: Member): Users {
+        return userRepository.findById(member.user.id)
+            .orElseThrow { NotFoundException(UserErrorCode.USER_NOT_FOUND) }
+    }
+
+    private fun findPerformance(performanceId: Long): Performance {
+        return performanceRepository.findById(performanceId)
+            .orElseThrow { NotFoundException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND) }
+    }
+
+    private fun calculateTotalTicketCount(schedules: List<Schedule>): Int {
+        return schedules.sumOf { it.totalTicketCount }
+    }
+
+    private fun calculateTotalSoldTicketCount(schedules: List<Schedule>): Int {
+        return schedules.sumOf { it.soldTicketCount }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(TicketQueryService::class.java)
+
+        private val DEFAULT_SEARCH_BOOKING_STATUSES = listOf(
+            BookingStatus.CHECKING_PAYMENT,
+            BookingStatus.BOOKING_CONFIRMED,
+            BookingStatus.BOOKING_CANCELLED,
+            BookingStatus.REFUND_REQUESTED,
+        )
+    }
+}

--- a/apis/src/main/kotlin/com/beat/apis/booking/facade/TicketFacade.kt
+++ b/apis/src/main/kotlin/com/beat/apis/booking/facade/TicketFacade.kt
@@ -1,0 +1,60 @@
+package com.beat.apis.booking.facade
+
+import com.beat.apis.booking.application.dto.TicketDeleteRequest
+import com.beat.apis.booking.application.dto.TicketRefundRequest
+import com.beat.apis.booking.application.dto.TicketRetrieveResponse
+import com.beat.apis.booking.application.dto.TicketUpdateRequest
+import com.beat.apis.booking.application.service.command.TicketCommandService
+import com.beat.apis.booking.application.service.query.TicketQueryService
+import com.beat.domain.booking.domain.BookingStatus
+import com.beat.domain.schedule.domain.ScheduleNumber
+import org.springframework.stereotype.Component
+
+@Component
+class TicketFacade(
+    private val ticketQueryService: TicketQueryService,
+    private val ticketCommandService: TicketCommandService,
+) {
+
+    fun findAllTicketsByConditions(
+        memberId: Long,
+        performanceId: Long,
+        scheduleNumbers: List<ScheduleNumber>?,
+        bookingStatuses: List<BookingStatus>?,
+    ): TicketRetrieveResponse {
+        return ticketQueryService.findAllTicketsByConditions(
+            memberId = memberId,
+            performanceId = performanceId,
+            scheduleNumbers = scheduleNumbers,
+            bookingStatuses = bookingStatuses,
+        )
+    }
+
+    fun searchAllTicketsByConditions(
+        memberId: Long,
+        performanceId: Long,
+        searchWord: String,
+        scheduleNumbers: List<ScheduleNumber>?,
+        bookingStatuses: List<BookingStatus>?,
+    ): TicketRetrieveResponse {
+        return ticketQueryService.searchAllTicketsByConditions(
+            memberId = memberId,
+            performanceId = performanceId,
+            searchWord = searchWord,
+            scheduleNumbers = scheduleNumbers,
+            bookingStatuses = bookingStatuses,
+        )
+    }
+
+    fun updateTickets(memberId: Long, request: TicketUpdateRequest) {
+        ticketCommandService.updateTickets(memberId, request)
+    }
+
+    fun refundTicketsByBookingIds(memberId: Long, request: TicketRefundRequest) {
+        ticketCommandService.refundTicketsByBookingIds(memberId, request)
+    }
+
+    fun deleteTicketsByBookingIds(memberId: Long, request: TicketDeleteRequest) {
+        ticketCommandService.deleteTicketsByBookingIds(memberId, request)
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Work Description ✏️

## 작업 목적

티켓 API를 예시로 `apis` 모듈의 application service 레벨에 CQRS 구조를 적용했습니다.

기존 v1 API와 Java DTO는 유지하고, `/api/v2/tickets` 경로에 Kotlin 기반 v2 API를 추가했습니다.

## 주요 변경 사항

### 티켓 v2 API 추가

- `TicketV2Api`
- `TicketV2Controller`

기존 `/api/tickets`는 유지하고, 신규 API는 `/api/v2/tickets`로 분리했습니다.

### Facade 레이어 추가

기존 직접 service 호출 구조 대신 아래 흐름을 적용했습니다.

```
Controller -> Facade -> CommandService / QueryService
```

- `TicketFacade`가 티켓 API 유스케이스 진입점 역할을 담당합니다.
- Controller는 HTTP 요청/응답 처리에 집중하도록 분리했습니다.

### CQRS 구조 적용

기존 `TicketService`의 책임을 조회/변경 기준으로 분리했습니다.

- `TicketQueryService`
    - 예매자 목록 조회
    - 예매자 목록 검색
    - 조회 응답 조립
- `TicketCommandService`
    - 예매 상태 수정
    - 환불 처리
    - 삭제 처리
    - 예매 확정 SMS 발송

## 범위 제외

이번 PR은 CQRS 예시 구조 도입에 집중하기 위해 DTO Kotlin 마이그레이션은 포함하지 않았습니다.

- 기존 Java DTO 유지
- 기존 Java v1 Controller/Service 유지
- domain / infra 레이어 변경 없음

## 영향 범위

- 신규 API 경로 `/api/v2/tickets` 추가
- 기존 `/api/tickets` 동작 변경 없음
- 모듈 의존성 변경 없음

## 후속 작업

- DTO Kotlin 전환
- 기존 v1 API와 중복 로직 정리
- 다른 booking 도메인 서비스로 CQRS 구조 확장 검토
