### PR TITLE
refactor: InfraBaseConfig top-level marker 의미를 명확히 고정

### DIFF
--- a/admin/src/main/kotlin/com/beat/admin/config/InfraConfig.kt
+++ b/admin/src/main/kotlin/com/beat/admin/config/InfraConfig.kt
@@ -2,7 +2,9 @@ package com.beat.admin.config
 
 import com.beat.infra.EnableInfraBaseConfig
 import com.beat.infra.InfraBaseConfigGroup
+import com.beat.infra.persistence.InfraPersistenceConfig
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 
 @Configuration(proxyBeanMethods = false)
 @EnableInfraBaseConfig(
@@ -11,4 +13,8 @@ import org.springframework.context.annotation.Configuration
         InfraBaseConfigGroup.EXTERNAL_CLIENTS,
     ]
 )
+// @EnableInfraBaseConfig is backed by DeferredImportSelector, which IntelliJ Spring plugin
+// cannot statically trace. This explicit import is an IDE breadcrumb only — runtime
+// persistence bootstrap is owned by JpaConfig via @Import(InfraPersistenceConfig.class).
+@Import(InfraPersistenceConfig::class)
 class InfraConfig

--- a/admin/src/main/kotlin/com/beat/admin/config/InfraConfig.kt
+++ b/admin/src/main/kotlin/com/beat/admin/config/InfraConfig.kt
@@ -2,9 +2,7 @@ package com.beat.admin.config
 
 import com.beat.infra.EnableInfraBaseConfig
 import com.beat.infra.InfraBaseConfigGroup
-import com.beat.infra.persistence.InfraPersistenceConfig
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 
 @Configuration(proxyBeanMethods = false)
 @EnableInfraBaseConfig(
@@ -13,6 +11,4 @@ import org.springframework.context.annotation.Import
         InfraBaseConfigGroup.EXTERNAL_CLIENTS,
     ]
 )
-// IDE static-analysis breadcrumb; runtime persistence import is still owned by JpaConfig.
-@Import(InfraPersistenceConfig::class)
 class InfraConfig

--- a/apis/src/main/kotlin/com/beat/apis/config/InfraConfig.kt
+++ b/apis/src/main/kotlin/com/beat/apis/config/InfraConfig.kt
@@ -2,9 +2,7 @@ package com.beat.apis.config
 
 import com.beat.infra.EnableInfraBaseConfig
 import com.beat.infra.InfraBaseConfigGroup
-import com.beat.infra.persistence.InfraPersistenceConfig
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 
 @Configuration(proxyBeanMethods = false)
 @EnableInfraBaseConfig(
@@ -14,6 +12,4 @@ import org.springframework.context.annotation.Import
         InfraBaseConfigGroup.EXTERNAL_CLIENTS,
     ]
 )
-// IDE static-analysis breadcrumb; runtime persistence import is still owned by JpaConfig.
-@Import(InfraPersistenceConfig::class)
 class InfraConfig

--- a/apis/src/main/kotlin/com/beat/apis/config/InfraConfig.kt
+++ b/apis/src/main/kotlin/com/beat/apis/config/InfraConfig.kt
@@ -2,7 +2,9 @@ package com.beat.apis.config
 
 import com.beat.infra.EnableInfraBaseConfig
 import com.beat.infra.InfraBaseConfigGroup
+import com.beat.infra.persistence.InfraPersistenceConfig
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 
 @Configuration(proxyBeanMethods = false)
 @EnableInfraBaseConfig(
@@ -12,4 +14,8 @@ import org.springframework.context.annotation.Configuration
         InfraBaseConfigGroup.EXTERNAL_CLIENTS,
     ]
 )
+// @EnableInfraBaseConfig is backed by DeferredImportSelector, which IntelliJ Spring plugin
+// cannot statically trace. This explicit import is an IDE breadcrumb only — runtime
+// persistence bootstrap is owned by JpaConfig via @Import(InfraPersistenceConfig.class).
+@Import(InfraPersistenceConfig::class)
 class InfraConfig

--- a/batch/src/main/kotlin/com/beat/batch/config/InfraConfig.kt
+++ b/batch/src/main/kotlin/com/beat/batch/config/InfraConfig.kt
@@ -2,9 +2,7 @@ package com.beat.batch.config
 
 import com.beat.infra.EnableInfraBaseConfig
 import com.beat.infra.InfraBaseConfigGroup
-import com.beat.infra.persistence.InfraPersistenceConfig
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 
 @Configuration(proxyBeanMethods = false)
 @EnableInfraBaseConfig(
@@ -13,6 +11,4 @@ import org.springframework.context.annotation.Import
         InfraBaseConfigGroup.ASYNC,
     ]
 )
