### PR TITLE
refactor: scanner probing을 nginx 차단 계약으로 고정

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -737,6 +737,64 @@ placeholder는 `app_bluegreen`(apis)이나 `app_stopstart/admin_nginx_route`(adm
 - 운영 확인은 `sudo ss -tulpen | grep -E ':80|:443|:4001|:4002|:4000'`와
   `docker ps --format 'table {{.Names}}\t{{.Ports}}'`로 수행한다.
 
+### Scanner/bot nginx 차단 정책
+
+BEAT는 PHP/WordPress/Laravel 기반 서비스가 아니므로 `/.env`, `/.git/config`, `/wp-admin/`,
+`/wp-content/`, `/wordpress/`, `/laravel/`, 명백한 PHP probing path는 nginx에서 먼저 종료한다.
+
+- scanner/bot 차단은 `nginx_base_config`가 소유하고, generated route fragment보다 앞에서 평가한다.
+- HTTP server에서는 `/.well-known/acme-challenge/`를 먼저 살린 뒤 scanner block을 적용하고, 그 다음 HTTPS redirect를 수행한다.
+- HTTPS server에서는 scanner block을 generated route include보다 먼저 둔다.
+- 기본 응답은 `404`다. `444`는 운영 access log와 smoke 검증 후에만 선택한다.
+- broad `*.php`/`.*\.php` regex는 사용하지 않는다. `/index.php`, `/phpinfo.php`, `/info.php` 같은 PHP probing은 exact match로만 차단한다.
+- root `.env` 계열만 narrow anchored regex로 보강한다. path 전체의 `.env`를 넓게 잡지 않는다.
+- scanner 결과 확인은 nginx `access.log`에서 수행한다. app request completion log를 추가하지 않는다.
+- rate limit은 1차 rollout에서 강제 적용하지 않는다. access log top-N과 정상 사용자 영향도를 확인한 뒤, 필요하면 scanner location에만 별도 threshold로 적용한다.
+
+운영 전/후 smoke:
+
+```bash
+docker exec nginx nginx -t
+
+curl -Ik https://<host>/.env
+curl -Ik https://<host>/.git/config
+curl -Ik https://<host>/wp-admin/index.php
+curl -Ik https://<host>/wordpress/.git/config
+curl -Ik https://<host>/laravel/.env
+
+curl -Ik https://<host>/api/main
+curl -Ik https://<host>/admin/
+curl -Ik https://<host>/robots.txt
+curl -Ik https://<host>/favicon.ico
+```
+
+기본 기대값은 scanner path `404`, 정상 route 비차단이다.
+
+응급 rollback은 scanner block만 disable하고 foundation/nginx role을 다시 적용한다.
+`nginx_base_config` transaction이 검증과 reload를 수행하므로, 아래 `nginx -t`는 적용 후 확인용이다.
+
+```bash
+ansible-playbook infra/ansible/playbooks/foundation.yml \
+  -i infra/ansible/inventories/prod/hosts.yml \
+  --tags nginx \
+  -e deploy_environment=prod \
+  -e foundation_manage_nginx=true \
+  -e nginx_scanner_block_enabled=false
+
+docker exec nginx nginx -t
+```
+
+재활성화:
+
+```bash
+ansible-playbook infra/ansible/playbooks/foundation.yml \
+  -i infra/ansible/inventories/prod/hosts.yml \
+  --tags nginx \
+  -e deploy_environment=prod \
+  -e foundation_manage_nginx=true \
+  -e nginx_scanner_block_enabled=true
+```
+
 ### Nginx fragment mapping contract
 
 `nginx_fragments` inventory 값은 upstream 이름과 generated fragment 파일명을 묶는 canonical mapping이다.

--- a/infra/README.md
+++ b/infra/README.md
@@ -779,7 +779,7 @@ ansible-playbook infra/ansible/playbooks/foundation.yml \
   --tags nginx \
   -e deploy_environment=prod \
   -e foundation_manage_nginx=true \
-  -e nginx_scanner_block_enabled=false
+  -e nginx_base_config_scanner_block_enabled=false
 
 docker exec nginx nginx -t
 ```
@@ -792,7 +792,7 @@ ansible-playbook infra/ansible/playbooks/foundation.yml \
   --tags nginx \
   -e deploy_environment=prod \
   -e foundation_manage_nginx=true \
-  -e nginx_scanner_block_enabled=true
+  -e nginx_base_config_scanner_block_enabled=true
 ```
 
 ### Nginx fragment mapping contract

--- a/infra/ansible/roles/nginx_base_config/defaults/main.yml
+++ b/infra/ansible/roles/nginx_base_config/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-nginx_scanner_block_enabled: true
-nginx_scanner_block_status: 404
+nginx_base_config_scanner_block_enabled: true
+nginx_base_config_scanner_block_status: 404
 
-nginx_scanner_exact_paths:
+nginx_base_config_scanner_exact_paths:
   - /.env
   - /.env.backup
   - /.git
@@ -13,7 +13,7 @@ nginx_scanner_exact_paths:
   - /phpinfo.php
   - /info.php
 
-nginx_scanner_prefix_paths:
+nginx_base_config_scanner_prefix_paths:
   - /.git/
   - /wordpress/
   - /wp-admin/
@@ -23,6 +23,6 @@ nginx_scanner_prefix_paths:
 
 # Phase-1 contract: scanner rate limiting is intentionally not enforced.
 # Thresholds are decided only after nginx access-log distribution review.
-nginx_scanner_rate_limit_enabled: false
-nginx_scanner_rate_limit_dry_run: true
-nginx_scanner_rate_limit_status: 429
+nginx_base_config_scanner_rate_limit_enabled: false
+nginx_base_config_scanner_rate_limit_dry_run: true
+nginx_base_config_scanner_rate_limit_status: 429

--- a/infra/ansible/roles/nginx_base_config/defaults/main.yml
+++ b/infra/ansible/roles/nginx_base_config/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+nginx_scanner_block_enabled: true
+nginx_scanner_block_status: 404
+
+nginx_scanner_exact_paths:
+  - /.env
+  - /.env.backup
+  - /.git
+  - /.git/config
+  - /wp-login.php
+  - /xmlrpc.php
+  - /index.php
+  - /phpinfo.php
+  - /info.php
+
+nginx_scanner_prefix_paths:
+  - /.git/
+  - /wordpress/
+  - /wp-admin/
+  - /wp-content/
+  - /wp-includes/
+  - /laravel/
+
+# Phase-1 contract: scanner rate limiting is intentionally not enforced.
+# Thresholds are decided only after nginx access-log distribution review.
+nginx_scanner_rate_limit_enabled: false
+nginx_scanner_rate_limit_dry_run: true
+nginx_scanner_rate_limit_status: 429

--- a/infra/ansible/roles/nginx_base_config/tasks/main.yml
+++ b/infra/ansible/roles/nginx_base_config/tasks/main.yml
@@ -14,6 +14,16 @@
     nginx_route_source_path: "{{ nginx_generated_source_dir }}/routes/{{ nginx_fragments.route.fragment_file }}"
     nginx_route_target_path: "{{ nginx_generated_target_dir }}/routes/{{ nginx_fragments.route.fragment_file }}"
 
+- name: Validate nginx scanner block settings
+  ansible.builtin.assert:
+    that:
+      - nginx_scanner_block_status | int in [404, 444]
+      - nginx_scanner_exact_paths is sequence
+      - nginx_scanner_exact_paths is not string
+      - nginx_scanner_prefix_paths is sequence
+      - nginx_scanner_prefix_paths is not string
+    fail_msg: "Invalid nginx scanner block settings"
+
 - name: Ensure nginx candidate directory exists
   ansible.builtin.file:
     path: "{{ deployment_dir }}/nginx"

--- a/infra/ansible/roles/nginx_base_config/tasks/main.yml
+++ b/infra/ansible/roles/nginx_base_config/tasks/main.yml
@@ -20,8 +20,22 @@
       - nginx_base_config_scanner_block_status | int in [404, 444]
       - nginx_base_config_scanner_exact_paths is sequence
       - nginx_base_config_scanner_exact_paths is not string
+      - >-
+        (nginx_base_config_scanner_exact_paths | select('string') | list | length)
+        == (nginx_base_config_scanner_exact_paths | length)
+      - >-
+        (nginx_base_config_scanner_exact_paths
+        | reject('match', '^/[A-Za-z0-9._/-]+$')
+        | list | length) == 0
       - nginx_base_config_scanner_prefix_paths is sequence
       - nginx_base_config_scanner_prefix_paths is not string
+      - >-
+        (nginx_base_config_scanner_prefix_paths | select('string') | list | length)
+        == (nginx_base_config_scanner_prefix_paths | length)
+      - >-
+        (nginx_base_config_scanner_prefix_paths
+        | reject('match', '^/[A-Za-z0-9._/-]+/$')
+        | list | length) == 0
     fail_msg: "Invalid nginx scanner block settings"
 
 - name: Ensure nginx candidate directory exists

--- a/infra/ansible/roles/nginx_base_config/tasks/main.yml
+++ b/infra/ansible/roles/nginx_base_config/tasks/main.yml
@@ -17,11 +17,11 @@
 - name: Validate nginx scanner block settings
   ansible.builtin.assert:
     that:
-      - nginx_scanner_block_status | int in [404, 444]
-      - nginx_scanner_exact_paths is sequence
-      - nginx_scanner_exact_paths is not string
-      - nginx_scanner_prefix_paths is sequence
-      - nginx_scanner_prefix_paths is not string
+      - nginx_base_config_scanner_block_status | int in [404, 444]
+      - nginx_base_config_scanner_exact_paths is sequence
+      - nginx_base_config_scanner_exact_paths is not string
+      - nginx_base_config_scanner_prefix_paths is sequence
+      - nginx_base_config_scanner_prefix_paths is not string
     fail_msg: "Invalid nginx scanner block settings"
 
 - name: Ensure nginx candidate directory exists

--- a/infra/ansible/roles/nginx_base_config/templates/default.conf.j2
+++ b/infra/ansible/roles/nginx_base_config/templates/default.conf.j2
@@ -6,20 +6,20 @@ include {{ nginx_generated_include_dir }}/upstreams/*.conf;
 # END BEAT MANAGED GENERATED UPSTREAM INCLUDES
 
 {% macro render_scanner_policy() -%}
-{% if nginx_scanner_block_enabled | default(true) | bool %}
+{% if nginx_base_config_scanner_block_enabled | default(true) | bool %}
     # BEAT scanner/bot terminal policy. Keep exact/^~ locations before generated routes.
-{% for path in nginx_scanner_exact_paths | default([]) %}
+{% for path in nginx_base_config_scanner_exact_paths | default([]) %}
     location = {{ path }} {
-        return {{ nginx_scanner_block_status | default(404) }};
+        return {{ nginx_base_config_scanner_block_status | default(404) }};
     }
 {% endfor %}
-{% for prefix in nginx_scanner_prefix_paths | default([]) %}
+{% for prefix in nginx_base_config_scanner_prefix_paths | default([]) %}
     location ^~ {{ prefix }} {
-        return {{ nginx_scanner_block_status | default(404) }};
+        return {{ nginx_base_config_scanner_block_status | default(404) }};
     }
 {% endfor %}
     location ~ ^/\.env(?:\.[A-Za-z0-9_-]{1,32})?$ {
-        return {{ nginx_scanner_block_status | default(404) }};
+        return {{ nginx_base_config_scanner_block_status | default(404) }};
     }
 {% endif %}
 {%- endmacro %}

--- a/infra/ansible/roles/nginx_base_config/templates/default.conf.j2
+++ b/infra/ansible/roles/nginx_base_config/templates/default.conf.j2
@@ -5,6 +5,25 @@
 include {{ nginx_generated_include_dir }}/upstreams/*.conf;
 # END BEAT MANAGED GENERATED UPSTREAM INCLUDES
 
+{% macro render_scanner_policy() -%}
+{% if nginx_scanner_block_enabled | default(true) | bool %}
+    # BEAT scanner/bot terminal policy. Keep exact/^~ locations before generated routes.
+{% for path in nginx_scanner_exact_paths | default([]) %}
+    location = {{ path }} {
+        return {{ nginx_scanner_block_status | default(404) }};
+    }
+{% endfor %}
+{% for prefix in nginx_scanner_prefix_paths | default([]) %}
+    location ^~ {{ prefix }} {
+        return {{ nginx_scanner_block_status | default(404) }};
+    }
+{% endfor %}
+    location ~ ^/\.env(?:\.[A-Za-z0-9_-]{1,32})?$ {
+        return {{ nginx_scanner_block_status | default(404) }};
+    }
+{% endif %}
+{%- endmacro %}
+
 log_format {{ nginx_access_log_format_name }} 'traceId=$request_id clientIp=$remote_addr request="$request" '
     'status=$status bytes=$body_bytes_sent referer="$http_referer" userAgent="$http_user_agent" '
     'xForwardedFor="$http_x_forwarded_for" requestTime=$request_time';
@@ -12,9 +31,11 @@ log_format {{ nginx_access_log_format_name }} 'traceId=$request_id clientIp=$rem
 server {
     listen 80;
     server_name {{ nginx_server_name }};
-    location /.well-known/acme-challenge/ {
+    location ^~ /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
+
+{{ render_scanner_policy() }}
 
     access_log /var/log/nginx/access.log {{ nginx_access_log_format_name }};
 
@@ -33,6 +54,8 @@ server {
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     underscores_in_headers on;
+
+{{ render_scanner_policy() }}
 
     # BEGIN BEAT MANAGED GENERATED ROUTE INCLUDES
     include {{ nginx_generated_include_dir }}/routes/*.conf;

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -125,6 +125,59 @@ class RootRetirementContractTest {
 	}
 
 	@Test
+	void nginxBaseConfigOwnsConservativeScannerBlockContract() throws Exception {
+		String defaultConfTemplate = read("infra/ansible/roles/nginx_base_config/templates/default.conf.j2");
+		String defaults = read("infra/ansible/roles/nginx_base_config/defaults/main.yml");
+		String tasks = read("infra/ansible/roles/nginx_base_config/tasks/main.yml");
+		String infraReadme = read("infra/README.md");
+		String httpServer = sectionBetween(defaultConfTemplate, "server {\n    listen 80;", "\n}\n\nserver {\n    listen 443 ssl;");
+		String httpsServer = defaultConfTemplate.substring(defaultConfTemplate.indexOf("server {\n    listen 443 ssl;"));
+
+		assertTrue(defaultConfTemplate.contains("macro render_scanner_policy()"));
+		assertEquals(2, countOccurrences(defaultConfTemplate, "{{ render_scanner_policy() }}"));
+		assertBefore(httpServer, "location ^~ /.well-known/acme-challenge/", "{{ render_scanner_policy() }}");
+		assertBefore(httpServer, "{{ render_scanner_policy() }}", "return 301 https://$host$request_uri;");
+		assertBefore(httpsServer, "{{ render_scanner_policy() }}", "BEAT MANAGED GENERATED ROUTE INCLUDES");
+		assertTrue(defaultConfTemplate.contains("location = {{ path }}"));
+		assertTrue(defaultConfTemplate.contains("location ^~ {{ prefix }}"));
+		assertTrue(defaultConfTemplate.contains("location ~ ^/\\.env(?:\\.[A-Za-z0-9_-]{1,32})?$"));
+		assertFalse(defaultConfTemplate.contains(".*\\.php"));
+		assertFalse(defaultConfTemplate.contains("limit_req "));
+		assertFalse(defaultConfTemplate.contains("limit_req_zone"));
+
+		assertTrue(defaults.contains("nginx_scanner_block_enabled: true"));
+		assertTrue(defaults.contains("nginx_scanner_block_status: 404"));
+		assertTrue(defaults.contains("- /.env"));
+		assertTrue(defaults.contains("- /.git/config"));
+		assertTrue(defaults.contains("- /wp-login.php"));
+		assertTrue(defaults.contains("- /xmlrpc.php"));
+		assertTrue(defaults.contains("- /index.php"));
+		assertTrue(defaults.contains("- /phpinfo.php"));
+		assertTrue(defaults.contains("- /info.php"));
+		assertTrue(defaults.contains("- /wordpress/"));
+		assertTrue(defaults.contains("- /wp-admin/"));
+		assertTrue(defaults.contains("- /wp-content/"));
+		assertTrue(defaults.contains("- /wp-includes/"));
+		assertTrue(defaults.contains("- /laravel/"));
+		assertTrue(defaults.contains("nginx_scanner_rate_limit_enabled: false"));
+		assertTrue(defaults.contains("nginx_scanner_rate_limit_dry_run: true"));
+		assertTrue(defaults.contains("nginx_scanner_rate_limit_status: 429"));
+
+		assertTrue(tasks.contains("Validate nginx scanner block settings"));
+		assertTrue(tasks.contains("nginx_scanner_block_status | int in [404, 444]"));
+		assertTrue(tasks.contains("nginx_scanner_exact_paths is sequence"));
+		assertTrue(tasks.contains("nginx_scanner_exact_paths is not string"));
+		assertTrue(tasks.contains("nginx_scanner_prefix_paths is sequence"));
+		assertTrue(tasks.contains("nginx_scanner_prefix_paths is not string"));
+
+		assertTrue(infraReadme.contains("Scanner/bot nginx 차단 정책"));
+		assertTrue(infraReadme.contains("기본 응답은 `404`"));
+		assertTrue(infraReadme.contains("`444`는 운영 access log와 smoke 검증 후에만 선택"));
+		assertTrue(infraReadme.contains("rate limit은 1차 rollout에서 강제 적용하지 않는다"));
+		assertTrue(infraReadme.contains("app request completion log를 추가하지 않는다"));
+	}
+
+	@Test
 	void batchRemainsTheSchedulerOwnerLaneAfterRootRetirement() throws Exception {
 		Path schedulerService = Path.of(
 			"batch/src/main/java/com/beat/batch/scheduler/application/JobSchedulerService.java");
@@ -976,6 +1029,14 @@ class RootRetirementContractTest {
 			return content.substring(start);
 		}
 		return content.substring(start, nextDocument);
+	}
+
+	private static String sectionBetween(String content, String startMarker, String endMarker) {
+		int start = content.indexOf(startMarker);
+		assertTrue(start >= 0, startMarker);
+		int end = content.indexOf(endMarker, start + startMarker.length());
+		assertTrue(end >= 0, endMarker);
+		return content.substring(start, end);
 	}
 
 	private static int countOccurrences(String content, String needle) {

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -145,8 +145,8 @@ class RootRetirementContractTest {
 		assertFalse(defaultConfTemplate.contains("limit_req "));
 		assertFalse(defaultConfTemplate.contains("limit_req_zone"));
 
-		assertTrue(defaults.contains("nginx_scanner_block_enabled: true"));
-		assertTrue(defaults.contains("nginx_scanner_block_status: 404"));
+		assertTrue(defaults.contains("nginx_base_config_scanner_block_enabled: true"));
+		assertTrue(defaults.contains("nginx_base_config_scanner_block_status: 404"));
 		assertTrue(defaults.contains("- /.env"));
 		assertTrue(defaults.contains("- /.git/config"));
 		assertTrue(defaults.contains("- /wp-login.php"));
@@ -159,16 +159,16 @@ class RootRetirementContractTest {
 		assertTrue(defaults.contains("- /wp-content/"));
 		assertTrue(defaults.contains("- /wp-includes/"));
 		assertTrue(defaults.contains("- /laravel/"));
-		assertTrue(defaults.contains("nginx_scanner_rate_limit_enabled: false"));
-		assertTrue(defaults.contains("nginx_scanner_rate_limit_dry_run: true"));
-		assertTrue(defaults.contains("nginx_scanner_rate_limit_status: 429"));
+		assertTrue(defaults.contains("nginx_base_config_scanner_rate_limit_enabled: false"));
+		assertTrue(defaults.contains("nginx_base_config_scanner_rate_limit_dry_run: true"));
+		assertTrue(defaults.contains("nginx_base_config_scanner_rate_limit_status: 429"));
 
 		assertTrue(tasks.contains("Validate nginx scanner block settings"));
-		assertTrue(tasks.contains("nginx_scanner_block_status | int in [404, 444]"));
-		assertTrue(tasks.contains("nginx_scanner_exact_paths is sequence"));
-		assertTrue(tasks.contains("nginx_scanner_exact_paths is not string"));
-		assertTrue(tasks.contains("nginx_scanner_prefix_paths is sequence"));
-		assertTrue(tasks.contains("nginx_scanner_prefix_paths is not string"));
+		assertTrue(tasks.contains("nginx_base_config_scanner_block_status | int in [404, 444]"));
+		assertTrue(tasks.contains("nginx_base_config_scanner_exact_paths is sequence"));
+		assertTrue(tasks.contains("nginx_base_config_scanner_exact_paths is not string"));
+		assertTrue(tasks.contains("nginx_base_config_scanner_prefix_paths is sequence"));
+		assertTrue(tasks.contains("nginx_base_config_scanner_prefix_paths is not string"));
 
 		assertTrue(infraReadme.contains("Scanner/bot nginx 차단 정책"));
 		assertTrue(infraReadme.contains("기본 응답은 `404`"));

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -167,8 +167,12 @@ class RootRetirementContractTest {
 		assertTrue(tasks.contains("nginx_base_config_scanner_block_status | int in [404, 444]"));
 		assertTrue(tasks.contains("nginx_base_config_scanner_exact_paths is sequence"));
 		assertTrue(tasks.contains("nginx_base_config_scanner_exact_paths is not string"));
+		assertTrue(tasks.contains("nginx_base_config_scanner_exact_paths | select('string')"));
+		assertTrue(tasks.contains("reject('match', '^/[A-Za-z0-9._/-]+$')"));
 		assertTrue(tasks.contains("nginx_base_config_scanner_prefix_paths is sequence"));
 		assertTrue(tasks.contains("nginx_base_config_scanner_prefix_paths is not string"));
+		assertTrue(tasks.contains("nginx_base_config_scanner_prefix_paths | select('string')"));
+		assertTrue(tasks.contains("reject('match', '^/[A-Za-z0-9._/-]+/$')"));
 
 		assertTrue(infraReadme.contains("Scanner/bot nginx 차단 정책"));
 		assertTrue(infraReadme.contains("기본 응답은 `404`"));


### PR DESCRIPTION
## Summary

- nginx base config에 scanner/bot terminal policy macro를 추가해 명백한 probing path를 app 이전에 `404`로 종료합니다.
- HTTP는 ACME challenge → scanner block → HTTPS redirect 순서로, HTTPS는 scanner block → generated route include 순서로 고정합니다.
- `nginx_base_config_scanner_block_enabled`, `nginx_base_config_scanner_block_status`와 scanner path defaults를 role defaults로 분리하고, status는 `404`/`444`만 허용하도록 검증합니다.
- rate limit은 1차 rollout에서 강제 적용하지 않고 disabled/dry-run 계약 및 문서만 남깁니다.
- 운영 smoke/rollback 절차와 contract test를 추가했습니다.

## Decisions

- 기본 응답은 `404`입니다. `444`는 access log와 smoke 검증 후 별도 선택합니다.
- broad `*.php` / `.*\.php` 차단은 넣지 않습니다.
- `/index.php`, `/phpinfo.php`, `/info.php`는 exact match로만 차단합니다.
- scanner 결과 분석은 nginx `access.log`에서 수행하고 app completion log는 추가하지 않습니다.
- #462 observability/MDC 변경 범위는 건드리지 않습니다.

## Validation

- `GRADLE_USER_HOME=$PWD/.gradle-local ./gradlew :test --tests com.beat.RootRetirementContractTest --no-daemon --no-parallel`
- `ANSIBLE_ROLES_PATH=$PWD/infra/ansible/roles ansible-playbook infra/ansible/playbooks/foundation.yml -i infra/ansible/inventories/dev/hosts.yml --syntax-check`
- rendered nginx scanner contract sanity check
- `git diff --check`

## Not tested

- live production `nginx -t` / curl smoke checks; server access is outside this local repo session.

## Related

- Parent: #462
- Closes #463

