### PR TITLE
docs: Java 25 migration baseline 문서 정합성 정리

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,5 +1,5 @@
 # BEAT team standard:
 # - Gradle launcher: JDK 25
 # - Toolchain: JDK 25
-# - Runtime target: Java 21
+# - Runtime target: Java 25
 java=25.0.2-tem

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@
 | 구분 | 현재 기준 |
 | --- | --- |
 | Spring | Spring Boot `4.0.5` |
-| Language / Runtime | Kotlin `2.3.20`, Java toolchain JDK `25`, Java compile release / Kotlin JVM target `25` |
+| Language / Runtime | Kotlin `2.3.20`, Java toolchain JDK `25`, Java compile release / Kotlin JVM target `25`, Docker runtime Java `25` |
 | Build | Gradle wrapper, root project는 실행 모듈이 아니라 공통 검증/조정 역할 |
 | 실행 모듈 | `apis`, `admin`, `batch` |
 | shared/support 모듈 | `domain`, `gateway`, `infra`, `global-utils`, `module-contracts`, `observability` |
@@ -28,6 +28,8 @@
 | Java toolchain | root `build.gradle.kts`와 `build-logic/build.gradle.kts`의 `JavaLanguageVersion.of(25)` | JDK `25` |
 | Java bytecode target | root `build.gradle.kts`와 `build-logic/build.gradle.kts`의 `options.release.set(25)` | release `25` |
 | Kotlin JVM target | root `build.gradle.kts`와 `build-logic/build.gradle.kts`의 `JvmTarget.JVM_25` | JVM `25` |
+| SDKMAN local JDK | `.sdkmanrc`의 `java=25.0.2-tem` 및 BEAT team standard 주석 | JDK `25` |
+| Docker runtime | `Dockerfile.module`의 `eclipse-temurin:25-jre-alpine` | Java `25` |
 
 확인 명령:
 

--- a/src/test/java/com/beat/SharedBoundaryContractTest.java
+++ b/src/test/java/com/beat/SharedBoundaryContractTest.java
@@ -17,6 +17,40 @@ import org.junit.jupiter.api.Test;
 class SharedBoundaryContractTest {
 
 	@Test
+	void migrationRuntimeBaselineMatchesCurrentBuildAndDockerSettings() throws Exception {
+		String migration = Files.readString(Path.of("MIGRATION.md"));
+		String sdkman = Files.readString(Path.of(".sdkmanrc"));
+		String rootBuild = Files.readString(Path.of("build.gradle.kts"));
+		String buildLogic = Files.readString(Path.of("build-logic/src/main/kotlin/beat.kotlin-base.gradle.kts"));
+		String buildLogicBuild = Files.readString(Path.of("build-logic/build.gradle.kts"));
+		String dockerfile = Files.readString(Path.of("Dockerfile.module"));
+		String versions = Files.readString(Path.of("gradle/libs.versions.toml"));
+
+		assertTrue(versions.contains("spring-boot = \"4.0.5\""));
+		assertTrue(versions.contains("kotlin = \"2.3.20\""));
+		assertTrue(migration.contains("Spring Boot `4.0.5`"));
+		assertTrue(migration.contains("Kotlin `2.3.20`"));
+		assertTrue(migration.contains("Docker runtime Java `25`"));
+
+		assertTrue(sdkman.contains("java=25.0.2-tem"));
+		assertTrue(sdkman.contains("Runtime target: Java 25"));
+		assertFalse(sdkman.contains("Runtime target: Java 21"));
+
+		assertTrue(rootBuild.contains("JavaLanguageVersion.of(25)"));
+		assertTrue(rootBuild.contains("options.release.set(25)"));
+		assertTrue(rootBuild.contains("JvmTarget.JVM_25"));
+		assertTrue(buildLogic.contains("JavaLanguageVersion.of(25)"));
+		assertTrue(buildLogic.contains("options.release.set(25)"));
+		assertTrue(buildLogic.contains("JvmTarget.JVM_25"));
+		assertTrue(buildLogicBuild.contains("JavaLanguageVersion.of(25)"));
+		assertTrue(buildLogicBuild.contains("options.release.set(25)"));
+		assertTrue(buildLogicBuild.contains("JvmTarget.JVM_25"));
+
+		assertTrue(dockerfile.contains("eclipse-temurin:25-jdk"));
+		assertTrue(dockerfile.contains("eclipse-temurin:25-jre-alpine"));
+	}
+
+	@Test
 	void domainRoleNoLongerOwnsSpringSecurityAuthorityBridge() throws Exception {
 		String roleSource = Files.readString(Path.of("domain/src/main/java/com/beat/domain/user/domain/Role.java"));
 		String buildFile = Files.readString(Path.of("domain/build.gradle.kts"));


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #402

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- `.sdkmanrc`의 BEAT team standard 주석을 현재 Java 25 런타임 기준과 일치하도록 수정했습니다.
- `MIGRATION.md`의 Language / Runtime 기준에 Docker runtime Java 25를 명시했습니다.
- `MIGRATION.md`의 빌드 설정 동기화 근거 표에 `.sdkmanrc`와 `Dockerfile.module` 기준을 추가했습니다.
- Java 25 migration baseline이 Gradle, SDKMAN, Docker, migration 문서 사이에서 어긋나지 않도록 contract test를 추가했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
- 기존 `.sdkmanrc` 주석에는 Runtime target이 Java 21로 남아 있어, 신규 작업자가 Java 21 런타임 호환성을 유지해야 하는 것으로 오해할 수 있었습니다.
- 실제 설정은 Java compile release 25, Kotlin JVM target 25, Docker runtime Java 25 기준이므로 문서/주석 기준을 현재 설정과 맞췄습니다.
- 전체 `test --tests ...` 명령은 멀티모듈 테스트 필터가 하위 모듈에도 적용되어 실패할 수 있어, root 테스트 task인 `:test`로 범위를 명확히 지정해 검증했습니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
- N/A

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->
- N/A

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- #350의 migration 기준은 현재 repo 설정과 맞춰 Java 25 런타임 기준으로 정리되어 있습니다.

### Verification

```bash
./gradlew --no-daemon :test --tests com.beat.SharedBoundaryContractTest
```