-// IDE static-analysis breadcrumb; runtime persistence import is still owned by JpaConfig.
-@Import(InfraPersistenceConfig::class)
 class InfraConfig

--- a/batch/src/main/kotlin/com/beat/batch/config/InfraConfig.kt
+++ b/batch/src/main/kotlin/com/beat/batch/config/InfraConfig.kt
@@ -2,7 +2,9 @@ package com.beat.batch.config
 
 import com.beat.infra.EnableInfraBaseConfig
 import com.beat.infra.InfraBaseConfigGroup
+import com.beat.infra.persistence.InfraPersistenceConfig
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 
 @Configuration(proxyBeanMethods = false)
 @EnableInfraBaseConfig(
@@ -11,4 +13,8 @@ import org.springframework.context.annotation.Configuration
         InfraBaseConfigGroup.ASYNC,
     ]
 )
+// @EnableInfraBaseConfig is backed by DeferredImportSelector, which IntelliJ Spring plugin
+// cannot statically trace. This explicit import is an IDE breadcrumb only — runtime
+// persistence bootstrap is owned by JpaConfig via @Import(InfraPersistenceConfig.class).
+@Import(InfraPersistenceConfig::class)
 class InfraConfig

--- a/infra/README.md
+++ b/infra/README.md
@@ -38,11 +38,12 @@ infra/
     InfraBaseConfigGroup.java
     InfraBaseConfigImportSelector.java      # DeferredImportSelector — enum → class 매핑
     config/
-      AsyncConfig.java                      # AsyncConfigurer, @Import(TaskExecutorConfig)
-      TaskExecutorConfig.java               # beatApplicationTaskExecutor 빈 생성
-      JpaConfig.java
+      AsyncConfig.java                      # InfraBaseConfig group owner, @Import(TaskExecutorConfig)
+      ExternalClientConfig.java             # InfraBaseConfig group owner, @Import(S3InfraConfig)
+      JpaConfig.java                        # InfraBaseConfig group owner, @Import(InfraPersistenceConfig)
+      RedisCacheConfig.java                 # dormant InfraBaseConfig group owner; no executable opt-in yet
+      TaskExecutorConfig.java               # support config; beatApplicationTaskExecutor 빈 생성
       MysqlCustomDialect.java
-      RedisCacheConfig.java
       ThreadPoolProperties.java
     persistence/
       InfraPersistenceConfig.java              # infra.persistence narrow component scan
@@ -104,8 +105,10 @@ current transitional sources:
 
 설명:
 - `InfraBaseConfigImportSelector`가 `@EnableInfraBaseConfig`의 enum 값을 읽어 해당 `@Configuration` 클래스를 선택적으로 import한다.
+- `InfraBaseConfig`는 실행 모듈이 선택할 수 있는 top-level group config marker다. `AsyncConfig`, `ExternalClientConfig`, `JpaConfig`, dormant `RedisCacheConfig` 같은 enum target만 이 marker를 구현하고, `TaskExecutorConfig`, `S3InfraConfig`, `InfraPersistenceConfig` 같은 support config는 group owner가 `@Import`로 전이 로드한다.
 - `InfraPersistenceConfig`는 `JpaConfig`가 runtime safety net으로 import하고, JPA를 쓰는 실행 모듈 `InfraConfig.kt`가 IDE static-analysis breadcrumb로 한 번 더 import한다. 두 경로 모두 의도된 중복이며, `@EnableInfraBaseConfig` meta-annotation에 persistence를 직접 넣지는 않는다.
 - `AsyncConfig`는 `@Import(TaskExecutorConfig.class)`로 executor 빈만 전이 로드하고, infra는 security-aware wrapper를 직접 소유하지 않는다.
+- `ExternalClientConfig`는 external-client group owner이고 S3 support bootstrap은 `@Import(S3InfraConfig.class)`로만 포함한다. 실행 모듈은 S3 support config를 직접 import하지 않는다.
 - scheduler bean은 infra custom config가 아니라 Spring Boot `TaskSchedulingAutoConfiguration`이 소유한다. 실행 모듈 중 `batch`만 `@EnableScheduling`을 켜며, pool/thread 설정은 `spring.task.scheduling.*` property로 조정한다.
 - Redis runtime wiring은 Spring Boot auto-configuration과 gateway-owned config가 담당하고, infra는 더 이상 gateway-specific Redis bean을 소유하지 않는다.
 - future shared caching은 dormant `RedisCacheConfig` + `InfraBaseConfigGroup.REDIS_CACHE`에서 시작하고, 현재 실행 모듈은 아직 이를 import하지 않는다. 활성화 전에는 cache name, TTL, serializer, namespace, invalidation policy, owner module, runtime opt-in이 먼저 정해져야 한다.
