### PR TITLE
refactor: EnableInfraBaseConfig 런타임 메타 애노테이션 명시

### DIFF
--- a/infra/src/main/java/com/beat/infra/EnableInfraBaseConfig.java
+++ b/infra/src/main/java/com/beat/infra/EnableInfraBaseConfig.java
@@ -1,7 +1,16 @@
 package com.beat.infra;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.springframework.context.annotation.Import;
 
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
 @Import(InfraBaseConfigImportSelector.class)
 public @interface EnableInfraBaseConfig {
 


### PR DESCRIPTION
## Related issue 🛠

- closes #398

## Work Description ✏️

- `EnableInfraBaseConfig`에 Spring `@EnableXxx` 스타일 메타 애노테이션 계약을 명시했습니다.
  - `@Target(ElementType.TYPE)`
  - `@Retention(RetentionPolicy.RUNTIME)`
  - `@Documented`
- Java 기본 retention(`CLASS`)에 기대지 않도록 하여 reflection / `AnnotationMetadata.introspect(Class)` 기반 메타데이터 조회 경로의 안정성을 높였습니다.
- `@Inherited`는 추가하지 않았습니다. infra config 활성화가 하위 타입으로 자동 전파되어야 한다는 요구가 없기 때문입니다.

## Trouble Shooting ⚽️

- 기존 annotation은 `@Import(InfraBaseConfigImportSelector.class)`만 갖고 있어 Java annotation 기본 retention인 `CLASS`가 적용됩니다.
- 현재 Kotlin/ASM metadata 경로에서는 동작할 수 있지만, Java 사용처나 reflective Spring metadata 경로에서는 `EnableInfraBaseConfig` attributes 조회가 안정적으로 보장되지 않을 수 있습니다.

## Related ScreenShot 📷

- N/A

## Uncompleted Tasks 😅

- `apis` context boot 검증은 현재 브랜치의 기존 `apis` 테스트 컴파일 오류로 실행 완료하지 못했습니다.

## To Reviewers 📢

로컬 검증:

```bash
git diff --check
```

```bash
./gradlew --no-daemon :infra:compileJava --console=plain
```

참고로 별도 로컬 확인에서 `javap` 기준 `Target`, `Retention(RUNTIME)`, `Documented`, `Import`가 `RuntimeVisibleAnnotations`에 존재함을 확인했습니다.