### PR TITLE
refactor: 관측성 로그 책임을 trace route 계약으로 고정

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -723,6 +723,20 @@ placeholder는 `app_bluegreen`(apis)이나 `app_stopstart/admin_nginx_route`(adm
 `upsert-upstream`으로 실제 컨테이너 이름과 포트로 덮어쓴다. inventory에서 host/port를 변경할 수는
 있지만, nginx pre-deploy validation + blackhole 계약을 깨지 않는 값으로만 유지해야 한다.
 
+### Nginx access log와 app port 노출 계약
+
+- HTTP request completion logging은 nginx `access.log`가 소유한다.
+- `nginx_base_config`의 `log_format`은 key=value로 `traceId=$request_id`, `clientIp=$remote_addr`,
+  `request="$request"`, `status=$status`, `bytes=$body_bytes_sent`, `referer="$http_referer"`,
+  `userAgent="$http_user_agent"`, `xForwardedFor="$http_x_forwarded_for"`, `requestTime=$request_time`을 기록한다.
+- application log는 business/domain event 중심이며, nginx access log와 같은 `traceId`로 join한다.
+- foundation compose에서 host publish는 nginx `80:80`, `443:443`만 공개 소유한다. MySQL은
+  `127.0.0.1:3306:3306`으로 loopback에 한정하고 Redis는 host publish를 갖지 않는다.
+- app container(`apis`, `admin`, `batch`) run task에는 `ports:`를 추가하지 않는다. 앱은 Docker network 내부에서
+  container name + app port로만 nginx upstream에 연결된다.
+- 운영 확인은 `sudo ss -tulpen | grep -E ':80|:443|:4001|:4002|:4000'`와
+  `docker ps --format 'table {{.Names}}\t{{.Ports}}'`로 수행한다.
+
 ### Nginx fragment mapping contract
 
 `nginx_fragments` inventory 값은 upstream 이름과 generated fragment 파일명을 묶는 canonical mapping이다.

--- a/infra/ansible/roles/nginx_base_config/templates/default.conf.j2
+++ b/infra/ansible/roles/nginx_base_config/templates/default.conf.j2
@@ -5,9 +5,9 @@
 include {{ nginx_generated_include_dir }}/upstreams/*.conf;
 # END BEAT MANAGED GENERATED UPSTREAM INCLUDES
 
-log_format {{ nginx_access_log_format_name }} '$request_id $remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for" "$request_time"';
+log_format {{ nginx_access_log_format_name }} 'traceId=$request_id clientIp=$remote_addr request="$request" '
+    'status=$status bytes=$body_bytes_sent referer="$http_referer" userAgent="$http_user_agent" '
+    'xForwardedFor="$http_x_forwarded_for" requestTime=$request_time';
 
 server {
     listen 80;

--- a/infra/src/main/resources/application-persistence.yml
+++ b/infra/src/main/resources/application-persistence.yml
@@ -34,6 +34,13 @@ spring:
     hibernate:
       ddl-auto: none
     show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+logging:
+  level:
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN
 
 ---
 spring:

--- a/observability/README.md
+++ b/observability/README.md
@@ -34,16 +34,16 @@ flowchart TB
     Gateway[gateway module]
     Infra[infra module]
     Obs[observability module]
-    Runtime[Spring runtime<br/>SecurityFilterChain · TaskExecutor · Log4j2]
+    Runtime["Spring runtime<br/>SecurityFilterChain / TaskExecutor / Log4j2"]
 
-    Apis -->|@Import ObservabilityModuleConfig| Obs
-    Admin -->|@Import ObservabilityModuleConfig| Obs
-    Batch -->|@Import ObservabilityModuleConfig| Obs
-    Gateway -->|extends BaseMdcLoggingFilter| Obs
-    Infra -->|uses TaskDecorator abstraction| Runtime
-    Obs -->|TaskDecorator bean · properties · resources| Runtime
-    Apis -->|SecurityFilterChain에 gateway MDC/JWT filter 배치| Gateway
-    Admin -->|SecurityFilterChain에 gateway MDC/JWT filter 배치| Gateway
+    Apis -->|"Import ObservabilityModuleConfig"| Obs
+    Admin -->|"Import ObservabilityModuleConfig"| Obs
+    Batch -->|"Import ObservabilityModuleConfig"| Obs
+    Gateway -->|"extends BaseMdcLoggingFilter"| Obs
+    Infra -->|"uses TaskDecorator abstraction"| Runtime
+    Obs -->|"TaskDecorator bean / properties / resources"| Runtime
+    Apis -->|"SecurityFilterChain adds gateway MDC and JWT filters"| Gateway
+    Admin -->|"SecurityFilterChain adds gateway MDC and JWT filters"| Gateway
 ```
 
 ### 레이어별 책임
@@ -65,7 +65,7 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    Module[apis/admin/batch Application<br/>@Import ObservabilityModuleConfig]
+    Module["apis/admin/batch Application<br/>Import ObservabilityModuleConfig"]
     Entry[ObservabilityModuleConfig]
 
     subgraph LOGGING[logging]
@@ -79,12 +79,12 @@ flowchart TB
 
     subgraph METRICS[metrics]
         MetricsConfig[MetricsConfig]
-        ActuatorProperties[ActuatorProperties<br/>management.endpoints.web.base-path]
+        ActuatorProperties["ActuatorProperties<br/>management.endpoints.web.base-path"]
         MetricsConfig --> ActuatorProperties
     end
 
     subgraph TRACING[tracing]
-        TracingConfig[TracingConfig<br/>vendor/exporter 없음]
+        TracingConfig["TracingConfig<br/>vendor/exporter 없음"]
     end
 
     Module --> Entry
@@ -121,16 +121,30 @@ flowchart TB
 
 ### MDC key 계약
 
-`BaseMdcLoggingFilter`가 HTTP 요청마다 아래 값을 MDC에 기록합니다.
+HTTP 요청 로깅 MDC pipeline은 아래 값을 기록합니다.
 
 | key | source | fallback |
 | --- | --- | --- |
-| `traceId` | `X-Request-ID` request header | UUID 기반 32자리 trace id 생성 |
-| `userId` | `resolveUserId()` 결과 | `GUEST` |
-| `clientIp` | `X-Forwarded-For` 첫 번째 값 → `X-Real-IP` → `remoteAddr` | `remoteAddr` |
-| `requestInfo` | `METHOD URI` | 없음 |
+| `traceId` | `BaseMdcLoggingFilter`: `X-Request-ID` request header | UUID 기반 32자리 trace id 생성 |
+| `userId` | `BaseMdcLoggingFilter`: `resolveUserId()` 결과 | `GUEST` |
+| `clientIp` | `BaseMdcLoggingFilter`: `X-Forwarded-For` 첫 번째 값 → `X-Real-IP` → `remoteAddr` | `remoteAddr` |
+| `requestInfo` | `BaseMdcLoggingFilter`: `METHOD URI` | 없음 |
+| `routePattern` | `RoutePatternMdcInterceptor`: `HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE` | `NO_ROUTE` |
 
 필터는 response에도 `X-Request-ID`를 기록하고, request 종료 시 `MDC.clear()`를 실행합니다.
+`routePattern`은 handler mapping 이후 `RoutePatternMdcInterceptor`가 채웁니다. 따라서 매칭된 Spring MVC 요청은
+`GET /api/performances/detail/{performanceId}`처럼 안정적인 route key로 집계할 수 있고, handler가 없는
+scanner/404 요청은 `NO_ROUTE` 또는 route 미기록이 정상입니다.
+
+### 운영 로그 책임 분리
+
+- Request completion logging은 nginx `access.log`가 소유합니다.
+- nginx access log는 `traceId`, `clientIp`, `request`, `status`, `bytes`, `referer`, `userAgent`, `xForwardedFor`,
+  `requestTime` 같은 HTTP 완료 사실을 기록합니다.
+- Application log는 request completion log를 중복으로 남기지 않고 business event/domain flow 메시지에 집중합니다.
+- Application log context는 MDC key-value(`traceId`, `userId`, `clientIp`, `request`, `route`)로 붙입니다.
+- nginx access log와 application log는 같은 `traceId`로 join합니다.
+- raw URI(`requestInfo`)는 디버깅용이고, route-level aggregation은 가능한 경우 `routePattern`을 사용합니다.
 
 ### Security-aware userId 흐름
 
@@ -175,9 +189,10 @@ JWT 인증 성공 시에는 `JwtAuthenticationFilter`가 MDC `userId`를 인증 
 `observability/src/main/resources/log4j2-spring.xml`은 MDC fallback을 포함합니다.
 
 ```text
-[%equals{%X{traceId}}{}{NO_TRACE}] [%equals{%X{userId}}{}{GUEST}]
+[traceId=%equals{%X{traceId}}{}{NO_TRACE}] [userId=%equals{%X{userId}}{}{GUEST}]
 [clientIp=%equals{%X{clientIp}}{}{UNKNOWN}]
 [request=%equals{%X{requestInfo}}{}{NO_REQUEST}]
+[route=%equals{%X{routePattern}}{}{NO_ROUTE}]
 ```
 
 ---
@@ -193,13 +208,13 @@ executor 소유자인 `infra`의 `TaskExecutorConfig`는 context에 있는 `Task
 flowchart LR
     Request[request thread MDC]
     Decorator[MdcTaskDecorator]
-    Executor[infra TaskExecutorConfig<br/>ThreadPoolTaskExecutor]
+    Executor["infra TaskExecutorConfig<br/>ThreadPoolTaskExecutor"]
     Worker[worker thread]
 
-    Request -->|capture MDC map| Decorator
-    Decorator -->|set before run| Worker
-    Executor -->|setTaskDecorator| Decorator
-    Worker -->|finally previous MDC restore| Decorator
+    Request -->|"capture MDC map"| Decorator
+    Decorator -->|"set before run"| Worker
+    Executor -->|"setTaskDecorator"| Decorator
+    Worker -->|"finally previous MDC restore"| Decorator
 ```
 
 규칙:
@@ -357,6 +372,13 @@ apis/admin/batch -> ObservabilityModuleConfig import
 - `requestInfo = METHOD URI`
 - userId null/blank 시 `GUEST`
 - request 종료 후 MDC clear
+
+### `RoutePatternMdcInterceptorTest`
+
+- `routePattern = METHOD BEST_MATCHING_PATTERN_ATTRIBUTE`
+- Spring MVC best matching pattern을 MDC `routePattern`으로 기록
+- handler mapping pattern이 없으면 `NO_ROUTE`
+- handler completion 후 `routePattern`만 제거하고 trace/user/request MDC는 filter boundary에 맡김
 
 ### `MdcTaskDecoratorTest`
 

--- a/observability/src/main/kotlin/com/beat/observability/logging/LoggingConfig.kt
+++ b/observability/src/main/kotlin/com/beat/observability/logging/LoggingConfig.kt
@@ -1,12 +1,26 @@
 package com.beat.observability.logging
 
+import com.beat.observability.logging.interceptor.RoutePatternMdcInterceptor
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.TaskDecorator
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration(proxyBeanMethods = false)
 class LoggingConfig {
 
     @Bean
     fun mdcTaskDecorator(): TaskDecorator = MdcTaskDecorator()
+
+    @Bean
+    fun routePatternMdcInterceptor(): RoutePatternMdcInterceptor = RoutePatternMdcInterceptor()
+
+    @Bean
+    fun routePatternMdcWebMvcConfigurer(routePatternMdcInterceptor: RoutePatternMdcInterceptor): WebMvcConfigurer =
+        object : WebMvcConfigurer {
+            override fun addInterceptors(registry: InterceptorRegistry) {
+                registry.addInterceptor(routePatternMdcInterceptor)
+            }
+        }
 }

--- a/observability/src/main/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilter.kt
+++ b/observability/src/main/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilter.kt
@@ -18,8 +18,10 @@ abstract class BaseMdcLoggingFilter : OncePerRequestFilter() {
         const val USER_ID_KEY = "userId"
         const val CLIENT_IP_KEY = "clientIp"
         const val REQUEST_INFO_KEY = "requestInfo"
+        const val ROUTE_PATTERN_KEY = "routePattern"
 
         const val DEFAULT_GUEST_USER = "GUEST"
+        const val DEFAULT_ROUTE_PATTERN = "NO_ROUTE"
 
         private const val MAX_TRACE_ID_LENGTH = 128
         private val TRACE_ID_PATTERN = Regex("^[A-Za-z0-9._:-]+$")

--- a/observability/src/main/kotlin/com/beat/observability/logging/interceptor/RoutePatternMdcInterceptor.kt
+++ b/observability/src/main/kotlin/com/beat/observability/logging/interceptor/RoutePatternMdcInterceptor.kt
@@ -1,0 +1,38 @@
+package com.beat.observability.logging.interceptor
+
+import com.beat.observability.logging.filter.BaseMdcLoggingFilter
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.HandlerMapping
+
+class RoutePatternMdcInterceptor : HandlerInterceptor {
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        MDC.put(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY, resolveRoutePattern(request))
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?,
+    ) {
+        MDC.remove(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY)
+    }
+
+    private fun resolveRoutePattern(request: HttpServletRequest): String {
+        val bestMatchingPattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE)
+            ?.toString()
+            ?.takeIf { it.isNotBlank() }
+            ?: return BaseMdcLoggingFilter.DEFAULT_ROUTE_PATTERN
+
+        return "${request.method} $bestMatchingPattern"
+    }
+}

--- a/observability/src/main/resources/log4j2-spring.xml
+++ b/observability/src/main/resources/log4j2-spring.xml
@@ -2,7 +2,7 @@
 <Configuration status="INFO">
     <Properties>
         <Property name="LOG_PATTERN">
-            %style{%d{yyyy-MM-dd HH:mm:ss,SSS}}{blue} %highlight{[%-5p]}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=bright_blue, TRACE=cyan} [%t] [%equals{%X{traceId}}{}{NO_TRACE}] [%equals{%X{userId}}{}{GUEST}] [clientIp=%equals{%X{clientIp}}{}{UNKNOWN}] [request=%equals{%X{requestInfo}}{}{NO_REQUEST}] %style{[%c{1}.%M():%L]}{BRIGHT_BLACK} - %m%n
+            %style{%d{yyyy-MM-dd HH:mm:ss,SSS}}{blue} %highlight{[%-5p]}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=bright_blue, TRACE=cyan} [%t] [traceId=%equals{%X{traceId}}{}{NO_TRACE}] [userId=%equals{%X{userId}}{}{GUEST}] [clientIp=%equals{%X{clientIp}}{}{UNKNOWN}] [request=%equals{%X{requestInfo}}{}{NO_REQUEST}] [route=%equals{%X{routePattern}}{}{NO_ROUTE}] %style{[%c{1}.%M():%L]}{BRIGHT_BLACK} - %m%n
         </Property>
     </Properties>
 

--- a/observability/src/test/kotlin/com/beat/observability/logging/Log4j2PatternContractTest.kt
+++ b/observability/src/test/kotlin/com/beat/observability/logging/Log4j2PatternContractTest.kt
@@ -1,0 +1,20 @@
+package com.beat.observability.logging
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class Log4j2PatternContractTest {
+
+    @Test
+    fun `application log pattern exposes request context as key value MDC fields`() {
+        val log4j2 = Files.readString(Path.of("src/main/resources/log4j2-spring.xml"))
+
+        assertTrue(log4j2.contains("[traceId=%equals{%X{traceId}}{}{NO_TRACE}]"))
+        assertTrue(log4j2.contains("[userId=%equals{%X{userId}}{}{GUEST}]"))
+        assertTrue(log4j2.contains("[clientIp=%equals{%X{clientIp}}{}{UNKNOWN}]"))
+        assertTrue(log4j2.contains("[request=%equals{%X{requestInfo}}{}{NO_REQUEST}]"))
+        assertTrue(log4j2.contains("[route=%equals{%X{routePattern}}{}{NO_ROUTE}]"))
+    }
+}

--- a/observability/src/test/kotlin/com/beat/observability/logging/interceptor/RoutePatternMdcInterceptorTest.kt
+++ b/observability/src/test/kotlin/com/beat/observability/logging/interceptor/RoutePatternMdcInterceptorTest.kt
@@ -1,0 +1,54 @@
+package com.beat.observability.logging.interceptor
+
+import com.beat.observability.logging.filter.BaseMdcLoggingFilter
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.web.servlet.HandlerMapping
+
+class RoutePatternMdcInterceptorTest {
+
+    private val interceptor = RoutePatternMdcInterceptor()
+
+    @AfterEach
+    fun clearMdc() {
+        MDC.clear()
+    }
+
+    @Test
+    fun `stores method and best matching route pattern in MDC`() {
+        val request = MockHttpServletRequest("GET", "/api/performances/detail/19")
+        request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/api/performances/detail/{performanceId}")
+
+        interceptor.preHandle(request, MockHttpServletResponse(), Any())
+
+        assertEquals(
+            "GET /api/performances/detail/{performanceId}",
+            MDC.get(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY),
+        )
+    }
+
+    @Test
+    fun `uses no route fallback when handler mapping pattern is unavailable`() {
+        val request = MockHttpServletRequest("GET", "/scanner/no-match")
+
+        interceptor.preHandle(request, MockHttpServletResponse(), Any())
+
+        assertEquals(BaseMdcLoggingFilter.DEFAULT_ROUTE_PATTERN, MDC.get(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY))
+    }
+
+    @Test
+    fun `removes route pattern after handler completion without clearing other MDC keys`() {
+        MDC.put(BaseMdcLoggingFilter.TRACE_ID_KEY, "trace-123")
+        MDC.put(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY, "GET /api/main")
+
+        interceptor.afterCompletion(MockHttpServletRequest(), MockHttpServletResponse(), Any(), null)
+
+        assertEquals("trace-123", MDC.get(BaseMdcLoggingFilter.TRACE_ID_KEY))
+        assertNull(MDC.get(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY))
+    }
+}

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -54,6 +54,25 @@ class RootRetirementContractTest {
 	}
 
 	@Test
+	void persistenceProfileKeepsProdSqlLoggingOffWhileDevSqlLoggingStaysExplicitOptIn() throws Exception {
+		String persistence = read("infra/src/main/resources/application-persistence.yml");
+		String baseSection = persistence.substring(0, persistence.indexOf("\n---"));
+		String prodSection = sectionAfter(persistence, "on-profile: prod");
+		String devSection = sectionAfter(persistence, "on-profile: dev");
+
+		assertTrue(devSection.contains("show-sql: true"));
+		assertTrue(baseSection.contains("format_sql: true"));
+		assertTrue(prodSection.contains("show-sql: false"));
+		assertTrue(prodSection.contains("format_sql: false"));
+		assertTrue(prodSection.contains("org.hibernate.SQL: WARN"));
+		assertTrue(prodSection.contains("org.hibernate.orm.jdbc.bind: WARN"));
+		assertFalse(prodSection.contains("org.hibernate.SQL: DEBUG"));
+		assertFalse(prodSection.contains("org.hibernate.SQL: TRACE"));
+		assertFalse(prodSection.contains("org.hibernate.orm.jdbc.bind: DEBUG"));
+		assertFalse(prodSection.contains("org.hibernate.orm.jdbc.bind: TRACE"));
+	}
+
+	@Test
 	void gradleBuildNoLongerVerifiesLegacyRootBootJarBaseline() throws Exception {
 		String buildFile = Files.readString(Path.of("build.gradle.kts"));
 
@@ -77,6 +96,32 @@ class RootRetirementContractTest {
 		assertTrue(executableBuildLogic.contains("tasks.withType<BootRun>().configureEach"));
 		assertTrue(executableBuildLogic.contains("workingDir = rootDir"));
 		assertTrue(Files.exists(Path.of("observability/src/main/resources/log4j2-spring.xml")));
+	}
+
+	@Test
+	void observabilityOwnsApplicationLogMdcKeyValueAndRoutePatternContract() throws Exception {
+		String log4j2 = read("observability/src/main/resources/log4j2-spring.xml");
+		String baseFilter = read("observability/src/main/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilter.kt");
+		String routeInterceptor =
+			read("observability/src/main/kotlin/com/beat/observability/logging/interceptor/RoutePatternMdcInterceptor.kt");
+		String loggingConfig = read("observability/src/main/kotlin/com/beat/observability/logging/LoggingConfig.kt");
+		String observabilityReadme = read("observability/README.md");
+
+		assertTrue(log4j2.contains("[traceId=%equals{%X{traceId}}{}{NO_TRACE}]"));
+		assertTrue(log4j2.contains("[userId=%equals{%X{userId}}{}{GUEST}]"));
+		assertTrue(log4j2.contains("[clientIp=%equals{%X{clientIp}}{}{UNKNOWN}]"));
+		assertTrue(log4j2.contains("[request=%equals{%X{requestInfo}}{}{NO_REQUEST}]"));
+		assertTrue(log4j2.contains("[route=%equals{%X{routePattern}}{}{NO_ROUTE}]"));
+		assertFalse(log4j2.contains("[%equals{%X{traceId}}{}{NO_TRACE}]"));
+		assertTrue(baseFilter.contains("const val ROUTE_PATTERN_KEY = \"routePattern\""));
+		assertTrue(routeInterceptor.contains("HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE"));
+		assertTrue(routeInterceptor.contains("MDC.put(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY"));
+		assertTrue(routeInterceptor.contains("\"${request.method} $bestMatchingPattern\""));
+		assertTrue(routeInterceptor.contains("MDC.remove(BaseMdcLoggingFilter.ROUTE_PATTERN_KEY)"));
+		assertTrue(loggingConfig.contains("registry.addInterceptor(routePatternMdcInterceptor)"));
+		assertTrue(observabilityReadme.contains("Request completion logging은 nginx `access.log`가 소유합니다"));
+		assertTrue(observabilityReadme.contains("Application log는 request completion log를 중복으로 남기지 않고"));
+		assertTrue(observabilityReadme.contains("route-level aggregation은 가능한 경우 `routePattern`을 사용합니다"));
 	}
 
 	@Test
@@ -456,6 +501,10 @@ class RootRetirementContractTest {
 		assertTrue(appContainerRuntimeEnv.contains("| string | lower"));
 		assertFalse(appStopStartRunContainer.contains("\"{{ module_cfg.spring_profile | upper }}_ACTUATOR_PORT\""));
 		assertFalse(appStopStartRunContainer.contains("SPRING_PROFILES_ACTIVE"));
+		assertFalse(appStopStartRunContainer.contains("\n    ports:"));
+		assertFalse(appStopStartRunContainer.contains("0.0.0.0:400"));
+		assertFalse(appBluegreenRunSwitch.contains("\n        ports:"));
+		assertFalse(appBluegreenRunSwitch.contains("0.0.0.0:400"));
 		assertTrue(foundationPlaybook.contains("role: foundation_stack"));
 		assertTrue(foundationPlaybook.contains("role: nginx_base_config"));
 		assertTrue(foundationStackTasks.contains("project_src: \"{{ deployment_dir }}\""));
@@ -477,11 +526,14 @@ class RootRetirementContractTest {
 		assertFalse(foundationStackTasks.contains("definition: \"{{ foundation_stack_compose_definition }}\""));
 		assertTrue(foundationComposeTemplate.contains("services:"));
 		assertTrue(foundationComposeTemplate.contains("container_name: \"{{ nginx_container_name }}\""));
+		assertTrue(foundationComposeTemplate.contains("- \"80:80\""));
+		assertTrue(foundationComposeTemplate.contains("- \"443:443\""));
 		assertTrue(foundationComposeTemplate.contains("{{ deployment_dir }}/nginx/conf.d:/etc/nginx/conf.d"));
 		assertTrue(foundationComposeTemplate.contains("{{ deployment_dir }}/nginx/generated:/etc/nginx/generated"));
 		assertFalse(foundationComposeTemplate.contains(":/etc/nginx\""));
 		assertFalse(foundationComposeTemplate.contains("nginx-config-volume"));
 		assertTrue(foundationComposeTemplate.contains("foundation_mysql_enabled"));
+		assertTrue(foundationComposeTemplate.contains("- \"127.0.0.1:3306:3306\""));
 		assertTrue(foundationComposeTemplate.contains("foundation_redis_enabled"));
 		assertFalse(defaultConfTemplate.contains("upstream {{ backend_upstream_name"));
 		assertFalse(defaultConfTemplate.contains("upstream {{ actuator_upstream_name"));
@@ -489,6 +541,22 @@ class RootRetirementContractTest {
 		assertFalse(defaultConfTemplate.contains("location /admin/"));
 		assertTrue(defaultConfTemplate.contains("BEAT MANAGED GENERATED UPSTREAM INCLUDES"));
 		assertTrue(defaultConfTemplate.contains("BEAT MANAGED GENERATED ROUTE INCLUDES"));
+		assertTrue(defaultConfTemplate.contains("traceId=$request_id"));
+		assertTrue(defaultConfTemplate.contains("clientIp=$remote_addr"));
+		assertTrue(defaultConfTemplate.contains("request=\"$request\""));
+		assertTrue(defaultConfTemplate.contains("status=$status"));
+		assertTrue(defaultConfTemplate.contains("bytes=$body_bytes_sent"));
+		assertTrue(defaultConfTemplate.contains("referer=\"$http_referer\""));
+		assertTrue(defaultConfTemplate.contains("userAgent=\"$http_user_agent\""));
+		assertTrue(defaultConfTemplate.contains("xForwardedFor=\"$http_x_forwarded_for\""));
+		assertTrue(defaultConfTemplate.contains("requestTime=$request_time"));
+		assertEquals(
+			2,
+			countOccurrences(defaultConfTemplate, "access_log /var/log/nginx/access.log {{ nginx_access_log_format_name }}"));
+		assertTrue(defaultConfTemplate.contains("proxy_set_header X-Request-ID $request_id"));
+		assertTrue(infraReadme.contains("HTTP request completion logging은 nginx `access.log`가 소유한다"));
+		assertTrue(infraReadme.contains("application log는 business/domain event 중심"));
+		assertTrue(infraReadme.contains("app container(`apis`, `admin`, `batch`) run task에는 `ports:`를 추가하지 않는다"));
 		assertTrue(nginxUpdateScript.contains("BEAT MANAGED GENERATED UPSTREAM INCLUDES"));
 		assertTrue(nginxUpdateScript.contains("BEAT MANAGED GENERATED ROUTE INCLUDES"));
 		assertTrue(nginxUpdateScript.contains("bootstrap-includes"));
@@ -898,6 +966,26 @@ class RootRetirementContractTest {
 
 	private static String read(String path) throws IOException {
 		return Files.readString(Path.of(path));
+	}
+
+	private static String sectionAfter(String content, String marker) {
+		int start = content.indexOf(marker);
+		assertTrue(start >= 0, marker);
+		int nextDocument = content.indexOf("\n---", start + marker.length());
+		if (nextDocument < 0) {
+			return content.substring(start);
+		}
+		return content.substring(start, nextDocument);
+	}
+
+	private static int countOccurrences(String content, String needle) {
+		int count = 0;
+		int index = 0;
+		while ((index = content.indexOf(needle, index)) >= 0) {
+			count++;
+			index += needle.length();
+		}
+		return count;
 	}
 
 	private static String run(String... command) throws Exception {


### PR DESCRIPTION
## Related issue 🛠

- closes #462
- Parent: #460
- Related: #461
- Traffic policy split: #463

## Work Description ✏️

- application log pattern을 `traceId/userId/clientIp/request/route` key=value MDC 계약으로 정리했습니다.
- Spring MVC handler mapping 이후 알 수 있는 `routePattern`을 `RoutePatternMdcInterceptor`에서 `HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE` 기반으로 기록하도록 추가했습니다.
- nginx access log를 HTTP access source of truth로 두고 `traceId/clientIp/request/status/bytes/referer/userAgent/xForwardedFor/requestTime` key=value format을 고정했습니다.
- prod persistence profile에서 SQL dump와 Hibernate SQL/bind DEBUG·TRACE 노출이 꺼져 있음을 repo-visible 설정과 contract test로 보강했습니다.
- app container가 host `400x` port를 직접 publish하지 않고 nginx 뒤 Docker network 내부 upstream으로만 붙는 계약을 RootRetirementContractTest와 infra 문서에 고정했습니다.
- nginx access log와 application log는 같은 traceId로 join하고, request completion logging은 nginx가 소유한다는 책임 분리를 문서화했습니다.

## Trouble Shooting ⚽️

- `routePattern`은 servlet filter 단계에서 아직 알 수 없으므로 filter가 아니라 Spring MVC `HandlerInterceptor`에서 기록했습니다.
- `HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE`는 모든 handler mapping에서 항상 보장되는 값은 아니므로 미존재 시 `NO_ROUTE` fallback을 사용합니다.
- scanner/404 및 static resource handler miss는 `NO_ROUTE` 또는 resource pattern 형태가 정상이며, app completion log는 추가하지 않았습니다.
- 운영 서버의 실제 socket/container 상태는 이 로컬 세션에서 확인하지 못해 repo/Ansible 계약과 테스트로 고정했습니다.

## Related ScreenShot 📷

- 없음

## Uncompleted Tasks 😅

- 운영 서버 직접 확인은 별도 실행 필요
  - `sudo ss -tulpen | grep -E ':80|:443|:4001|:4002|:4000'`
  - `docker ps --format 'table {{.Names}}\t{{.Ports}}'`

## To Reviewers 📢

핵심은 로그를 더 많이 찍는 것이 아니라 책임을 분리하는 것입니다.

- nginx access log: HTTP 완료 사실(status/requestTime/request/client/userAgent 등)
- application log: business/domain event + MDC context(traceId/userId/clientIp/request/route)
- route-level aggregation: raw URI가 아니라 `routePattern` 사용

검증:

```bash
GRADLE_USER_HOME=$PWD/.gradle-local ./gradlew :observability:test --no-daemon
GRADLE_USER_HOME=$PWD/.gradle-local ./gradlew :test --tests com.beat.RootRetirementContractTest --no-parallel --no-daemon
GRADLE_USER_HOME=$PWD/.gradle-local ./gradlew :apis:test --tests com.beat.apis.ApisApplicationTest --no-daemon
GRADLE_USER_HOME=$PWD/.gradle-local ./gradlew :admin:test --tests com.beat.admin.AdminApplicationTest --no-daemon
GRADLE_USER_HOME=$PWD/.gradle-local ./gradlew :batch:test --tests com.beat.batch.BatchApplicationTest --no-daemon
git diff --check
```