@@ -169,8 +172,8 @@ Facade/ApplicationService/DomainService 표준에서 `infra`는 서비스 계층
 ## 최종 목표
 
 - `infra.external.*` 타입을 상위 실행 모듈이 직접 import하지 않는다.
-- `InfraModuleConfig`가 실제 기술 import를 모으는 진입점으로 성장한다.
-- JPA/QueryDSL/async 부트스트랩이 명시적으로 조립된다.
+- `@EnableInfraBaseConfig` + `InfraBaseConfigGroup`이 실행 모듈의 명시적 infra opt-in 진입점이다.
+- JPA/QueryDSL/async/external-client 부트스트랩은 top-level group config가 조립하고 support config는 marker를 구현하지 않는다.
 - JPA entity / Spring Data adapter / query 구현체 / domain repository 구현체는 infra 책임으로 모인다.
 - shared cache가 필요해질 때 `REDIS_CACHE` 그룹으로 확장한다.
 

--- a/infra/src/main/java/com/beat/infra/InfraBaseConfig.java
+++ b/infra/src/main/java/com/beat/infra/InfraBaseConfig.java
@@ -1,4 +1,11 @@
 package com.beat.infra;
 
+/**
+ * Marker for top-level infra bootstrap configurations selectable through
+ * {@link InfraBaseConfigGroup}.
+ *
+ * <p>Support configurations imported or scanned by those top-level groups must
+ * not implement this marker; only enum-owned entrypoint configs should.
+ */
 public interface InfraBaseConfig {
 }

--- a/infra/src/main/java/com/beat/infra/InfraBaseConfigGroup.java
+++ b/infra/src/main/java/com/beat/infra/InfraBaseConfigGroup.java
@@ -5,6 +5,13 @@ import com.beat.infra.config.ExternalClientConfig;
 import com.beat.infra.config.JpaConfig;
 import com.beat.infra.config.RedisCacheConfig;
 
+/**
+ * Selectable top-level infra slices for {@link EnableInfraBaseConfig}.
+ *
+ * <p>Every config class registered here must implement {@link InfraBaseConfig}.
+ * Support configurations that are imported or scanned internally by these slices
+ * must not be added to this enum and must not implement {@link InfraBaseConfig}.
+ */
 public enum InfraBaseConfigGroup {
 
 	ASYNC(AsyncConfig.class),

--- a/infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java
+++ b/infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java
@@ -14,21 +14,26 @@ import com.beat.infra.storage.s3.S3InfraConfig;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 
 @Configuration(proxyBeanMethods = false)
+@Import(S3InfraConfig.class)
 @EnableFeignClients(basePackageClasses = {
 	KakaoApiClient.class,
 	KakaoAuthApiClient.class,
 	BookingSlackClient.class,
 	MemberSlackClient.class
 })
-@ComponentScan(basePackageClasses = {
-	KakaoSocialLoginAdapter.class,
-	SlackBookingNotificationAdapter.class,
-	SlackMemberNotificationAdapter.class,
-	S3FileStorageAdapter.class,
-	S3InfraConfig.class,
-	CoolSmsAdapter.class
-})
+@ComponentScan(
+	basePackageClasses = {
+		KakaoSocialLoginAdapter.class,
+		SlackBookingNotificationAdapter.class,
+		SlackMemberNotificationAdapter.class,
+		S3FileStorageAdapter.class,
+		CoolSmsAdapter.class
+	},
+	excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = S3InfraConfig.class)
+)
 public class ExternalClientConfig implements InfraBaseConfig {
 }

--- a/infra/src/main/kotlin/com/beat/infra/InfraModuleConfig.kt
+++ b/infra/src/main/kotlin/com/beat/infra/InfraModuleConfig.kt
@@ -1,9 +1,0 @@
-package com.beat.infra
-
-import org.springframework.context.annotation.Configuration
-
-// Marker config for the infra module.
-// Next step: keep growing this as the single entry point for infra bootstrapping
-// such as JPA, Redis, QueryDSL, async, and other technical adapters.
-@Configuration(proxyBeanMethods = false)
-class InfraModuleConfig

--- a/src/test/java/com/beat/SharedBoundaryContractTest.java
+++ b/src/test/java/com/beat/SharedBoundaryContractTest.java
@@ -1242,9 +1242,14 @@ class SharedBoundaryContractTest {
 			Path.of("admin/src/main"),
 			Path.of("batch/src/main")
 		);
