### PR TITLE
refactor: apis 요청 진입점을 facade로 수렴

### DIFF
--- a/apis/src/main/java/com/beat/apis/booking/api/BookingController.java
+++ b/apis/src/main/java/com/beat/apis/booking/api/BookingController.java
@@ -11,11 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.beat.apis.booking.application.BookingCancelService;
-import com.beat.apis.booking.application.GuestBookingRetrieveService;
-import com.beat.apis.booking.application.GuestBookingService;
-import com.beat.apis.booking.application.MemberBookingRetrieveService;
-import com.beat.apis.booking.application.MemberBookingService;
 import com.beat.apis.booking.application.dto.BookingCancelRequest;
 import com.beat.apis.booking.application.dto.BookingCancelResponse;
 import com.beat.apis.booking.application.dto.BookingRefundRequest;
@@ -28,6 +23,7 @@ import com.beat.apis.booking.application.dto.MemberBookingRequest;
 import com.beat.apis.booking.application.dto.MemberBookingResponse;
 import com.beat.apis.booking.application.dto.MemberBookingRetrieveResponse;
 import com.beat.apis.booking.api.response.BookingSuccessCode;
+import com.beat.apis.booking.facade.BookingFacade;
 import com.beat.gateway.annotation.CurrentMember;
 import com.beat.global.common.dto.SuccessResponse;
 