+		// InfraPersistenceConfig is allowed as an IDE-only breadcrumb: @EnableInfraBaseConfig is backed by
+		// DeferredImportSelector, which IntelliJ Spring plugin cannot statically trace, so each module-level
+		// InfraConfig carries @Import(InfraPersistenceConfig::class) purely to give the IDE a resolvable path.
+		// It has no effect at runtime — persistence bootstrap is owned by JpaConfig.
 		List<String> violations = executableSources.stream()
 			.flatMap(path -> readLines(path).stream()
-				.filter(line -> line.startsWith("import com.beat.infra.persistence."))
+				.filter(line -> line.startsWith("import com.beat.infra.persistence.")
+					&& !line.contains("InfraPersistenceConfig"))
 				.map(line -> path.toString().replace('\\', '/') + ": " + line))
 			.toList();
 

--- a/src/test/java/com/beat/SharedBoundaryContractTest.java
+++ b/src/test/java/com/beat/SharedBoundaryContractTest.java
@@ -112,6 +112,44 @@ class SharedBoundaryContractTest {
 	}
 
 	@Test
+	void infraBaseConfigMarkerIsLimitedToSelectableTopLevelGroups() throws Exception {
+		String infraBaseConfig = Files.readString(Path.of("infra/src/main/java/com/beat/infra/InfraBaseConfig.java"));
+		String infraConfigGroup = Files.readString(Path.of("infra/src/main/java/com/beat/infra/InfraBaseConfigGroup.java"));
+
+		List<String> topLevelConfigSources = List.of(
+			"infra/src/main/java/com/beat/infra/config/AsyncConfig.java",
+			"infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java",
+			"infra/src/main/java/com/beat/infra/config/JpaConfig.java",
+			"infra/src/main/java/com/beat/infra/config/RedisCacheConfig.java"
+		);
+		List<String> supportConfigSources = List.of(
+			"infra/src/main/java/com/beat/infra/config/TaskExecutorConfig.java",
+			"infra/src/main/java/com/beat/infra/config/ThreadPoolProperties.java",
+			"infra/src/main/java/com/beat/infra/persistence/InfraPersistenceConfig.java",
+			"infra/src/main/java/com/beat/infra/storage/s3/S3InfraConfig.java"
+		);
+
+		assertTrue(infraBaseConfig.contains("Marker for top-level infra bootstrap configurations"));
+		assertTrue(infraBaseConfig.contains("Support configurations"));
+		assertFalse(Files.exists(Path.of("infra/src/main/kotlin/com/beat/infra/InfraModuleConfig.kt")),
+			"InfraModuleConfig must not compete with @EnableInfraBaseConfig as a module-wide entrypoint");
+
+		for (String sourcePath : topLevelConfigSources) {
+			String source = Files.readString(Path.of(sourcePath));
+			String simpleName = Path.of(sourcePath).getFileName().toString().replace(".java", "");
+			assertTrue(infraConfigGroup.contains(simpleName + ".class"));
+			assertTrue(source.contains("InfraBaseConfig"), sourcePath);
+			assertTrue(Pattern.compile("class\\s+" + simpleName + "[^{]*implements[^{]*InfraBaseConfig").matcher(source).find(),
+				sourcePath);
+		}
+
+		for (String sourcePath : supportConfigSources) {
+			String source = Files.readString(Path.of(sourcePath));
+			assertFalse(source.contains("implements InfraBaseConfig"), sourcePath);
+		}
+	}
+
+	@Test
 	void infraKeepsDormantRedisCacheSkeletonForFutureSharedCaching() throws Exception {
 		String infraConfigGroup = Files.readString(
 			Path.of("infra/src/main/java/com/beat/infra/InfraBaseConfigGroup.java"));
@@ -1003,8 +1041,14 @@ class SharedBoundaryContractTest {
 			Path.of("infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java"));
 
 		assertTrue(externalClientConfig.contains("@Configuration(proxyBeanMethods = false)"));
+		assertTrue(externalClientConfig.contains("@Import(S3InfraConfig.class)"));
+		assertTrue(externalClientConfig.contains("KakaoSocialLoginAdapter.class"));
 		assertTrue(externalClientConfig.contains("SlackBookingNotificationAdapter.class"));
 		assertTrue(externalClientConfig.contains("SlackMemberNotificationAdapter.class"));
+		assertTrue(externalClientConfig.contains("S3FileStorageAdapter.class"));
+		assertTrue(externalClientConfig.contains("CoolSmsAdapter.class"));
+		assertTrue(externalClientConfig.contains("excludeFilters"));
+		assertTrue(externalClientConfig.contains("classes = S3InfraConfig.class"));
 	}
 
 	@Test
@@ -1201,7 +1245,6 @@ class SharedBoundaryContractTest {
 		List<String> violations = executableSources.stream()
 			.flatMap(path -> readLines(path).stream()
 				.filter(line -> line.startsWith("import com.beat.infra.persistence."))
-				.filter(line -> !line.equals("import com.beat.infra.persistence.InfraPersistenceConfig"))
 				.map(line -> path.toString().replace('\\', '/') + ": " + line))
 			.toList();
 


### PR DESCRIPTION
## Summary

- **InfraBaseConfig Javadoc 추가**: top-level opt-in marker임을 코드 주석으로 명시. support config는 구현하지 않는다는 규칙도 명시
- **InfraBaseConfigGroup Javadoc 추가**: 등록 규칙(등록된 class는 InfraBaseConfig 구현 필수, support config는 등록 불가)을 명시
- **ExternalClientConfig 분리**: \`@Import(S3InfraConfig.class)\` 명시적 추가, \`@ComponentScan\`에서 \`S3InfraConfig\` excludeFilter로 제거 → configuration import와 adapter scan 역할 분리
- **InfraModuleConfig 삭제**: \`@EnableInfraBaseConfig\`가 실제 bootstrap entrypoint이므로 경쟁하는 marker 제거
- **IDE breadcrumb 복원**: \`apis/admin/batch InfraConfig\`에 \`@Import(InfraPersistenceConfig::class)\`를 유지. **제거하면 IDE autowiring false positive 발생** (자세한 이유는 아래 참고)
- **contract test 고정**: \`SharedBoundaryContractTest.infraBaseConfigMarkerIsLimitedToSelectableTopLevelGroups\`로 top-level/support config 경계를 테스트로 고정

## 왜 @Import(InfraPersistenceConfig::class) breadcrumb을 제거할 수 없는가

\`@EnableInfraBaseConfig\`는 내부적으로 \`@Import(InfraBaseConfigImportSelector.class)\`를 통해 동작하며,
\`InfraBaseConfigImportSelector\`는 \`DeferredImportSelector\`를 구현한다.

\`DeferredImportSelector\`는 Spring의 의도적인 설계로:
- 모든 \`@Configuration\` 클래스가 파싱된 **이후**에 처리되어 \`@ConditionalOnMissingBean\` 정확도를 보장
- Spring Boot autoconfiguration도 동일한 패턴을 사용

문제는 **IntelliJ Spring 플러그인이 \`DeferredImportSelector\`를 정적으로 추적하지 못한다는 것**이다.
플러그인은 \`@Import(SomeClass.class)\` 형태의 직접 참조만 분석할 수 있어서,
DeferredImportSelector가 동적으로 선택하는 config class들을 인식하지 못한다.

그 결과: \`@EnableInfraBaseConfig(InfraBaseConfigGroup.JPA)\` → \`JpaConfig\` → \`InfraPersistenceConfig\` 경로가
IDE에서는 끊겨 보이고, \`ScheduleRepository\`, \`BookingRepository\` 등 모든 Repository bean에
**"bean을 찾을 수 없습니다"** false positive가 발생한다.

해결책: 각 모듈 \`InfraConfig\`에 \`@Import(InfraPersistenceConfig::class)\` IDE breadcrumb을 유지한다.
- **런타임**: \`JpaConfig\`가 이미 \`@Import(InfraPersistenceConfig.class)\`를 소유하므로 중복 import는 Spring이 무시 → **실행에 영향 없음**
- **IDE**: 직접 참조로 IntelliJ가 추적 가능 → false positive 제거

이는 Spring Boot 오픈소스 이슈가 아니라 IntelliJ Spring 플러그인의 정적 분석 한계이므로,
\`DeferredImportSelector\` 자체를 변경하는 것은 설계 의도에 반한다.

## Test plan

- [x] \`SharedBoundaryContractTest\` 전체 통과
- [x] \`ApisModuleContextBootTest\` 통과
- [x] \`AdminModuleContextBootTest\` 통과
- [x] \`BatchModuleContextBootTest\` 통과
- [x] runtime behavior 변경 없음 (bootstrap 책임만 명확화)
- [x] IDE autowiring false positive 해소 (\`@Import(InfraPersistenceConfig::class)\` breadcrumb 복원)

## Related

- Parent: #350
- Related: #381
- Related: #440

🤖 Generated with [Claude Code](https://claude.ai/claude-code)