@@ -37,18 +33,14 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/bookings")
 @RequiredArgsConstructor
 public class BookingController implements BookingApi {
-	private final MemberBookingService memberBookingService;
-	private final MemberBookingRetrieveService memberBookingRetrieveService;
-	private final GuestBookingService guestBookingService;
-	private final GuestBookingRetrieveService guestBookingRetrieveService;
-	private final BookingCancelService bookingCancelService;
+	private final BookingFacade bookingFacade;
 
 	@Override
 	@PostMapping("/member")
 	public ResponseEntity<SuccessResponse<MemberBookingResponse>> createMemberBooking(
 		@CurrentMember Long memberId,
 		@RequestBody MemberBookingRequest memberBookingRequest) {
-		MemberBookingResponse response = memberBookingService.createMemberBooking(memberId, memberBookingRequest);
+		MemberBookingResponse response = bookingFacade.createMemberBooking(memberId, memberBookingRequest);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(SuccessResponse.of(BookingSuccessCode.MEMBER_BOOKING_SUCCESS, response));
 	}
@@ -57,7 +49,7 @@ public class BookingController implements BookingApi {
 	@GetMapping("/member/retrieve")
 	public ResponseEntity<SuccessResponse<List<MemberBookingRetrieveResponse>>> getMemberBookings(
 		@CurrentMember Long memberId) {
-		List<MemberBookingRetrieveResponse> response = memberBookingRetrieveService.findMemberBookings(memberId);
+		List<MemberBookingRetrieveResponse> response = bookingFacade.findMemberBookings(memberId);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(SuccessResponse.of(BookingSuccessCode.MEMBER_BOOKING_RETRIEVE_SUCCESS, response));
 	}
@@ -66,7 +58,7 @@ public class BookingController implements BookingApi {
 	@PostMapping("/guest")
 	public ResponseEntity<SuccessResponse<GuestBookingResponse>> createGuestBookings(
 		@RequestBody GuestBookingRequest guestBookingRequest) {
-		GuestBookingResponse response = guestBookingService.createGuestBooking(guestBookingRequest);
+		GuestBookingResponse response = bookingFacade.createGuestBooking(guestBookingRequest);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(SuccessResponse.of(BookingSuccessCode.GUEST_BOOKING_SUCCESS, response));
 	}
@@ -75,7 +67,7 @@ public class BookingController implements BookingApi {
 	@PostMapping("/guest/retrieve")
 	public ResponseEntity<SuccessResponse<List<GuestBookingRetrieveResponse>>> getGuestBookings(
 		@RequestBody GuestBookingRetrieveRequest guestBookingRetrieveRequest) {
-		List<GuestBookingRetrieveResponse> response = guestBookingRetrieveService.findGuestBookings(
+		List<GuestBookingRetrieveResponse> response = bookingFacade.findGuestBookings(
 			guestBookingRetrieveRequest);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(SuccessResponse.of(BookingSuccessCode.GUEST_BOOKING_RETRIEVE_SUCCESS, response));
@@ -86,7 +78,7 @@ public class BookingController implements BookingApi {
 	public ResponseEntity<SuccessResponse<BookingRefundResponse>> refundBookings(
 		@RequestBody BookingRefundRequest bookingRefundRequest
 	) {
-		BookingRefundResponse response = bookingCancelService.refundBooking(bookingRefundRequest);
+		BookingRefundResponse response = bookingFacade.refundBooking(bookingRefundRequest);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(SuccessResponse.of(BookingSuccessCode.BOOKING_REFUND_SUCCESS, response));
 	}
@@ -96,7 +88,7 @@ public class BookingController implements BookingApi {
 	public ResponseEntity<SuccessResponse<BookingCancelResponse>> cancelBookings(
 		@RequestBody BookingCancelRequest bookingCancelRequest
 	) {
-		BookingCancelResponse response = bookingCancelService.cancelBooking(bookingCancelRequest);
+		BookingCancelResponse response = bookingFacade.cancelBooking(bookingCancelRequest);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(SuccessResponse.of(BookingSuccessCode.BOOKING_CANCEL_SUCCESS, response));
 	}

--- a/apis/src/main/java/com/beat/apis/booking/facade/BookingFacade.java
+++ b/apis/src/main/java/com/beat/apis/booking/facade/BookingFacade.java
@@ -1,0 +1,58 @@
+package com.beat.apis.booking.facade;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.apis.booking.application.BookingCancelService;
+import com.beat.apis.booking.application.GuestBookingRetrieveService;
+import com.beat.apis.booking.application.GuestBookingService;
+import com.beat.apis.booking.application.MemberBookingRetrieveService;
+import com.beat.apis.booking.application.MemberBookingService;
+import com.beat.apis.booking.application.dto.BookingCancelRequest;
+import com.beat.apis.booking.application.dto.BookingCancelResponse;
+import com.beat.apis.booking.application.dto.BookingRefundRequest;
+import com.beat.apis.booking.application.dto.BookingRefundResponse;
+import com.beat.apis.booking.application.dto.GuestBookingRequest;
+import com.beat.apis.booking.application.dto.GuestBookingResponse;
+import com.beat.apis.booking.application.dto.GuestBookingRetrieveRequest;
+import com.beat.apis.booking.application.dto.GuestBookingRetrieveResponse;
+import com.beat.apis.booking.application.dto.MemberBookingRequest;
+import com.beat.apis.booking.application.dto.MemberBookingResponse;
+import com.beat.apis.booking.application.dto.MemberBookingRetrieveResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BookingFacade {
+	private final MemberBookingService memberBookingService;
+	private final MemberBookingRetrieveService memberBookingRetrieveService;
+	private final GuestBookingService guestBookingService;
+	private final GuestBookingRetrieveService guestBookingRetrieveService;
+	private final BookingCancelService bookingCancelService;
+
+	public MemberBookingResponse createMemberBooking(Long memberId, MemberBookingRequest request) {
+		return memberBookingService.createMemberBooking(memberId, request);
+	}
+
+	public List<MemberBookingRetrieveResponse> findMemberBookings(Long memberId) {
+		return memberBookingRetrieveService.findMemberBookings(memberId);
+	}
+
+	public GuestBookingResponse createGuestBooking(GuestBookingRequest request) {
+		return guestBookingService.createGuestBooking(request);
+	}
+
+	public List<GuestBookingRetrieveResponse> findGuestBookings(GuestBookingRetrieveRequest request) {
+		return guestBookingRetrieveService.findGuestBookings(request);
+	}
+
+	public BookingRefundResponse refundBooking(BookingRefundRequest request) {
+		return bookingCancelService.refundBooking(request);
+	}
+
+	public BookingCancelResponse cancelBooking(BookingCancelRequest request) {
+		return bookingCancelService.cancelBooking(request);
+	}
+}

--- a/apis/src/main/java/com/beat/apis/external/s3/api/FileController.java
+++ b/apis/src/main/java/com/beat/apis/external/s3/api/FileController.java
@@ -1,9 +1,9 @@
 package com.beat.apis.external.s3.api;
 
-import com.beat.contracts.storage.FileStoragePort;
 import com.beat.global.common.dto.SuccessResponse;
 import com.beat.apis.external.s3.api.dto.PerformanceMakerPresignedUrlFindAllResponse;
 import com.beat.apis.external.s3.exception.FileSuccessCode;
+import com.beat.apis.external.s3.facade.FileFacade;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FileController implements FileApi {
 
-	private final FileStoragePort fileStoragePort;
+	private final FileFacade fileFacade;
 
 	@GetMapping("/presigned-url")
 	@Override
@@ -29,25 +29,12 @@ public class FileController implements FileApi {
 		@RequestParam(required = false) List<String> castImages,
 		@RequestParam(required = false) List<String> staffImages,
 		@RequestParam(required = false) List<String> performanceImages) {
-		// 토큰 주도록 변경이 필요
-		if (castImages == null) {
-			castImages = List.of();
-		}
-		if (staffImages == null) {
-			staffImages = List.of();
-		}
-		if (performanceImages == null) {
-			performanceImages = List.of();
-		}
-
 		// S3 upload URL issuance is currently public by existing API policy.
-		PerformanceMakerPresignedUrlFindAllResponse response = PerformanceMakerPresignedUrlFindAllResponse.from(
-			fileStoragePort.issueAllPresignedUrlsForPerformanceMaker(
-				posterImage,
-				castImages,
-				staffImages,
-				performanceImages
-			)
+		PerformanceMakerPresignedUrlFindAllResponse response = fileFacade.issueAllPresignedUrlsForPerformanceMaker(
+			posterImage,
+			castImages,
+			staffImages,
+			performanceImages
 		);
 		return ResponseEntity.ok(SuccessResponse.of(FileSuccessCode.PERFORMANCE_MAKER_PRESIGNED_URL_ISSUED, response));
 	}

--- a/apis/src/main/java/com/beat/apis/external/s3/application/FileService.java
+++ b/apis/src/main/java/com/beat/apis/external/s3/application/FileService.java
@@ -19,9 +19,16 @@ public class FileService {
 		List<String> castImages, List<String> staffImages, List<String> performanceImages) {
 		return fileStoragePort.issueAllPresignedUrlsForPerformanceMaker(
 			posterImage,
-			castImages,
-			staffImages,
-			performanceImages
+			nullToEmpty(castImages),
+			nullToEmpty(staffImages),
+			nullToEmpty(performanceImages)
 		);
+	}
+
+	private List<String> nullToEmpty(List<String> values) {
+		if (values == null) {
+			return List.of();
+		}
+		return values;
 	}
 }

--- a/apis/src/main/java/com/beat/apis/external/s3/application/FileService.java
+++ b/apis/src/main/java/com/beat/apis/external/s3/application/FileService.java
@@ -1,0 +1,27 @@
+package com.beat.apis.external.s3.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.contracts.storage.FileStoragePort;
+import com.beat.contracts.storage.PerformancePresignedUrls;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+	private final FileStoragePort fileStoragePort;
+
+	public PerformancePresignedUrls issueAllPresignedUrlsForPerformanceMaker(String posterImage,
+		List<String> castImages, List<String> staffImages, List<String> performanceImages) {
+		return fileStoragePort.issueAllPresignedUrlsForPerformanceMaker(
+			posterImage,
+			castImages,
+			staffImages,
+			performanceImages
+		);
+	}
+}

--- a/apis/src/main/java/com/beat/apis/external/s3/facade/FileFacade.java
+++ b/apis/src/main/java/com/beat/apis/external/s3/facade/FileFacade.java
@@ -1,0 +1,35 @@
+package com.beat.apis.external.s3.facade;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.apis.external.s3.api.dto.PerformanceMakerPresignedUrlFindAllResponse;
+import com.beat.contracts.storage.FileStoragePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FileFacade {
+	private final FileStoragePort fileStoragePort;
+
+	public PerformanceMakerPresignedUrlFindAllResponse issueAllPresignedUrlsForPerformanceMaker(String posterImage,
+		List<String> castImages, List<String> staffImages, List<String> performanceImages) {
+		return PerformanceMakerPresignedUrlFindAllResponse.from(
+			fileStoragePort.issueAllPresignedUrlsForPerformanceMaker(
+				posterImage,
+				nullToEmpty(castImages),
+				nullToEmpty(staffImages),
+				nullToEmpty(performanceImages)
+			)
+		);
+	}
+
+	private List<String> nullToEmpty(List<String> values) {
+		if (values == null) {
+			return List.of();
+		}
+		return values;
+	}
+}

--- a/apis/src/main/java/com/beat/apis/external/s3/facade/FileFacade.java
+++ b/apis/src/main/java/com/beat/apis/external/s3/facade/FileFacade.java
@@ -19,17 +19,10 @@ public class FileFacade {
 		return PerformanceMakerPresignedUrlFindAllResponse.from(
 			fileService.issueAllPresignedUrlsForPerformanceMaker(
 				posterImage,
-				nullToEmpty(castImages),
-				nullToEmpty(staffImages),
-				nullToEmpty(performanceImages)
+				castImages,
+				staffImages,
+				performanceImages
 			)
 		);
-	}
-
-	private List<String> nullToEmpty(List<String> values) {
-		if (values == null) {
-			return List.of();
-		}
-		return values;
 	}
 }

--- a/apis/src/main/java/com/beat/apis/external/s3/facade/FileFacade.java
+++ b/apis/src/main/java/com/beat/apis/external/s3/facade/FileFacade.java
@@ -5,19 +5,19 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.beat.apis.external.s3.api.dto.PerformanceMakerPresignedUrlFindAllResponse;
-import com.beat.contracts.storage.FileStoragePort;
+import com.beat.apis.external.s3.application.FileService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class FileFacade {
-	private final FileStoragePort fileStoragePort;
+	private final FileService fileService;
 
 	public PerformanceMakerPresignedUrlFindAllResponse issueAllPresignedUrlsForPerformanceMaker(String posterImage,
 		List<String> castImages, List<String> staffImages, List<String> performanceImages) {
 		return PerformanceMakerPresignedUrlFindAllResponse.from(
-			fileStoragePort.issueAllPresignedUrlsForPerformanceMaker(
+			fileService.issueAllPresignedUrlsForPerformanceMaker(
 				posterImage,
 				nullToEmpty(castImages),
 				nullToEmpty(staffImages),

--- a/apis/src/main/java/com/beat/apis/member/api/MemberController.java
+++ b/apis/src/main/java/com/beat/apis/member/api/MemberController.java
@@ -1,6 +1,5 @@
 package com.beat.apis.member.api;
 
-import com.beat.contracts.auth.RefreshTokenPort;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -11,13 +10,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.beat.apis.member.application.AuthenticationService;
-import com.beat.apis.member.application.SocialLoginService;
 import com.beat.apis.member.application.dto.request.MemberLoginRequest;
 import com.beat.apis.member.application.dto.response.AccessTokenGenerateResponse;
 import com.beat.apis.member.application.dto.response.LoginSuccessResponse;
 import com.beat.apis.member.application.dto.response.MemberLoginResponse;
 import com.beat.apis.member.api.response.MemberSuccessCode;
+import com.beat.apis.member.facade.MemberFacade;
 import com.beat.gateway.annotation.CurrentMember;
 import com.beat.global.common.dto.SuccessResponse;
 
@@ -28,9 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class MemberController implements MemberApi {
-	private final RefreshTokenPort refreshTokenPort;
-	private final AuthenticationService authenticationService;
-	private final SocialLoginService socialLoginService;
+	private final MemberFacade memberFacade;
 
 	private static final int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
 	private static final String REFRESH_TOKEN = "refreshToken";
@@ -42,7 +38,7 @@ public class MemberController implements MemberApi {
 		@RequestBody final MemberLoginRequest loginRequest,
 		HttpServletResponse httpServletResponse
 	) {
-		LoginSuccessResponse loginSuccessResponse = socialLoginService.handleSocialLogin(authorizationCode,
+		LoginSuccessResponse loginSuccessResponse = memberFacade.handleSocialLogin(authorizationCode,
 			loginRequest);
 
 		ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN, loginSuccessResponse.refreshToken())
@@ -67,7 +63,7 @@ public class MemberController implements MemberApi {
 	public ResponseEntity<SuccessResponse<AccessTokenGenerateResponse>> issueAccessTokenUsingRefreshToken(
 		@CookieValue(value = REFRESH_TOKEN) final String refreshToken
 	) {
-		AccessTokenGenerateResponse response = authenticationService.generateAccessTokenFromRefreshToken(refreshToken);
+		AccessTokenGenerateResponse response = memberFacade.generateAccessTokenFromRefreshToken(refreshToken);
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(MemberSuccessCode.ISSUE_ACCESS_TOKEN_USING_REFRESH_TOKEN, response));
 	}
@@ -77,7 +73,7 @@ public class MemberController implements MemberApi {
 	public ResponseEntity<SuccessResponse<Void>> signOut(
 		@CurrentMember final Long memberId
 	) {
-		refreshTokenPort.deleteRefreshToken(memberId);
+		memberFacade.signOut(memberId);
 		return ResponseEntity.ok()
 			.body(SuccessResponse.from(MemberSuccessCode.SIGN_OUT_SUCCESS));
 	}

--- a/apis/src/main/java/com/beat/apis/member/application/AuthenticationService.java
+++ b/apis/src/main/java/com/beat/apis/member/application/AuthenticationService.java
@@ -70,6 +70,7 @@ public class AuthenticationService {
 		validateRefreshToken(refreshToken);
 
 		Long memberId = jwtTokenPort.getMemberId(refreshToken);
+		validateMemberId(memberId);
 		verifyMemberIdWithStoredToken(refreshToken, memberId);
 
 		Role role = mapRole(jwtTokenPort.getRoleName(refreshToken));
@@ -120,6 +121,13 @@ public class AuthenticationService {
 		if (!memberId.equals(storedMemberId)) {
 			log.error("MemberId mismatch: token does not match the stored refresh token");
 			throw new BadRequestException(TokenErrorCode.REFRESH_TOKEN_MEMBER_ID_MISMATCH_ERROR);
+		}
+	}
+
+	private void validateMemberId(Long memberId) {
+		if (memberId == null) {
+			log.error("Refresh token memberId claim is missing");
+			throw new BadRequestException(TokenErrorCode.INVALID_REFRESH_TOKEN_ERROR);
 		}
 	}
 

--- a/apis/src/main/java/com/beat/apis/member/application/AuthenticationService.java
+++ b/apis/src/main/java/com/beat/apis/member/application/AuthenticationService.java
@@ -123,6 +123,11 @@ public class AuthenticationService {
 		}
 	}
 
+	@Transactional
+	public void signOut(Long memberId) {
+		refreshTokenPort.deleteRefreshToken(memberId);
+	}
+
 	private Role mapRole(String roleName) {
 		if (roleName == null || roleName.isBlank()) {
 			log.error("Refresh token role claim is missing");

--- a/apis/src/main/java/com/beat/apis/member/facade/MemberFacade.java
+++ b/apis/src/main/java/com/beat/apis/member/facade/MemberFacade.java
@@ -7,14 +7,11 @@ import com.beat.apis.member.application.SocialLoginService;
 import com.beat.apis.member.application.dto.request.MemberLoginRequest;
 import com.beat.apis.member.application.dto.response.AccessTokenGenerateResponse;
 import com.beat.apis.member.application.dto.response.LoginSuccessResponse;
-import com.beat.contracts.auth.RefreshTokenPort;
-
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MemberFacade {
-	private final RefreshTokenPort refreshTokenPort;
 	private final AuthenticationService authenticationService;
 	private final SocialLoginService socialLoginService;
 
@@ -27,6 +24,6 @@ public class MemberFacade {
 	}
 
 	public void signOut(Long memberId) {
-		refreshTokenPort.deleteRefreshToken(memberId);
+		authenticationService.signOut(memberId);
 	}
 }

--- a/apis/src/main/java/com/beat/apis/member/facade/MemberFacade.java
+++ b/apis/src/main/java/com/beat/apis/member/facade/MemberFacade.java
@@ -1,0 +1,32 @@
+package com.beat.apis.member.facade;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.apis.member.application.AuthenticationService;
+import com.beat.apis.member.application.SocialLoginService;
+import com.beat.apis.member.application.dto.request.MemberLoginRequest;
+import com.beat.apis.member.application.dto.response.AccessTokenGenerateResponse;
+import com.beat.apis.member.application.dto.response.LoginSuccessResponse;
+import com.beat.contracts.auth.RefreshTokenPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberFacade {
+	private final RefreshTokenPort refreshTokenPort;
+	private final AuthenticationService authenticationService;
+	private final SocialLoginService socialLoginService;
+
+	public LoginSuccessResponse handleSocialLogin(String authorizationCode, MemberLoginRequest loginRequest) {
+		return socialLoginService.handleSocialLogin(authorizationCode, loginRequest);
+	}
+
+	public AccessTokenGenerateResponse generateAccessTokenFromRefreshToken(String refreshToken) {
+		return authenticationService.generateAccessTokenFromRefreshToken(refreshToken);
+	}
+
+	public void signOut(Long memberId) {
+		refreshTokenPort.deleteRefreshToken(memberId);
+	}
+}

--- a/apis/src/main/java/com/beat/apis/performance/api/HomeController.java
+++ b/apis/src/main/java/com/beat/apis/performance/api/HomeController.java
@@ -1,10 +1,9 @@
 package com.beat.apis.performance.api;
 
-import com.beat.apis.performance.application.HomeService;
-import com.beat.apis.performance.application.dto.home.HomeFindRequest;
 import com.beat.apis.performance.application.dto.home.HomeFindAllResponse;
 import com.beat.domain.performance.domain.Genre;
 import com.beat.apis.performance.api.response.PerformanceSuccessCode;
+import com.beat.apis.performance.facade.HomeFacade;
 import com.beat.global.common.dto.SuccessResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -20,16 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HomeController implements HomeApi {
 
-	private final HomeService homeService;
+	private final HomeFacade homeFacade;
 
 	@Override
 	@GetMapping
 	public ResponseEntity<SuccessResponse<HomeFindAllResponse>> getHomePerformanceList(
 		@RequestParam(required = false) Genre genre) {
 
-		HomeFindRequest homeFindRequest = new HomeFindRequest(genre);
-
-		HomeFindAllResponse homeFindAllResponse = homeService.findHomePerformanceList(homeFindRequest);
+		HomeFindAllResponse homeFindAllResponse = homeFacade.findHomePerformanceList(genre);
 		return ResponseEntity.ok(
 			SuccessResponse.of(PerformanceSuccessCode.HOME_PERFORMANCE_RETRIEVE_SUCCESS, homeFindAllResponse));
 	}

--- a/apis/src/main/java/com/beat/apis/performance/api/PerformanceController.java
+++ b/apis/src/main/java/com/beat/apis/performance/api/PerformanceController.java
@@ -11,9 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.beat.apis.performance.application.PerformanceManagementService;
-import com.beat.apis.performance.application.PerformanceModifyService;
-import com.beat.apis.performance.application.PerformanceService;
 import com.beat.apis.performance.application.dto.bookingPerformanceDetail.BookingPerformanceDetailResponse;
 import com.beat.apis.performance.application.dto.create.PerformanceRequest;
 import com.beat.apis.performance.application.dto.create.PerformanceResponse;
@@ -23,6 +20,7 @@ import com.beat.apis.performance.application.dto.modify.PerformanceModifyRequest
 import com.beat.apis.performance.application.dto.modify.PerformanceModifyResponse;
 import com.beat.apis.performance.application.dto.performanceDetail.PerformanceDetailResponse;
 import com.beat.apis.performance.api.response.PerformanceSuccessCode;
+import com.beat.apis.performance.facade.PerformanceFacade;
 import com.beat.gateway.annotation.CurrentMember;
 import com.beat.global.common.dto.SuccessResponse;
 
@@ -34,16 +32,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PerformanceController implements PerformanceApi {
 
-	private final PerformanceService performanceService;
-	private final PerformanceManagementService performanceManagementService;
-	private final PerformanceModifyService performanceModifyService;
+	private final PerformanceFacade performanceFacade;
 
 	@Override
 	@PostMapping
 	public ResponseEntity<SuccessResponse<PerformanceResponse>> createPerformance(
 		@CurrentMember Long memberId,
 		@Valid @RequestBody PerformanceRequest performanceRequest) {
-		PerformanceResponse response = performanceManagementService.createPerformance(memberId, performanceRequest);
+		PerformanceResponse response = performanceFacade.createPerformance(memberId, performanceRequest);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_CREATE_SUCCESS, response));
 	}
@@ -53,7 +49,7 @@ public class PerformanceController implements PerformanceApi {
 	public ResponseEntity<SuccessResponse<PerformanceModifyResponse>> updatePerformance(
 		@CurrentMember Long memberId,
 		@Valid @RequestBody PerformanceModifyRequest performanceModifyRequest) {
-		PerformanceModifyResponse response = performanceModifyService.modifyPerformance(memberId,
+		PerformanceModifyResponse response = performanceFacade.modifyPerformance(memberId,
 			performanceModifyRequest);
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_UPDATE_SUCCESS, response));
@@ -64,7 +60,7 @@ public class PerformanceController implements PerformanceApi {
 	public ResponseEntity<SuccessResponse<PerformanceModifyDetailResponse>> getPerformanceForEdit(
 		@CurrentMember Long memberId,
 		@PathVariable Long performanceId) {
-		PerformanceModifyDetailResponse response = performanceService.getPerformanceEdit(memberId, performanceId);
+		PerformanceModifyDetailResponse response = performanceFacade.getPerformanceEdit(memberId, performanceId);
 		return ResponseEntity.ok(SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_MODIFY_PAGE_SUCCESS, response));
 	}
 
@@ -72,7 +68,7 @@ public class PerformanceController implements PerformanceApi {
 	@GetMapping("/detail/{performanceId}")
 	public ResponseEntity<SuccessResponse<PerformanceDetailResponse>> getPerformanceDetail(
 		@PathVariable Long performanceId) {
-		PerformanceDetailResponse performanceDetail = performanceService.getPerformanceDetail(performanceId);
+		PerformanceDetailResponse performanceDetail = performanceFacade.getPerformanceDetail(performanceId);
 		return ResponseEntity.ok(
 			SuccessResponse.of(PerformanceSuccessCode.PERFORMANCE_RETRIEVE_SUCCESS, performanceDetail));
 	}
@@ -81,7 +77,7 @@ public class PerformanceController implements PerformanceApi {
 	@GetMapping("/booking/{performanceId}")
 	public ResponseEntity<SuccessResponse<BookingPerformanceDetailResponse>> getBookingPerformanceDetail(
 		@PathVariable Long performanceId) {
-		BookingPerformanceDetailResponse bookingPerformanceDetail = performanceService.getBookingPerformanceDetail(
+		BookingPerformanceDetailResponse bookingPerformanceDetail = performanceFacade.getBookingPerformanceDetail(
 			performanceId);
 		return ResponseEntity.ok(
 			SuccessResponse.of(PerformanceSuccessCode.BOOKING_PERFORMANCE_RETRIEVE_SUCCESS, bookingPerformanceDetail));
@@ -90,7 +86,7 @@ public class PerformanceController implements PerformanceApi {
 	@Override
 	@GetMapping("/user")
 	public ResponseEntity<SuccessResponse<MakerPerformanceResponse>> getUserPerformances(@CurrentMember Long memberId) {
-		MakerPerformanceResponse response = performanceService.getMemberPerformances(memberId);
+		MakerPerformanceResponse response = performanceFacade.getMemberPerformances(memberId);
 		return ResponseEntity.ok(
 			SuccessResponse.of(PerformanceSuccessCode.MAKER_PERFORMANCE_RETRIEVE_SUCCESS, response));
 	}
@@ -100,7 +96,7 @@ public class PerformanceController implements PerformanceApi {
 	public ResponseEntity<SuccessResponse<Void>> deletePerformance(
 		@CurrentMember Long memberId,
 		@PathVariable Long performanceId) {
-		performanceManagementService.deletePerformance(memberId, performanceId);
+		performanceFacade.deletePerformance(memberId, performanceId);
 		return ResponseEntity.ok(SuccessResponse.from(PerformanceSuccessCode.PERFORMANCE_DELETE_SUCCESS));
 	}
 }

--- a/apis/src/main/java/com/beat/apis/performance/facade/HomeFacade.java
+++ b/apis/src/main/java/com/beat/apis/performance/facade/HomeFacade.java
@@ -1,0 +1,20 @@
+package com.beat.apis.performance.facade;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.apis.performance.application.HomeService;
+import com.beat.apis.performance.application.dto.home.HomeFindAllResponse;
+import com.beat.apis.performance.application.dto.home.HomeFindRequest;
+import com.beat.domain.performance.domain.Genre;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HomeFacade {
+	private final HomeService homeService;
+
+	public HomeFindAllResponse findHomePerformanceList(Genre genre) {
+		return homeService.findHomePerformanceList(new HomeFindRequest(genre));
+	}
+}

--- a/apis/src/main/java/com/beat/apis/performance/facade/PerformanceFacade.java
+++ b/apis/src/main/java/com/beat/apis/performance/facade/PerformanceFacade.java
@@ -1,0 +1,53 @@
+package com.beat.apis.performance.facade;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.apis.performance.application.PerformanceManagementService;
+import com.beat.apis.performance.application.PerformanceModifyService;
+import com.beat.apis.performance.application.PerformanceService;
+import com.beat.apis.performance.application.dto.bookingPerformanceDetail.BookingPerformanceDetailResponse;
+import com.beat.apis.performance.application.dto.create.PerformanceRequest;
+import com.beat.apis.performance.application.dto.create.PerformanceResponse;
+import com.beat.apis.performance.application.dto.makerPerformance.MakerPerformanceResponse;
+import com.beat.apis.performance.application.dto.modify.PerformanceModifyDetailResponse;
+import com.beat.apis.performance.application.dto.modify.PerformanceModifyRequest;
+import com.beat.apis.performance.application.dto.modify.PerformanceModifyResponse;
+import com.beat.apis.performance.application.dto.performanceDetail.PerformanceDetailResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceFacade {
+	private final PerformanceService performanceService;
+	private final PerformanceManagementService performanceManagementService;
+	private final PerformanceModifyService performanceModifyService;
+
+	public PerformanceResponse createPerformance(Long memberId, PerformanceRequest request) {
+		return performanceManagementService.createPerformance(memberId, request);
+	}
+
+	public PerformanceModifyResponse modifyPerformance(Long memberId, PerformanceModifyRequest request) {
+		return performanceModifyService.modifyPerformance(memberId, request);
+	}
+
+	public PerformanceModifyDetailResponse getPerformanceEdit(Long memberId, Long performanceId) {
+		return performanceService.getPerformanceEdit(memberId, performanceId);
+	}
+
+	public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {
+		return performanceService.getPerformanceDetail(performanceId);
+	}
+
+	public BookingPerformanceDetailResponse getBookingPerformanceDetail(Long performanceId) {
+		return performanceService.getBookingPerformanceDetail(performanceId);
+	}
+
+	public MakerPerformanceResponse getMemberPerformances(Long memberId) {
+		return performanceService.getMemberPerformances(memberId);
+	}
+
+	public void deletePerformance(Long memberId, Long performanceId) {
+		performanceManagementService.deletePerformance(memberId, performanceId);
+	}
+}

--- a/apis/src/main/java/com/beat/apis/schedule/api/ScheduleController.java
+++ b/apis/src/main/java/com/beat/apis/schedule/api/ScheduleController.java
@@ -8,10 +8,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.beat.apis.schedule.application.ScheduleService;
-import com.beat.apis.schedule.application.dto.request.TicketAvailabilityRequest;
 import com.beat.apis.schedule.application.dto.response.TicketAvailabilityResponse;
 import com.beat.apis.schedule.api.response.ScheduleSuccessCode;
+import com.beat.apis.schedule.facade.ScheduleFacade;
 import com.beat.global.common.dto.SuccessResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ScheduleController implements ScheduleApi {
 
-	private final ScheduleService scheduleService;
+	private final ScheduleFacade scheduleFacade;
 
 	@Override
 	@GetMapping("/{scheduleId}/availability")
@@ -29,9 +28,7 @@ public class ScheduleController implements ScheduleApi {
 		@PathVariable Long scheduleId,
 		@RequestParam int purchaseTicketCount) {
 
-		TicketAvailabilityRequest ticketAvailabilityRequest = TicketAvailabilityRequest.of(purchaseTicketCount);
-		TicketAvailabilityResponse response = scheduleService.findTicketAvailability(scheduleId,
-			ticketAvailabilityRequest);
+		TicketAvailabilityResponse response = scheduleFacade.findTicketAvailability(scheduleId, purchaseTicketCount);
 
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(SuccessResponse.of(ScheduleSuccessCode.TICKET_AVAILABILITY_RETRIEVAL_SUCCESS, response));

--- a/apis/src/main/java/com/beat/apis/schedule/facade/ScheduleFacade.java
+++ b/apis/src/main/java/com/beat/apis/schedule/facade/ScheduleFacade.java
@@ -1,0 +1,19 @@
+package com.beat.apis.schedule.facade;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.apis.schedule.application.ScheduleService;
+import com.beat.apis.schedule.application.dto.request.TicketAvailabilityRequest;
+import com.beat.apis.schedule.application.dto.response.TicketAvailabilityResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleFacade {
+	private final ScheduleService scheduleService;
+
+	public TicketAvailabilityResponse findTicketAvailability(Long scheduleId, int purchaseTicketCount) {
+		return scheduleService.findTicketAvailability(scheduleId, TicketAvailabilityRequest.of(purchaseTicketCount));
+	}
+}

--- a/apis/src/main/java/com/beat/apis/ticket/api/TicketController.java
+++ b/apis/src/main/java/com/beat/apis/ticket/api/TicketController.java
@@ -12,18 +12,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.beat.apis.ticket.application.TicketService;
 import com.beat.apis.ticket.application.dto.TicketDeleteRequest;
 import com.beat.apis.ticket.application.dto.TicketRefundRequest;
 import com.beat.apis.ticket.application.dto.TicketRetrieveResponse;
 import com.beat.apis.ticket.application.dto.TicketUpdateRequest;
 import com.beat.domain.booking.domain.BookingStatus;
-import com.beat.apis.ticket.application.exception.TicketApplicationErrorCode;
 import com.beat.apis.ticket.api.response.TicketSuccessCode;
+import com.beat.apis.ticket.facade.TicketFacade;
 import com.beat.domain.schedule.domain.ScheduleNumber;
 import com.beat.gateway.annotation.CurrentMember;
 import com.beat.global.common.dto.SuccessResponse;
-import com.beat.global.common.exception.BadRequestException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TicketController implements TicketApi {
 
-	private final TicketService ticketService;
+	private final TicketFacade ticketFacade;
 
 	@Override
 	@GetMapping("/{performanceId}")
@@ -41,10 +39,7 @@ public class TicketController implements TicketApi {
 		@PathVariable Long performanceId,
 		@RequestParam(required = false) List<ScheduleNumber> scheduleNumbers,
 		@RequestParam(required = false) List<BookingStatus> bookingStatuses) {
-		if (bookingStatuses != null && bookingStatuses.contains(BookingStatus.BOOKING_DELETED)) {
-			throw new BadRequestException(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED);
-		}
-		TicketRetrieveResponse response = ticketService.findAllTicketsByConditions(memberId, performanceId,
+		TicketRetrieveResponse response = ticketFacade.findTickets(memberId, performanceId,
 			scheduleNumbers, bookingStatuses);
 		return ResponseEntity.ok(SuccessResponse.of(TicketSuccessCode.TICKET_RETRIEVE_SUCCESS, response));
 	}
@@ -57,14 +52,7 @@ public class TicketController implements TicketApi {
 		@RequestParam String searchWord,
 		@RequestParam(required = false) List<ScheduleNumber> scheduleNumbers,
 		@RequestParam(required = false) List<BookingStatus> bookingStatuses) {
-		if (searchWord.length() < 2) {
-			throw new BadRequestException(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT);
-		}
-		if (bookingStatuses != null && bookingStatuses.contains(BookingStatus.BOOKING_DELETED)) {
-			throw new BadRequestException(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED);
-		}
-
-		TicketRetrieveResponse response = ticketService.searchAllTicketsByConditions(memberId, performanceId,
+		TicketRetrieveResponse response = ticketFacade.searchTickets(memberId, performanceId,
 			searchWord, scheduleNumbers, bookingStatuses);
 		return ResponseEntity.ok()
 			.cacheControl(CacheControl.noCache())
@@ -76,7 +64,7 @@ public class TicketController implements TicketApi {
 	public ResponseEntity<SuccessResponse<Void>> updateTickets(
 		@CurrentMember Long memberId,
 		@RequestBody TicketUpdateRequest ticketUpdateRequest) {
-		ticketService.updateTickets(memberId, ticketUpdateRequest);
+		ticketFacade.updateTickets(memberId, ticketUpdateRequest);
 		return ResponseEntity.ok(SuccessResponse.from(TicketSuccessCode.TICKET_UPDATE_SUCCESS));
 	}
 
@@ -85,7 +73,7 @@ public class TicketController implements TicketApi {
 	public ResponseEntity<SuccessResponse<Void>> refundTickets(
 		@CurrentMember Long memberId,
 		@RequestBody TicketRefundRequest ticketRefundRequest) {
-		ticketService.refundTicketsByBookingIds(memberId, ticketRefundRequest);
+		ticketFacade.refundTickets(memberId, ticketRefundRequest);
 		return ResponseEntity.ok(SuccessResponse.from(TicketSuccessCode.TICKET_REFUND_SUCCESS));
 	}
 
@@ -94,7 +82,7 @@ public class TicketController implements TicketApi {
 	public ResponseEntity<SuccessResponse<Void>> deleteTickets(
 		@CurrentMember Long memberId,
 		@RequestBody TicketDeleteRequest ticketDeleteRequest) {
-		ticketService.deleteTicketsByBookingIds(memberId, ticketDeleteRequest);
+		ticketFacade.deleteTickets(memberId, ticketDeleteRequest);
 		return ResponseEntity.ok(SuccessResponse.from(TicketSuccessCode.TICKET_DELETE_SUCCESS));
 	}
 

--- a/apis/src/main/java/com/beat/apis/ticket/application/TicketService.java
+++ b/apis/src/main/java/com/beat/apis/ticket/application/TicketService.java
@@ -59,6 +59,8 @@ public class TicketService {
 
 	public TicketRetrieveResponse findAllTicketsByConditions(Long memberId, Long performanceId,
 		List<ScheduleNumber> scheduleNumbers, List<BookingStatus> bookingStatuses) {
+		validateDeletedTicketsAreNotRequested(bookingStatuses);
+
 		Member member = findMember(memberId);
 		Users user = findUser(member);
 		Performance performance = findPerformance(performanceId);
@@ -83,6 +85,9 @@ public class TicketService {
 
 	public TicketRetrieveResponse searchAllTicketsByConditions(Long memberId, Long performanceId, String searchWord,
 		List<ScheduleNumber> scheduleNumbers, List<BookingStatus> bookingStatuses) {
+		validateSearchWord(searchWord);
+		validateDeletedTicketsAreNotRequested(bookingStatuses);
+
 		Member member = findMember(memberId);
 		Users user = findUser(member);
 		Performance performance = findPerformance(performanceId);
@@ -128,6 +133,18 @@ public class TicketService {
 
 		return findTicketRetrieveResponse(performance, totalPerformanceTicketCount, totalPerformanceSoldTicketCount,
 			schedules, tickets);
+	}
+
+	private void validateSearchWord(String searchWord) {
+		if (searchWord == null || searchWord.length() < 2) {
+			throw new BadRequestException(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT);
+		}
+	}
+
+	private void validateDeletedTicketsAreNotRequested(List<BookingStatus> bookingStatuses) {
+		if (bookingStatuses != null && bookingStatuses.contains(BookingStatus.BOOKING_DELETED)) {
+			throw new BadRequestException(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED);
+		}
 	}
 
 	private <E extends Enum<E>> List<String> toNames(List<E> values) {

--- a/apis/src/main/java/com/beat/apis/ticket/facade/TicketFacade.java
+++ b/apis/src/main/java/com/beat/apis/ticket/facade/TicketFacade.java
@@ -9,10 +9,8 @@ import com.beat.apis.ticket.application.dto.TicketDeleteRequest;
 import com.beat.apis.ticket.application.dto.TicketRefundRequest;
 import com.beat.apis.ticket.application.dto.TicketRetrieveResponse;
 import com.beat.apis.ticket.application.dto.TicketUpdateRequest;
-import com.beat.apis.ticket.application.exception.TicketApplicationErrorCode;
 import com.beat.domain.booking.domain.BookingStatus;
 import com.beat.domain.schedule.domain.ScheduleNumber;
-import com.beat.global.common.exception.BadRequestException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,14 +21,11 @@ public class TicketFacade {
 
 	public TicketRetrieveResponse findTickets(Long memberId, Long performanceId, List<ScheduleNumber> scheduleNumbers,
 		List<BookingStatus> bookingStatuses) {
-		validateDeletedTicketsAreNotRequested(bookingStatuses);
 		return ticketService.findAllTicketsByConditions(memberId, performanceId, scheduleNumbers, bookingStatuses);
 	}
 
 	public TicketRetrieveResponse searchTickets(Long memberId, Long performanceId, String searchWord,
 		List<ScheduleNumber> scheduleNumbers, List<BookingStatus> bookingStatuses) {
-		validateSearchWord(searchWord);
-		validateDeletedTicketsAreNotRequested(bookingStatuses);
 		return ticketService.searchAllTicketsByConditions(memberId, performanceId, searchWord, scheduleNumbers,
 			bookingStatuses);
 	}
@@ -45,17 +40,5 @@ public class TicketFacade {
 
 	public void deleteTickets(Long memberId, TicketDeleteRequest request) {
 		ticketService.deleteTicketsByBookingIds(memberId, request);
-	}
-
-	private void validateSearchWord(String searchWord) {
-		if (searchWord == null || searchWord.length() < 2) {
-			throw new BadRequestException(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT);
-		}
-	}
-
-	private void validateDeletedTicketsAreNotRequested(List<BookingStatus> bookingStatuses) {
-		if (bookingStatuses != null && bookingStatuses.contains(BookingStatus.BOOKING_DELETED)) {
-			throw new BadRequestException(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED);
-		}
 	}
 }

--- a/apis/src/main/java/com/beat/apis/ticket/facade/TicketFacade.java
+++ b/apis/src/main/java/com/beat/apis/ticket/facade/TicketFacade.java
@@ -48,7 +48,7 @@ public class TicketFacade {
 	}
 
 	private void validateSearchWord(String searchWord) {
-		if (searchWord.length() < 2) {
+		if (searchWord == null || searchWord.length() < 2) {
 			throw new BadRequestException(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT);
 		}
 	}

--- a/apis/src/main/java/com/beat/apis/ticket/facade/TicketFacade.java
+++ b/apis/src/main/java/com/beat/apis/ticket/facade/TicketFacade.java
@@ -1,0 +1,61 @@
+package com.beat.apis.ticket.facade;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.beat.apis.ticket.application.TicketService;
+import com.beat.apis.ticket.application.dto.TicketDeleteRequest;
+import com.beat.apis.ticket.application.dto.TicketRefundRequest;
+import com.beat.apis.ticket.application.dto.TicketRetrieveResponse;
+import com.beat.apis.ticket.application.dto.TicketUpdateRequest;
+import com.beat.apis.ticket.application.exception.TicketApplicationErrorCode;
+import com.beat.domain.booking.domain.BookingStatus;
+import com.beat.domain.schedule.domain.ScheduleNumber;
+import com.beat.global.common.exception.BadRequestException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TicketFacade {
+	private final TicketService ticketService;
+
+	public TicketRetrieveResponse findTickets(Long memberId, Long performanceId, List<ScheduleNumber> scheduleNumbers,
+		List<BookingStatus> bookingStatuses) {
+		validateDeletedTicketsAreNotRequested(bookingStatuses);
+		return ticketService.findAllTicketsByConditions(memberId, performanceId, scheduleNumbers, bookingStatuses);
+	}
+
+	public TicketRetrieveResponse searchTickets(Long memberId, Long performanceId, String searchWord,
+		List<ScheduleNumber> scheduleNumbers, List<BookingStatus> bookingStatuses) {
+		validateSearchWord(searchWord);
+		validateDeletedTicketsAreNotRequested(bookingStatuses);
+		return ticketService.searchAllTicketsByConditions(memberId, performanceId, searchWord, scheduleNumbers,
+			bookingStatuses);
+	}
+
+	public void updateTickets(Long memberId, TicketUpdateRequest request) {
+		ticketService.updateTickets(memberId, request);
+	}
+
+	public void refundTickets(Long memberId, TicketRefundRequest request) {
+		ticketService.refundTicketsByBookingIds(memberId, request);
+	}
+
+	public void deleteTickets(Long memberId, TicketDeleteRequest request) {
+		ticketService.deleteTicketsByBookingIds(memberId, request);
+	}
+
+	private void validateSearchWord(String searchWord) {
+		if (searchWord.length() < 2) {
+			throw new BadRequestException(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT);
+		}
+	}
+
+	private void validateDeletedTicketsAreNotRequested(List<BookingStatus> bookingStatuses) {
+		if (bookingStatuses != null && bookingStatuses.contains(BookingStatus.BOOKING_DELETED)) {
+			throw new BadRequestException(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED);
+		}
+	}
+}

--- a/apis/src/test/java/com/beat/apis/external/s3/application/FileServiceTest.java
+++ b/apis/src/test/java/com/beat/apis/external/s3/application/FileServiceTest.java
@@ -1,0 +1,48 @@
+package com.beat.apis.external.s3.application;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.beat.contracts.storage.FileStoragePort;
+import com.beat.contracts.storage.PerformancePresignedUrls;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+	@Mock
+	private FileStoragePort fileStoragePort;
+
+	private FileService fileService;
+
+	@BeforeEach
+	void setUp() {
+		fileService = new FileService(fileStoragePort);
+	}
+
+	@Test
+	void issueAllPresignedUrlsNormalizesNullableListsBeforeCallingStoragePort() {
+		PerformancePresignedUrls presignedUrls = new PerformancePresignedUrls(
+			Map.of("poster", Map.of("poster.png", "https://example.com/poster.png"))
+		);
+		when(fileStoragePort.issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of()))
+			.thenReturn(presignedUrls);
+
+		fileService.issueAllPresignedUrlsForPerformanceMaker(
+			"poster.png",
+			null,
+			null,
+			null
+		);
+
+		verify(fileStoragePort).issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of());
+	}
+}

--- a/apis/src/test/java/com/beat/apis/external/s3/facade/FileFacadeTest.java
+++ b/apis/src/test/java/com/beat/apis/external/s3/facade/FileFacadeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -31,11 +30,11 @@ class FileFacadeTest {
 	}
 
 	@Test
-	void issueAllPresignedUrlsNormalizesNullableListsBeforeDelegatingToApplicationService() {
+	void issueAllPresignedUrlsDelegatesNullableListsToApplicationService() {
 		PerformancePresignedUrls presignedUrls = new PerformancePresignedUrls(
 			Map.of("poster", Map.of("poster.png", "https://example.com/poster.png"))
 		);
-		when(fileService.issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of()))
+		when(fileService.issueAllPresignedUrlsForPerformanceMaker("poster.png", null, null, null))
 			.thenReturn(presignedUrls);
 
 		PerformanceMakerPresignedUrlFindAllResponse response = fileFacade.issueAllPresignedUrlsForPerformanceMaker(
@@ -46,6 +45,6 @@ class FileFacadeTest {
 		);
 
 		assertEquals(presignedUrls.performanceMakerPresignedUrls(), response.performanceMakerPresignedUrls());
-		verify(fileService).issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of());
+		verify(fileService).issueAllPresignedUrlsForPerformanceMaker("poster.png", null, null, null);
 	}
 }

--- a/apis/src/test/java/com/beat/apis/external/s3/facade/FileFacadeTest.java
+++ b/apis/src/test/java/com/beat/apis/external/s3/facade/FileFacadeTest.java
@@ -1,0 +1,51 @@
+package com.beat.apis.external.s3.facade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.beat.apis.external.s3.api.dto.PerformanceMakerPresignedUrlFindAllResponse;
+import com.beat.apis.external.s3.application.FileService;
+import com.beat.contracts.storage.PerformancePresignedUrls;
+
+@ExtendWith(MockitoExtension.class)
+class FileFacadeTest {
+
+	@Mock
+	private FileService fileService;
+
+	private FileFacade fileFacade;
+
+	@BeforeEach
+	void setUp() {
+		fileFacade = new FileFacade(fileService);
+	}
+
+	@Test
+	void issueAllPresignedUrlsNormalizesNullableListsBeforeDelegatingToApplicationService() {
+		PerformancePresignedUrls presignedUrls = new PerformancePresignedUrls(
+			Map.of("poster", Map.of("poster.png", "https://example.com/poster.png"))
+		);
+		when(fileService.issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of()))
+			.thenReturn(presignedUrls);
+
+		PerformanceMakerPresignedUrlFindAllResponse response = fileFacade.issueAllPresignedUrlsForPerformanceMaker(
+			"poster.png",
+			null,
+			null,
+			null
+		);
+
+		assertEquals(presignedUrls.performanceMakerPresignedUrls(), response.performanceMakerPresignedUrls());
+		verify(fileService).issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of());
+	}
+}

--- a/apis/src/test/java/com/beat/apis/member/AuthenticationServiceTest.java
+++ b/apis/src/test/java/com/beat/apis/member/AuthenticationServiceTest.java
@@ -2,6 +2,7 @@ package com.beat.apis.member;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,11 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.beat.apis.member.application.AuthenticationService;
 import com.beat.contracts.auth.JwtTokenPort;
 import com.beat.contracts.auth.RefreshTokenPort;
 import com.beat.contracts.auth.TokenErrorCode;
 import com.beat.contracts.auth.TokenValidationResult;
-import com.beat.apis.member.application.AuthenticationService;
 import com.beat.global.common.exception.BadRequestException;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +51,22 @@ class AuthenticationServiceTest {
 
 		assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN_ERROR, exception.getBaseErrorCode());
 		verify(jwtTokenPort).getRoleName(refreshToken);
+	}
+
+	@Test
+	void generateAccessTokenFromRefreshTokenShouldRejectMissingMemberIdClaim() {
+		String refreshToken = "refresh-token";
+
+		when(jwtTokenPort.validateToken(refreshToken)).thenReturn(TokenValidationResult.VALID);
+		when(jwtTokenPort.getMemberId(refreshToken)).thenReturn(null);
+
+		BadRequestException exception = assertThrows(
+			BadRequestException.class,
+			() -> authenticationService.generateAccessTokenFromRefreshToken(refreshToken)
+		);
+
+		assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN_ERROR, exception.getBaseErrorCode());
+		verify(refreshTokenPort, never()).findMemberIdByRefreshToken(refreshToken);
 	}
 
 	@Test

--- a/apis/src/test/java/com/beat/apis/member/AuthenticationServiceTest.java
+++ b/apis/src/test/java/com/beat/apis/member/AuthenticationServiceTest.java
@@ -53,6 +53,13 @@ class AuthenticationServiceTest {
 	}
 
 	@Test
+	void signOutDeletesRefreshTokenThroughApplicationService() {
+		authenticationService.signOut(1L);
+
+		verify(refreshTokenPort).deleteRefreshToken(1L);
+	}
+
+	@Test
 	void generateAccessTokenFromRefreshTokenShouldRejectMissingRoleClaim() {
 		String refreshToken = "refresh-token";
 

--- a/apis/src/test/java/com/beat/apis/ticket/api/TicketControllerTest.java
+++ b/apis/src/test/java/com/beat/apis/ticket/api/TicketControllerTest.java
@@ -1,6 +1,7 @@
 package com.beat.apis.ticket.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
+import com.beat.apis.ticket.api.response.TicketSuccessCode;
 import com.beat.apis.ticket.application.dto.TicketRetrieveResponse;
 import com.beat.apis.ticket.facade.TicketFacade;
 import com.beat.global.common.dto.SuccessResponse;
@@ -34,15 +36,16 @@ class TicketControllerTest {
 
 	@Test
 	void searchTicketsDelegatesToFacade() {
+		TicketRetrieveResponse expected = TicketRetrieveResponse.of(
+			"title",
+			"team",
+			1,
+			2,
+			3,
+			List.of()
+		);
 		when(ticketFacade.searchTickets(anyLong(), anyLong(), any(), any(), any()))
-			.thenReturn(TicketRetrieveResponse.of(
-				"title",
-				"team",
-				1,
-				2,
-				3,
-				List.of()
-			));
+			.thenReturn(expected);
 
 		ResponseEntity<SuccessResponse<TicketRetrieveResponse>> response = ticketController.searchTickets(
 			1L,
@@ -53,6 +56,10 @@ class TicketControllerTest {
 		);
 
 		assertEquals(200, response.getStatusCode().value());
+		assertEquals("no-cache", response.getHeaders().getCacheControl());
+		assertEquals(TicketSuccessCode.TICKET_SEARCH_SUCCESS.getStatus(), response.getBody().status());
+		assertEquals(TicketSuccessCode.TICKET_SEARCH_SUCCESS.getMessage(), response.getBody().message());
+		assertSame(expected, response.getBody().data());
 		verify(ticketFacade).searchTickets(1L, 100L, "ab", null, null);
 	}
 }

--- a/apis/src/test/java/com/beat/apis/ticket/api/TicketControllerTest.java
+++ b/apis/src/test/java/com/beat/apis/ticket/api/TicketControllerTest.java
@@ -1,10 +1,8 @@
 package com.beat.apis.ticket.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,56 +15,26 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
-import com.beat.apis.ticket.application.TicketService;
 import com.beat.apis.ticket.application.dto.TicketRetrieveResponse;
-import com.beat.domain.booking.domain.BookingStatus;
-import com.beat.apis.ticket.application.exception.TicketApplicationErrorCode;
-import com.beat.domain.schedule.domain.ScheduleNumber;
+import com.beat.apis.ticket.facade.TicketFacade;
 import com.beat.global.common.dto.SuccessResponse;
-import com.beat.global.common.exception.BadRequestException;
 
 @ExtendWith(MockitoExtension.class)
 class TicketControllerTest {
 
 	@Mock
-	private TicketService ticketService;
+	private TicketFacade ticketFacade;
 
 	private TicketController ticketController;
 
 	@BeforeEach
 	void setUp() {
-		ticketController = new TicketController(ticketService);
+		ticketController = new TicketController(ticketFacade);
 	}
 
 	@Test
-	void searchTicketsRejectsBlankSearchWord() {
-		BadRequestException exception = assertThrows(BadRequestException.class, () ->
-			ticketController.searchTickets(
-				1L,
-				100L,
-				"",
-				List.of(ScheduleNumber.FIRST),
-				List.of(BookingStatus.CHECKING_PAYMENT)
-			)
-		);
-
-		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
-		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
-	}
-
-	@Test
-	void searchTicketsRejectsSingleCharacterSearchWord() {
-		BadRequestException exception = assertThrows(BadRequestException.class, () ->
-			ticketController.searchTickets(1L, 100L, "a", null, null)
-		);
-
-		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
-		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
-	}
-
-	@Test
-	void searchTicketsDelegatesForValidSearchWord() {
-		when(ticketService.searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any()))
+	void searchTicketsDelegatesToFacade() {
+		when(ticketFacade.searchTickets(anyLong(), anyLong(), any(), any(), any()))
 			.thenReturn(TicketRetrieveResponse.of(
 				"title",
 				"team",
@@ -85,6 +53,6 @@ class TicketControllerTest {
 		);
 
 		assertEquals(200, response.getStatusCode().value());
-		verify(ticketService).searchAllTicketsByConditions(1L, 100L, "ab", null, null);
+		verify(ticketFacade).searchTickets(1L, 100L, "ab", null, null);
 	}
 }

--- a/apis/src/test/java/com/beat/apis/ticket/application/TicketServiceTest.java
+++ b/apis/src/test/java/com/beat/apis/ticket/application/TicketServiceTest.java
@@ -1,0 +1,144 @@
+package com.beat.apis.ticket.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.beat.apis.ticket.application.exception.TicketApplicationErrorCode;
+import com.beat.contracts.booking.MakerTicketReadPort;
+import com.beat.contracts.sms.SmsPort;
+import com.beat.domain.booking.domain.BookingStatus;
+import com.beat.domain.booking.repository.BookingRepository;
+import com.beat.domain.member.repository.MemberRepository;
+import com.beat.domain.performance.repository.PerformanceRepository;
+import com.beat.domain.schedule.domain.ScheduleNumber;
+import com.beat.domain.schedule.repository.ScheduleRepository;
+import com.beat.domain.user.repository.UserRepository;
+import com.beat.global.common.exception.BadRequestException;
+
+@ExtendWith(MockitoExtension.class)
+class TicketServiceTest {
+
+	@Mock
+	private BookingRepository bookingRepository;
+
+	@Mock
+	private MakerTicketReadPort makerTicketReadPort;
+
+	@Mock
+	private PerformanceRepository performanceRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private ScheduleRepository scheduleRepository;
+
+	@Mock
+	private SmsPort smsPort;
+
+	private TicketService ticketService;
+
+	@BeforeEach
+	void setUp() {
+		ticketService = new TicketService(
+			bookingRepository,
+			makerTicketReadPort,
+			performanceRepository,
+			memberRepository,
+			userRepository,
+			scheduleRepository,
+			smsPort
+		);
+	}
+
+	@Test
+	void searchAllTicketsByConditionsRejectsNullSearchWord() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketService.searchAllTicketsByConditions(1L, 100L, null, null, null)
+		);
+
+		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
+		verifyNoDependencyInteractions();
+	}
+
+	@Test
+	void searchAllTicketsByConditionsRejectsBlankSearchWord() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketService.searchAllTicketsByConditions(
+				1L,
+				100L,
+				"",
+				List.of(ScheduleNumber.FIRST),
+				List.of(BookingStatus.CHECKING_PAYMENT)
+			)
+		);
+
+		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
+		verifyNoDependencyInteractions();
+	}
+
+	@Test
+	void searchAllTicketsByConditionsRejectsSingleCharacterSearchWord() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketService.searchAllTicketsByConditions(1L, 100L, "a", null, null)
+		);
+
+		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
+		verifyNoDependencyInteractions();
+	}
+
+	@Test
+	void searchAllTicketsByConditionsRejectsDeletedBookingStatus() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketService.searchAllTicketsByConditions(
+				1L,
+				100L,
+				"ab",
+				null,
+				List.of(BookingStatus.BOOKING_DELETED)
+			)
+		);
+
+		assertEquals(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED, exception.getBaseErrorCode());
+		verifyNoDependencyInteractions();
+	}
+
+	@Test
+	void findAllTicketsByConditionsRejectsDeletedBookingStatus() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketService.findAllTicketsByConditions(
+				1L,
+				100L,
+				null,
+				List.of(BookingStatus.BOOKING_DELETED)
+			)
+		);
+
+		assertEquals(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED, exception.getBaseErrorCode());
+		verifyNoDependencyInteractions();
+	}
+
+	private void verifyNoDependencyInteractions() {
+		verifyNoInteractions(
+			bookingRepository,
+			makerTicketReadPort,
+			performanceRepository,
+			memberRepository,
+			userRepository,
+			scheduleRepository,
+			smsPort
+		);
+	}
+}

--- a/apis/src/test/java/com/beat/apis/ticket/facade/TicketFacadeTest.java
+++ b/apis/src/test/java/com/beat/apis/ticket/facade/TicketFacadeTest.java
@@ -51,6 +51,16 @@ class TicketFacadeTest {
 	}
 
 	@Test
+	void searchTicketsRejectsNullSearchWord() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketFacade.searchTickets(1L, 100L, null, null, null)
+		);
+
+		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
+		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
+	}
+
+	@Test
 	void searchTicketsRejectsSingleCharacterSearchWord() {
 		BadRequestException exception = assertThrows(BadRequestException.class, () ->
 			ticketFacade.searchTickets(1L, 100L, "a", null, null)

--- a/apis/src/test/java/com/beat/apis/ticket/facade/TicketFacadeTest.java
+++ b/apis/src/test/java/com/beat/apis/ticket/facade/TicketFacadeTest.java
@@ -1,0 +1,72 @@
+package com.beat.apis.ticket.facade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.beat.apis.ticket.application.TicketService;
+import com.beat.apis.ticket.application.exception.TicketApplicationErrorCode;
+import com.beat.domain.booking.domain.BookingStatus;
+import com.beat.domain.schedule.domain.ScheduleNumber;
+import com.beat.global.common.exception.BadRequestException;
+
+@ExtendWith(MockitoExtension.class)
+class TicketFacadeTest {
+
+	@Mock
+	private TicketService ticketService;
+
+	private TicketFacade ticketFacade;
+
+	@BeforeEach
+	void setUp() {
+		ticketFacade = new TicketFacade(ticketService);
+	}
+
+	@Test
+	void searchTicketsRejectsBlankSearchWord() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketFacade.searchTickets(
+				1L,
+				100L,
+				"",
+				List.of(ScheduleNumber.FIRST),
+				List.of(BookingStatus.CHECKING_PAYMENT)
+			)
+		);
+
+		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
+		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
+	}
+
+	@Test
+	void searchTicketsRejectsSingleCharacterSearchWord() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketFacade.searchTickets(1L, 100L, "a", null, null)
+		);
+
+		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
+		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
+	}
+
+	@Test
+	void searchTicketsRejectsDeletedBookingStatus() {
+		BadRequestException exception = assertThrows(BadRequestException.class, () ->
+			ticketFacade.searchTickets(1L, 100L, "ab", null, List.of(BookingStatus.BOOKING_DELETED))
+		);
+
+		assertEquals(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED, exception.getBaseErrorCode());
+		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
+	}
+}

--- a/apis/src/test/java/com/beat/apis/ticket/facade/TicketFacadeTest.java
+++ b/apis/src/test/java/com/beat/apis/ticket/facade/TicketFacadeTest.java
@@ -1,11 +1,7 @@
 package com.beat.apis.ticket.facade;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -16,10 +12,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.beat.apis.ticket.application.TicketService;
-import com.beat.apis.ticket.application.exception.TicketApplicationErrorCode;
+import com.beat.apis.ticket.application.dto.TicketRetrieveResponse;
 import com.beat.domain.booking.domain.BookingStatus;
 import com.beat.domain.schedule.domain.ScheduleNumber;
-import com.beat.global.common.exception.BadRequestException;
 
 @ExtendWith(MockitoExtension.class)
 class TicketFacadeTest {
@@ -35,48 +30,34 @@ class TicketFacadeTest {
 	}
 
 	@Test
-	void searchTicketsRejectsBlankSearchWord() {
-		BadRequestException exception = assertThrows(BadRequestException.class, () ->
-			ticketFacade.searchTickets(
-				1L,
-				100L,
-				"",
-				List.of(ScheduleNumber.FIRST),
-				List.of(BookingStatus.CHECKING_PAYMENT)
-			)
-		);
+	void findTicketsDelegatesToService() {
+		Long memberId = 1L;
+		Long performanceId = 100L;
+		List<ScheduleNumber> scheduleNumbers = List.of(ScheduleNumber.FIRST);
+		List<BookingStatus> bookingStatuses = List.of(BookingStatus.CHECKING_PAYMENT);
+		TicketRetrieveResponse expected = TicketRetrieveResponse.of("title", "team", 1, 100, 10, List.of());
+		when(ticketService.findAllTicketsByConditions(memberId, performanceId, scheduleNumbers, bookingStatuses))
+			.thenReturn(expected);
 
-		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
-		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
+		ticketFacade.findTickets(memberId, performanceId, scheduleNumbers, bookingStatuses);
+
+		verify(ticketService).findAllTicketsByConditions(memberId, performanceId, scheduleNumbers, bookingStatuses);
 	}
 
 	@Test
-	void searchTicketsRejectsNullSearchWord() {
-		BadRequestException exception = assertThrows(BadRequestException.class, () ->
-			ticketFacade.searchTickets(1L, 100L, null, null, null)
-		);
+	void searchTicketsDelegatesToService() {
+		Long memberId = 1L;
+		Long performanceId = 100L;
+		String searchWord = "홍길동";
+		List<ScheduleNumber> scheduleNumbers = List.of(ScheduleNumber.FIRST);
+		List<BookingStatus> bookingStatuses = List.of(BookingStatus.CHECKING_PAYMENT);
+		TicketRetrieveResponse expected = TicketRetrieveResponse.of("title", "team", 1, 100, 10, List.of());
+		when(ticketService.searchAllTicketsByConditions(memberId, performanceId, searchWord, scheduleNumbers,
+			bookingStatuses)).thenReturn(expected);
 
-		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
-		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
-	}
+		ticketFacade.searchTickets(memberId, performanceId, searchWord, scheduleNumbers, bookingStatuses);
 
-	@Test
-	void searchTicketsRejectsSingleCharacterSearchWord() {
-		BadRequestException exception = assertThrows(BadRequestException.class, () ->
-			ticketFacade.searchTickets(1L, 100L, "a", null, null)
-		);
-
-		assertEquals(TicketApplicationErrorCode.SEARCH_WORD_TOO_SHORT, exception.getBaseErrorCode());
-		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
-	}
-
-	@Test
-	void searchTicketsRejectsDeletedBookingStatus() {
-		BadRequestException exception = assertThrows(BadRequestException.class, () ->
-			ticketFacade.searchTickets(1L, 100L, "ab", null, List.of(BookingStatus.BOOKING_DELETED))
-		);
-
-		assertEquals(TicketApplicationErrorCode.DELETED_TICKET_RETRIEVE_NOT_ALLOWED, exception.getBaseErrorCode());
-		verify(ticketService, never()).searchAllTicketsByConditions(anyLong(), anyLong(), any(), any(), any());
+		verify(ticketService).searchAllTicketsByConditions(memberId, performanceId, searchWord, scheduleNumbers,
+			bookingStatuses);
 	}
 }

--- a/apis/src/test/kotlin/com/beat/apis/ApisArchitectureGuardTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/ApisArchitectureGuardTest.kt
@@ -79,16 +79,14 @@ class ApisArchitectureGuardTest {
 
     @Test
     fun `apis controllers must enter use cases through facades`() {
-        val forbiddenControllerImportPatterns = listOf(
-            Regex("""^\s*import\s+com\.beat\.apis(?:\.[^.]+)+\.application(?:\.[^.]+)*\.[A-Za-z0-9_]+Service;?\s*$"""),
-            Regex("""^\s*import\s+com\.beat\.contracts\..*Port;?\s*$"""),
-        )
-
-        val violations = findImportViolations(
+        val violations = findSourceViolations(
             pathPredicate = { path ->
                 path.fileName.toString().matches(Regex(""".*Controller\.(java|kt)"""))
             },
-            forbiddenImportPatterns = forbiddenControllerImportPatterns,
+            forbiddenReferencePatterns = listOf(
+                Regex("""com\.beat\.apis(?:\.[A-Za-z0-9_]+)+\.application(?:\.[A-Za-z0-9_]+)*\.[A-Za-z0-9_]+Service"""),
+                Regex("""com\.beat\.contracts\.(?:[A-Za-z0-9_]+\.)*[A-Za-z0-9_]+Port"""),
+            ),
         )
 
         assertTrue(
@@ -101,12 +99,12 @@ class ApisArchitectureGuardTest {
 
     @Test
     fun `apis facades must delegate port access to application services`() {
-        val violations = findImportViolations(
+        val violations = findSourceViolations(
             pathPredicate = { path ->
                 path.fileName.toString().matches(Regex(""".*Facade\.(java|kt)"""))
             },
-            forbiddenImportPatterns = listOf(
-                Regex("""^\s*import\s+com\.beat\.contracts\..*Port;?\s*$"""),
+            forbiddenReferencePatterns = listOf(
+                Regex("""com\.beat\.contracts\.(?:[A-Za-z0-9_]+\.)*[A-Za-z0-9_]+Port"""),
             ),
         )
 
@@ -118,9 +116,9 @@ class ApisArchitectureGuardTest {
         )
     }
 
-    private fun findImportViolations(
+    private fun findSourceViolations(
         pathPredicate: (Path) -> Boolean,
-        forbiddenImportPatterns: List<Regex>,
+        forbiddenReferencePatterns: List<Regex>,
     ): List<String> {
         val paths = Files.walk(Path.of("src/main"))
 
@@ -131,15 +129,10 @@ class ApisArchitectureGuardTest {
                 .filter(pathPredicate)
                 .toList()
                 .flatMap { path ->
-                    Files.readAllLines(path)
-                        .asSequence()
-                        .filter { it.trimStart().startsWith("import ") }
-                        .flatMap { line ->
-                            forbiddenImportPatterns
-                                .filter { pattern -> pattern.containsMatchIn(line) }
-                                .map { "${path}: $line" }
-                        }
-                        .toList()
+                    val source = Files.readString(path)
+                    forbiddenReferencePatterns
+                        .filter { pattern -> pattern.containsMatchIn(source) }
+                        .map { pattern -> "${path}: ${pattern.pattern}" }
                 }
         } finally {
             paths.close()
@@ -190,6 +183,7 @@ class ApisArchitectureGuardTest {
     }
 
     private fun findFilesMatching(vararg forbiddenReferences: String): List<String> {
+        val packagePatterns = forbiddenReferences.map { reference -> Regex("""(?m)^\s*${Regex.escape(reference)}""") }
         val paths = Files.walk(Path.of("src/main"))
 
         return try {
@@ -199,9 +193,9 @@ class ApisArchitectureGuardTest {
                 .toList()
                 .flatMap { path ->
                     val source = Files.readString(path)
-                    forbiddenReferences
-                        .filter(source::startsWith)
-                        .map { pattern -> "${path}: $pattern" }
+                    packagePatterns
+                        .filter { pattern -> pattern.containsMatchIn(source) }
+                        .map { pattern -> "${path}: ${pattern.pattern}" }
                 }
         } finally {
             paths.close()

--- a/apis/src/test/kotlin/com/beat/apis/ApisArchitectureGuardTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/ApisArchitectureGuardTest.kt
@@ -77,6 +77,42 @@ class ApisArchitectureGuardTest {
         )
     }
 
+    @Test
+    fun `apis controllers must enter use cases through facades`() {
+        val forbiddenControllerImportPatterns = listOf(
+            Regex("""import com\.beat\.apis\.[^.]+\.application\.[A-Za-z0-9]+Service;"""),
+            Regex("""import com\.beat\.contracts\..*Port;"""),
+        )
+
+        val paths = Files.walk(Path.of("src/main/java/com/beat/apis"))
+        val violations = try {
+            paths
+                .filter { Files.isRegularFile(it) }
+                .filter { it.toString().endsWith("Controller.java") }
+                .toList()
+                .flatMap { path ->
+                    Files.readAllLines(path)
+                        .asSequence()
+                        .filter { it.trimStart().startsWith("import ") }
+                        .flatMap { line ->
+                            forbiddenControllerImportPatterns
+                                .filter { pattern -> pattern.containsMatchIn(line) }
+                                .map { "${path}: $line" }
+                        }
+                        .toList()
+                }
+        } finally {
+            paths.close()
+        }
+
+        assertTrue(
+            violations.isEmpty(),
+            "Controllers must depend on facade entrypoints instead of application services or ports:\n${
+                violations.joinToString("\n")
+            }"
+        )
+    }
+
     private fun findForbiddenImports(vararg forbiddenReferences: String): List<String> {
         val paths = Files.walk(Path.of("src/main"))
 

--- a/apis/src/test/kotlin/com/beat/apis/ApisArchitectureGuardTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/ApisArchitectureGuardTest.kt
@@ -80,22 +80,62 @@ class ApisArchitectureGuardTest {
     @Test
     fun `apis controllers must enter use cases through facades`() {
         val forbiddenControllerImportPatterns = listOf(
-            Regex("""import com\.beat\.apis\.[^.]+\.application\.[A-Za-z0-9]+Service;"""),
-            Regex("""import com\.beat\.contracts\..*Port;"""),
+            Regex("""^\s*import\s+com\.beat\.apis(?:\.[^.]+)+\.application(?:\.[^.]+)*\.[A-Za-z0-9_]+Service;?\s*$"""),
+            Regex("""^\s*import\s+com\.beat\.contracts\..*Port;?\s*$"""),
         )
 
-        val paths = Files.walk(Path.of("src/main/java/com/beat/apis"))
-        val violations = try {
+        val violations = findImportViolations(
+            pathPredicate = { path ->
+                path.fileName.toString().matches(Regex(""".*Controller\.(java|kt)"""))
+            },
+            forbiddenImportPatterns = forbiddenControllerImportPatterns,
+        )
+
+        assertTrue(
+            violations.isEmpty(),
+            "Controllers must depend on facade entrypoints instead of application services or ports:\n${
+                violations.joinToString("\n")
+            }"
+        )
+    }
+
+    @Test
+    fun `apis facades must delegate port access to application services`() {
+        val violations = findImportViolations(
+            pathPredicate = { path ->
+                path.fileName.toString().matches(Regex(""".*Facade\.(java|kt)"""))
+            },
+            forbiddenImportPatterns = listOf(
+                Regex("""^\s*import\s+com\.beat\.contracts\..*Port;?\s*$"""),
+            ),
+        )
+
+        assertTrue(
+            violations.isEmpty(),
+            "Facades must call application services instead of module-contract ports directly:\n${
+                violations.joinToString("\n")
+            }"
+        )
+    }
+
+    private fun findImportViolations(
+        pathPredicate: (Path) -> Boolean,
+        forbiddenImportPatterns: List<Regex>,
+    ): List<String> {
+        val paths = Files.walk(Path.of("src/main"))
+
+        return try {
             paths
                 .filter { Files.isRegularFile(it) }
-                .filter { it.toString().endsWith("Controller.java") }
+                .filter { it.toString().endsWith(".java") || it.toString().endsWith(".kt") }
+                .filter(pathPredicate)
                 .toList()
                 .flatMap { path ->
                     Files.readAllLines(path)
                         .asSequence()
                         .filter { it.trimStart().startsWith("import ") }
                         .flatMap { line ->
-                            forbiddenControllerImportPatterns
+                            forbiddenImportPatterns
                                 .filter { pattern -> pattern.containsMatchIn(line) }
                                 .map { "${path}: $line" }
                         }
@@ -104,13 +144,6 @@ class ApisArchitectureGuardTest {
         } finally {
             paths.close()
         }
-
-        assertTrue(
-            violations.isEmpty(),
-            "Controllers must depend on facade entrypoints instead of application services or ports:\n${
-                violations.joinToString("\n")
-            }"
-        )
     }
 
     private fun findForbiddenImports(vararg forbiddenReferences: String): List<String> {


### PR DESCRIPTION
## Feature Issue
- Closes #431
- Parent: #350

## Summary
- `apis` Controller 진입점을 Facade로 수렴해 Controller가 ApplicationService/port를 직접 호출하지 않도록 정리했습니다.
- booking/member/performance/home/schedule/ticket/file facade를 추가하고 기존 응답 조립 흐름은 유지했습니다.
- controller guard와 ticket controller/facade focused test를 보강했습니다.

## Compatibility
- API response status/message/shape 변경 없음
- DB schema 변경 없음
- application service 내부 정책 변경 없음

## Verification
- [x] `./gradlew :apis:compileJava :apis:compileKotlin :apis:test --tests com.beat.apis.ApisArchitectureGuardTest --tests com.beat.apis.ticket.api.TicketControllerTest --tests com.beat.apis.ticket.facade.TicketFacadeTest --no-daemon`
