### PR TITLE
feat: Grafana Cloud + Alloy edge observability 파이프라인 도입

### DIFF
--- a/.github/workflows/deploy-observability-dev.yml
+++ b/.github/workflows/deploy-observability-dev.yml
@@ -1,0 +1,107 @@
+name: deploy-observability-dev
+
+# Alloy edge agent + Grafana Cloud observability stack 배포 (dev)
+# Trigger:
+#   - push to develop with paths match (alloy role/playbook/inventory observability vars 변경 시)
+#   - workflow_dispatch (수동)
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'infra/ansible/roles/observability_alloy/**'
+      - 'infra/ansible/playbooks/observability.yml'
+      - 'infra/ansible/inventories/dev/group_vars/all/main.yml'
+      - 'infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml'
+      - '.github/workflows/deploy-observability-dev.yml'
+      - '.github/workflows/_ansible-exec.yml'
+  workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: "Optional branch, tag, or SHA to deploy (defaults to the triggering commit)"
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  resolve-ref:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve deploy ref
+        id: resolve
+        env:
+          DEPLOY_REF: ${{ github.event.inputs.deploy_ref }}
+          DEFAULT_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          requested="${DEPLOY_REF:-}"
+          if [[ -z "$requested" ]]; then
+            requested="$DEFAULT_SHA"
+          fi
+
+          git fetch --force --prune origin \
+            '+refs/heads/*:refs/remotes/origin/*' \
+            '+refs/tags/*:refs/tags/*'
+
+          candidates=("$requested")
+          if [[ "$requested" == refs/heads/* ]]; then
+            candidates+=("refs/remotes/origin/${requested#refs/heads/}")
+          elif [[ "$requested" != refs/* ]]; then
+            candidates+=("refs/remotes/origin/$requested" "refs/tags/$requested")
+          fi
+
+          commit_sha=""
+          for candidate in "${candidates[@]}"; do
+            if resolved="$(git rev-parse --verify --quiet "${candidate}^{commit}")"; then
+              commit_sha="$resolved"
+              break
+            fi
+          done
+
+          if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid deploy_ref: $requested (expected a branch, tag, or commit SHA in this repository)" >&2
+            exit 1
+          fi
+
+          echo "Resolved deploy ref '$requested' to $commit_sha"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs:
+      - resolve-ref
+    # alloy 재시작은 app deploy/foundation과 같은 dev runtime concurrency group으로 묶어 직렬화
+    concurrency:
+      group: dev-runtime
+      queue: max
+      cancel-in-progress: false
+    uses: ./.github/workflows/_ansible-exec.yml
+    with:
+      environment_name: dev
+      # observability.yml은 hosts:all이라 module 변수 안 쓰지만 _ansible-exec.yml 계약상 필수
+      module: observability
+      connection_module: ${{ vars.DEV_FOUNDATION_CONNECTION_MODULE || 'apis' }}
+      playbook: playbooks/observability.yml
+      inventory_path: inventories/dev/hosts.yml
+      success_title: Observability Dev Succeeded
+      failure_title: Observability Dev Failed
+      notify_description: |
+        Alloy edge agent deploy
+        Actor: ${{ github.actor }}
+        Commit: ${{ needs.resolve-ref.outputs.commit_sha }}
+      commit_sha: ${{ needs.resolve-ref.outputs.commit_sha }}
+      checkout_ref: ${{ needs.resolve-ref.outputs.commit_sha }}
+    secrets:
+      ssh_private_key: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
+      sops_age_key: ${{ secrets.AGE_SECRET_KEY }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-observability-prod.yml
+++ b/.github/workflows/deploy-observability-prod.yml
@@ -1,0 +1,100 @@
+name: deploy-observability-prod
+
+# Alloy edge agent + Grafana Cloud observability stack 배포 (prod)
+# Trigger: workflow_dispatch only (prod 변경은 운영자 수동 통제)
+# 자동 트리거 안 두는 이유:
+#   - alloy 재시작은 prod 메트릭/로그/트레이스 스트림에 잠시 영향
+#   - 변경 빈도 매우 낮음 (월 1회 미만 예상)
+#   - release tag 배포와 별개 cadence
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: "Branch, tag, or SHA to deploy (required for prod)"
+        type: string
+        required: true
+
+jobs:
+  resolve-ref:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve deploy ref
+        id: resolve
+        env:
+          DEPLOY_REF: ${{ github.event.inputs.deploy_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          requested="$DEPLOY_REF"
+
+          git fetch --force --prune origin \
+            '+refs/heads/*:refs/remotes/origin/*' \
+            '+refs/tags/*:refs/tags/*'
+
+          candidates=("$requested")
+          if [[ "$requested" == refs/heads/* ]]; then
+            candidates+=("refs/remotes/origin/${requested#refs/heads/}")
+          elif [[ "$requested" != refs/* ]]; then
+            candidates+=("refs/remotes/origin/$requested" "refs/tags/$requested")
+          fi
+
+          commit_sha=""
+          for candidate in "${candidates[@]}"; do
+            if resolved="$(git rev-parse --verify --quiet "${candidate}^{commit}")"; then
+              commit_sha="$resolved"
+              break
+            fi
+          done
+
+          if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid deploy_ref: $requested (expected a branch, tag, or commit SHA in this repository)" >&2
+            exit 1
+          fi
+
+          # prod 배포 대상 commit은 origin/main 계열에 포함되어야 함 (deploy-prod.yml과 동일 가드)
+          if ! git merge-base --is-ancestor "$commit_sha" origin/main; then
+            origin_main="$(git rev-parse --verify origin/main)"
+            echo "Refusing prod observability deploy: commit $commit_sha is not an ancestor of origin/main ($origin_main)" >&2
+            exit 1
+          fi
+
+          echo "Resolved deploy ref '$requested' to $commit_sha"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs:
+      - resolve-ref
+    # alloy 재시작은 prod runtime concurrency group으로 묶어 deploy/rollback과 직렬화
+    concurrency:
+      group: prod-runtime
+      queue: max
+      cancel-in-progress: false
+    uses: ./.github/workflows/_ansible-exec.yml
+    with:
+      environment_name: prod
+      module: observability
+      connection_module: ${{ vars.PROD_FOUNDATION_CONNECTION_MODULE || 'apis' }}
+      playbook: playbooks/observability.yml
+      inventory_path: inventories/prod/hosts.yml
+      success_title: Observability Prod Succeeded
+      failure_title: Observability Prod Failed
+      notify_description: |
+        Alloy edge agent deploy
+        Actor: ${{ github.actor }}
+        Commit: ${{ needs.resolve-ref.outputs.commit_sha }}
+      commit_sha: ${{ needs.resolve-ref.outputs.commit_sha }}
+      checkout_ref: ${{ needs.resolve-ref.outputs.commit_sha }}
+    secrets:
+      ssh_private_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+      sops_age_key: ${{ secrets.AGE_SECRET_KEY }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/admin/build.gradle.kts
+++ b/admin/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("beat.openapi")
     id("beat.feign-runtime")
     id("beat.sentry-source-context")
+    id("beat.prometheus-runtime")
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ testcontainers = "1.21.3"
 redis-testcontainers = "2.2.2"
 sentry = "8.41.0"
 sentry-gradle-plugin = "6.6.0"
+micrometer-tracing = "1.4.2"
+opentelemetry = "1.55.0"
 # JUnit Platform/Jupiter is the baseline for existing Java tests and Spring Boot starter-test.
 # Kotlin migration may add Kotest/MockK as an optional Kotlin test layer on top of this baseline,
 # not as a replacement for the shared JUnit Platform execution contract.
@@ -76,6 +78,8 @@ aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3" }
 nurigo-java-sdk = { module = "net.nurigo:javaSDK", version = "2.2" }
 
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
+micrometer-tracing-bridge-otel = { module = "io.micrometer:micrometer-tracing-bridge-otel", version.ref = "micrometer-tracing" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
 testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 testcontainers-redis = { module = "com.redis:testcontainers-redis", version.ref = "redis-testcontainers" }

--- a/infra/ansible/inventories/dev/group_vars/all/main.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/main.yml
@@ -78,3 +78,14 @@ modules:
     app_port: 4002
     container_name: batch
     scheduler_owner: true
+
+# observability_alloy — dev는 metrics-only (t3.micro 1GB 메모리 절약)
+observability_alloy_mem_limit: "128m"
+observability_alloy_cpus: "0.5"
+observability_alloy_scrape_interval: "60s"
+observability_alloy_wal_truncate: "1h"
+observability_alloy_enable_logs: false
+observability_alloy_enable_traces: false
+observability_alloy_enable_cadvisor: false
+observability_alloy_published_ports:
+  - "127.0.0.1:12345:12345"

--- a/infra/ansible/inventories/dev/group_vars/all/main.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/main.yml
@@ -89,3 +89,7 @@ observability_alloy_enable_traces: false
 observability_alloy_enable_cadvisor: false
 observability_alloy_published_ports:
   - "127.0.0.1:12345:12345"
+
+# Spring Boot OTel exporter endpoint (app 컨테이너에 환경변수로 주입)
+# dev는 tracing.enabled=false라 실제 송신 안 되지만, 일관성 위해 정의
+otel_otlp_tracing_endpoint: "http://alloy:4318/v1/traces"

--- a/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
@@ -1,46 +1,55 @@
 actuator_allow_cidrs:
-    - ENC[AES256_GCM,data:/XSiUk1mSc57KAILZ7d7XaA=,iv:MSRTBJP71aoUsdAuWI1vpyGoO5ji4icRZqCIMHV7kjE=,tag:LhZVYAM77GgFcbAFb2ox7g==,type:str]
-actuator_path: ENC[AES256_GCM,data:ttFyYFjaCq+dtNqumYj5vw643xiZRkUdB1mYycIJzjkdqNGvrQ==,iv:w4ozp1yQouqLUK09X/3a38+ICYYN8e/rSb/WKavEi50=,tag:p520VMIzeZTK8ENIwhEy8A==,type:str]
-actuator_port: ENC[AES256_GCM,data:99tPYA==,iv:wQakTebzo9IAll1cSXwpZ/kDRvI0IUeKNwz1ZqUjAfI=,tag:NFDmT653oduaeCjlYfxIFQ==,type:int]
-ansible_host: ENC[AES256_GCM,data:b/faCDAQ1bNZTNA=,iv:xXevdNKGH0jEJDIMdmf3gLSBYENa3VwAThmbdcv/5I4=,tag:R3K8sm4i7K5XjY+2d1o7Ug==,type:str]
-app_secret_content: ENC[AES256_GCM,data:jSGopmFCZtq4yqZB/DAQKXWau5lIQoeCUZbUOOmeviw411jSEz5q2etap+nSdG+heewlYA2Mj1BU4QYmw1IFL8ENIDtmtOTt09Tw7Waj9khZABe1UcJ1n90S8XNqEi1QM/xQg1aZemSYFmE5u/ynA7rcnABlSIfYXflhNTT7QnBH4cgtRD/a8TZguVhb5iP8dQorDsyLNF41vXcjUmlmFVWw67P6RymHeeK2IQBW4/7dJ3D1JgseYTBnoWqo2pTaEEnwwGM6I0jomLApyuFSWlD+ZFF5ge5Uiwh8qD8Ol1O3e18RVwzP16FbV7S24OpS3T9zI//9tVvRZ4vfp5wzuOaPt5tsuJHO1u8SvDM/U9BvysS/hKbbSelqzmlltsjzsOaFsxJZvsHNHRuZLKiqKi9tUGTYI49LbWaz7lgEsZVi0wtGZyQ2RRA2bSw/GV1dddOKfFMjxNKVgHoPpNuaZmcbZgTCo+rqatanddPKYTrj6ol9ToTkVercyzzQOTnXD0lpa/jTzoDVpJfD0NUHbFePeq8HKz1ZCmE3w/2fx863ZMvcS6bHccDya5yV6LlD5bmEZobU1ybKP5CigmGKsDn5U6BbmBsVdA5ZQt+p8s+xfU68898G9j8HA2MsSPq76hHtb8OIodoC7w4njCU/ilcGdO0SEFdxY1Z97Y2/c2QHnj6vlVTyxCME7Dq1otabbufowNRw+3OUu5ujrVhHERivRLlMllyR2IENRGBBZ8WqPCVveGMBhBPNaLv6lWCwiPgJ84D6ChPXErGdyjyWV7EsE+BceeFIS0Jj0qVcxQeLWntzzD6Nq6EYTa1k8B3zahALFiFVe3ltVFe3P8xaW6nrgpbBjS5Icb6kuW1TwrFr3LNoju8hYavN0OGMcYotFv7E+11v1D+4zUH+KAG6w6lQlN0YOj8sb7X+xLgKSfBCYcZBUXCaPHRLAszQSkWMrUetEYokKSp0POe/pBqwEY6jOuXv9DfHsL5Xq3frZmu1Thzkpr9/mPixOhqcX9Cb01m8SxaJ6LVJZ0rr6sVDM/ehTW6/EDtqE4yYxnatfygayEVaMw7faxQr5leT3n8YNphjuDoBYdcq7nbGmBPznVHlH1BVIbYUROIC2YKm82XILrviAuEwbX+YxdqBzLmtDgC4YtRVpp1tD+QBngZ791zLLjQ7jN6jCsprqWSEaATWRaoTlgbkdq3oaSYCRsh030mI+QxSSSShl84l4GOgwpjmnjsVnrwTmAlorkuKEFib1SqWy69uq5jwVDbxEIETQF5pNBLb6RbazL8iHyvghli7eerhFeey+KV2Mzq/Y2a6OI4fSj45UYG/QOr/nn9FAwlJYNJ+R6/opat275tC8km0XSnnOdMEmsgPzJ6mqg3YM1G6nEPAJWIhEP05qTFxX7nCkWgnoR+KpX1tu2HFWJ6TtXGU6IkeORMlPNefm/sp8PUTnz1ezEXVQQWqx6KHIiHMlmEJYltBmHUDL1jhuZwCeuMFdEUGdWmMJA9JJAr3l4c4cy1ekIu5+7P8WDvVwy1d0rdX92ZfNLp4poz/p1BZ0ynqsFfZPbQitMlTlmRGXp3oez3hr8nh63DHhgGJrmn9fGLppzU/7gqWHSeGShbgiRL6/Q3Rj61yMx6SMeM0Xv6OCxcjpqUoZUC0R7iHGE33IbNGPsnmXg+4TiPX5AJWkPAqnkCfd4U0Xwf+Cd6O9/HNbMswkfj+ST1WnODm3M/PJokqNvJ84VZaCzlcjMkR7KppExeWO/drzd2ScDcYEyPDwwNGq/p8SYRB6C/kycAK2eYA+F8Y7YTSa+nBTMgQUZ69/zb9dqQs6852m/FtdLE3xbgwYNLlj6dlrWXnZADDV+7K+vIuoxBFzgD5dCxrbXcq99hqIo0XIxoqdyC8o2jk9sQl/O2CA6Xq2T25hcbY5Q0FoB6Uc1biY1zHsoI1w2gGMQm50nXTuMyH0Or55YoYhi4+HUpEdU/rH4PiN7YmC1UCyFiRcqhED/eFg49ky/wmIQlKy2SVW3yFpGEWGaThfHozFXbGZiw9I+8qCOpX,iv:omhamWBvuNMgpofjcrM2wdFKvqWEjgRwoA/d5PODYAA=,tag:WheH3xrj1Kc7eYyke2q/1g==,type:str]
-letsencrypt_cert_name: ENC[AES256_GCM,data:wStAzwNeGmQurwsD29uXMBnS,iv:Ih8epiiTnhnNdwSDRl4mvZk0gAlfUSSo2+0Gy/rYPpw=,tag:jQHu5n9xk2cfOifxYoEmKg==,type:str]
-mysql_database: ENC[AES256_GCM,data:EuRqF5IT1w==,iv:/dyg/1/gnuZWgErAS/fvi9HH6k6Y58sUA1SwBUVra+A=,tag:Tl+4zlaFzWUtsO/pQMOlEQ==,type:str]
-mysql_password: ENC[AES256_GCM,data:oFsAShG1MHoTYFiT,iv:n8e+0+Qu9EkhjV/fDVopvhSZZzst+VU44PV1ildgIl4=,tag:g+IR3cEG6kU+6Qekc7Aw1w==,type:str]
-mysql_root_password: ENC[AES256_GCM,data:/Mlp6B5P7FcEEcA=,iv:2/9jgBdq7j8I0gJWtxavSxaIHcjcqJcv7M1A63t1gcE=,tag:1a5pVXnwsgs0g/N9Ncp//Q==,type:str]
-mysql_user: ENC[AES256_GCM,data:q6qxVUIWew==,iv:Wk+gH7JApk4Qwyd63NYQDSS6NsueqTF8Rt8Tz9clrjY=,tag:oBebEd1gl/NQBcdlNjjieQ==,type:str]
-nginx_server_name: ENC[AES256_GCM,data:oyIVkz1J2c8tUzpsUDA6X9FV,iv:DyPZUxN0LXRTWZJnQwInMyifigLuem98/GBqcFM0gbI=,tag:cBbspgB45oNY0RWVUs0zUQ==,type:str]
-ssh_host_fingerprint: ENC[AES256_GCM,data:ZNt1uYsgLPQ+mEa0NUuAjriV3IQmwL91GRy6GfxheQPYN4OUcchLW4qaOB+MJagWmgQ=,iv:OqQUWLvbgHuSNAXD80tV55x5Ocv1cxnd42YcJwopMKo=,tag:bkcmcdMtCPjzA2RjApkrqA==,type:str]
+    - ENC[AES256_GCM,data:OXxU8hVoHbAJNhuF47p4EOo=,iv:L/6auwU5LULkE5tqnoMfU3aaV8dVoKsdpuEeTP+RVi0=,tag:bxKWpKHuedm7POcj5PGEeg==,type:str]
+actuator_path: ENC[AES256_GCM,data:CSs68ZadVm5hlAQJ34Sp0kH4efwtJiRtWVFI0ndHh7WPk2bJVQ==,iv:sidNPT1pNCTFMaTk5ckraZ7fZP02x0FzeX0WWb1lcUQ=,tag:xltoglNCXmGTKJKlvBjlLQ==,type:str]
+actuator_port: ENC[AES256_GCM,data:LMKr9g==,iv:W4/YNX9pxOrDMaTKDvYecQcvpe4yQ/U33MjvHpatzCo=,tag:04YouiBxdU4mzapctUYmdw==,type:int]
+ansible_host: ENC[AES256_GCM,data:YTt4pYLSjBwUFQ0=,iv:Id89pdIkxlHUXco2IJGDtWmPreURJT3tIVaJqc/dCCc=,tag:kfrnY+qBVwqTajP5t4Vx3Q==,type:str]
+app_secret_content: ENC[AES256_GCM,data:tck34sFn1hMj9A/bcgOxPHc30tpq6yFVJZJHrfLZkPPh0WEASV9bKz2DF5tAaNSepglwEi7UeOOKzKhBv3tn3Q8vqlAuizns2vQnkBzNG8FcECKsxQ9ulimKUO8rfdeViOFlljveBOw3iufdSvyIezFgdi6TUSJ8zsaTTzZfgCFABheBUUnGc7QpimKt6XzKcUYD7FbGEYjoYTSDJF1vZK6GCGS++yiJV9HvVRwFS9EHH9R+wBJJ5Ycc4KR63gaS5vl6OWKcv5JeOBN8PdFLPFEZu+R0G2CJqlhTuB1ipXzUtl8JXZPKPCTVDlgc/sU2y7P2cFSL0w6Znh0iM38XjD3oKh7N7XjykBI5ErHN5vsYAOBGWZ2mVnRUM+GyYfs/j13rkx6P9t+IjQHoshpYJQKllX7cCfQbKKCs9F7r8uurls4Qm6/dECJJ/Ujke96JoI/ynzC9NDA7kCXMIaH35nbB6LflIzxjZ8vc5hYLvijuDHztL0I591qwgY/fatPJHg6vtf67NOGxa/owuTICopxRWOKYbiN7nUGDRB4v6AMfcZLKB7kpZRJeMup+XFR39Ap3HyYkYBEwwUWvCJFWzWCyvS+2mfLvGwuVJ6XIEo+tjMAHlxtM5fZw/5oJOjgQFem6JNxjK6yX/oe04OhTrdPJs8aadXIq8QHx+Fc443ahtF7nBOUoapJXgydfdXcVEL9g4S7MeTZUGS7Ithrohr4SlTGU8X5spkjDBeKZUD0u9V5G08HWULUzNGkPkjx5Lgw/xdUGE+gWAPZRWWzzOkviQWkijQ1jFN3QrjEnDM5PNyphsJSDxNmCY5JThWPGW7WB6TpeX+XVISV4LwlsP3xoZnrZg3t0os1BoeWAy0XTParxHjZq/7hTVcfo+/ldWTvvsRls3CDi4YjsoJOeME3ae5iQZyxUvmgXWADsGI6d8CgLOhwkjCjmRJ6M2qv4feC0WnonJ33evboD0ZXc73yCyBEMR5XBKvlMlCyzaMkj7LLJAwUByN/tfyUhDWZPTFkSW51pexM5pcMWXhhTtkwElvmLHDQb7sJ2nnESLgszA0ANODZLUyKwJkKKNmEmtDAfz5Ltf0a4TkDkdX3TUnLD2kmE1/5klcMel7tV8eFxrlYFBBQv7udyiiKx0tXUsWM3WF405ESwi3U+Vc6re5DEzCQ8s3wqnSpojQ5UYfKB6/oNdhvnxDft2y5rSmF+bQbJjE69egBvILaNPBC4FAfIUG00RB0GKdXGNmJBqfQTlXE6Ovy+o7IReVwT1ggBO6b/Hy3dUoT9YNieQKTKKAyiNZQGZwnF7ntTQzvCVwRiN02ge+880ICM6jGcHg4cAYhn0S4pNW85hiU3gsCorAnV82woAmmH59peB7jWCRBzOScRoenNdBVKfcooEaBqmVPPI4qxthk6nasvSXhxxKOBygq7p3MojFGGMR5+DeEMDA3k7WbX96WaXMsEllfgsB/5CWio+OupBUp45Z2vps7WjUiin8ulIEJ84dT+9yge6aMmlksZAq9cesHS+xHMw5sm8+99LSPx7Aiva6DnA+hUT4+qvHvVF55WRNFyqIXX+vqeSzCPYFGfEXZA6xNB63uMatdk4Qfc3MUhGnUcClU8tTvgGbWdkrJyJNmBhHM8dVohlBk1qbe9XSVhks4jHVcdOgIEiM4LWFbxSSG247wE+EhAZjlKmrUTNjnIEv9e8rgOu9LLFdNhRs1Blh7NRMfxmKu5tRsytNZZ9CKY1WEm4aR0UeDNVMqMDGYbLIQi5AlCvvccSO6ZHTD3OGL8MHyMVd79UGwbA32NfbqhtUAZebGXXmKXPtLthYe6zcz2JR4hfBS12uUS3Oo9Zxq4FPE/diCWr6qoUnReexUy7vycRoOuc2sQN1SWIEVEWc4p+sfdZB7RUB4r7lyYXXN0M0ouh9El4XbkNbjp7w7WC0VbSzlQ89QIW+Bl6dKQ/dpR6xk1GpxkuAEGuAA8IQf89PD5SyYHrkZJDJh3ZBGeTSdXur9uVAVdbiZEdg7QAe1Q9LGdgw0LLlctWvcbeWko00Q5,iv:C+kCXJNM3R/tpjurzTHdQVHGv4okzYalbW7Lyem+m0Y=,tag:ia0IuNkYGu9HI85suZ2Llg==,type:str]
+letsencrypt_cert_name: ENC[AES256_GCM,data:x7oUyiBwweSckgKQmfp2i4yr,iv:cIMdDVwwAi49DAz8/TZylTqNEPVs+GsKPWPR2WzFRIY=,tag:JXhF6e0tgYE3MkrglATWvg==,type:str]
+mysql_database: ENC[AES256_GCM,data:QFxaymM1UQ==,iv:nePO4aMkUU04GwU2AGZiR0KBAtInYqsMhjjni1JXUjc=,tag:gbSndXuT1nihJW1CAKWOfQ==,type:str]
+mysql_password: ENC[AES256_GCM,data:3b4ldQfp/5+8/PN9,iv:QaL0NzxnJjXWrXpaWEL86x2dquLeN5njx1azsmz8k58=,tag:nj+spqwMp575QkYxJ47Elg==,type:str]
+mysql_root_password: ENC[AES256_GCM,data:pl3Zq6kR4YayyHo=,iv:7ZDtSwVhVK7osLS+ucfj6aHGYYiJlsJt0+SKE0oqUMc=,tag:154tEq+g/CBKXq6iLZlGbQ==,type:str]
+mysql_user: ENC[AES256_GCM,data:CvSWHHM8VA==,iv:2md6RGBHwfbNHVL0SCGEc9xHXceizBFf3nUDm6y/dak=,tag:DlTeUHHrNeJcHIbFDQjkow==,type:str]
+nginx_server_name: ENC[AES256_GCM,data:rUZAO23Jh+9ZVKgmSjilLKB6,iv:To6MbsUtCZMtwafd6X2z8E0B074TBjzdjsS5QX79ahA=,tag:5GCH/pP4L7rSQe4glnuJHg==,type:str]
+ssh_host_fingerprint: ENC[AES256_GCM,data:hW/T8pHRBLpkZ7U3m5q4EJuP8OH3DDxj9I8GB5n7embt4QH2RiRDG3Fcgj31C6HizWo=,iv:GqY5M5tYszPvqTj2/AmD8ETfCldIO32aKgROP0Vh49E=,tag:HkTciz/L1tUsT2eII4cxwg==,type:str]
+#ENC[AES256_GCM,data:I/f2d9taZFKt5F5ucECJnAglxFm62k0zohLck+/pG1ANGAL1i3h3vvbX/Tr7pREQD2RV9SA0XFlcTJZVR1UbIysGZSeiQcpGzxahtzc3XPUWq47ADWnl0N3c7sQLcfsw,iv:enzT7KxNfE/d8HvmTkfs2strBEQ3oChpx39eO6wBLWU=,tag:P2XtM1qdFpOqiEUDSKTqYw==,type:comment]
+#ENC[AES256_GCM,data:QRbDK5dsMAcl6iZ09cc/m2C/G4cQ51T6AWdWES8oACLU4r3lZpyYzbuJgAxzq8Ej5UWzz+Fc5UpMduiw6scgxZ4WLRPFYvvVdsD6T4pj,iv:5erfmhYTiaX96X/E+hI3/b1giEASAv6y17dL4WRinlo=,tag:sZfiFP12CFCuQ5cu6SGT9A==,type:comment]
+gc_token: ENC[AES256_GCM,data:pKJ8CNJwdffc7J0izn4S3Z7DraVydgQUYitQzyFHYZGQiM/ebl3RNx8okGvlcmvXa6wVw6ZuQVGxUKZWYFztN6LjSmoh5rSXE4dUjQBS01AYFSM+tjg4+76rCmS1eLBcrP/QGSSZwU2zVcrppe6qjALaTyC0Zw0DN98a2YmCxH+WFroFsB1UC57H7Rb68CADIMRzgg==,iv:IetCguerTybbzZgpcvC7+aJZKK/fgjIsnl6W8++Grv0=,tag:WDwD4r0zbFebXPsqWavQEA==,type:str]
+gc_prom_url: ENC[AES256_GCM,data:bajl1Xr7HMP9jYFljZSVEReO/O8/yVPhhdeaRPrXslpVKetfZVq8rZhlEOY6cgPUXtUFemzKc9uCYsuMfLhKmmoVkyUmT7M2,iv:okimJLNa6wTNzwlJh8h+gZX8fikPws4fUjA1dhEaxNk=,tag:NFEyyxF2PsRf8PQa0+mfAw==,type:str]
+gc_prom_user: ENC[AES256_GCM,data:b/2rUKYHGA==,iv:alHEAQwQbap1LQY3Yldc89t3A208Dohv8frnTA/VK3A=,tag:J5GN857jHrjYUiJmYA8IRw==,type:str]
+gc_loki_url: ENC[AES256_GCM,data:tc/8rrtvz7hKk9MuaptsZLwUdDegRVYBan9VeNDKquRSlLxyHmrTYngQ0zM1XF7SpcI=,iv:ZJ2X3S/9NZpmuQPehFNjYhFP5t8LSsgo39xggfVhDuk=,tag:d2iERrvdkpl/t3CrKe/Rag==,type:str]
+gc_loki_user: ENC[AES256_GCM,data:1NDCEhr1yA==,iv:Aw4bgeJeDi5a3XJ8YOpMXHVGl0w41z4d1RoczyJfVgU=,tag:U7Yd6P/I0fO167Sz705Rqw==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:QdBYu1g+f1FjxustrhjSdwc+rQoIK4/5Oq63AHp/rZYPcPcxmAaSSJeRH8JfsVqJtg==,iv:51J5IJMtxTofK+05kHlBZww7FGxT5TfzbBudplzkTjQ=,tag:Skqirh2ldoeZtzceHjM96w==,type:str]
+gc_tempo_user: ENC[AES256_GCM,data:G9n219PIAQ==,iv:7ukcLgU9HJoVj//bU3OqFbQK5xVTPZbM7HcNsA8d7Vs=,tag:z8CfW4Tu9rXOCXNkQf0VHw==,type:str]
 sops:
     age:
         - recipient: age10ku4fy9jalda7pkqwmgnywjnmeqdknv0fkt5a7dgs5egk9xf7atsa6vnpa
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNRW9qWHVlNXowakdZZVhV
-            K0NCNzFrL0F1amNjejlMcjJBNWh1b1BSVHg0ClRFZEROcmljakZLSTcvNS84OWNL
-            bStBY3kxWTF5WStnMjc1bzlVUXIrRTgKLS0tIHlDMGh1MmtIam1wdHJEV2wrNnVq
-            V0xMREtadjNkbEdlcVRJS0lpZ2dBSFkK5713AiAtOl9wtorIDvRvQHZP6hhEHgrY
-            psbd3VposssiJgDAJzHHQT3oYZc+BlBvLmrxv3H696z3bEHGPILE6g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0QVFsblFWbGpXRXIxNVBi
+            VytMVlQ3VE1zcnRUTWxreUtHQSt0MlhtTGtzCithc1FIMytKUHprbzdENTUvRlVG
+            RHhJM3ZBUWw1YUp3TnRKKzc0R3JoTm8KLS0tIFI1UmNkaHNVem9zV1BFVkFaSGNa
+            WmhlbzdkbFZ1YnFZNXZyNWlRNnREYjAKiW8P2WwbMZI06wj1FVP49JzFm6uu84rF
+            w5xarp67SfBi9oW5M7GNbVXnmiaxti00/APNLPewCCpv5rIljzDfgg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gagkvs6ur249muxexemtwumzqsvgpc74yxu7sfkhhsqyw7t8asesgsyyfn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLdWtZb0w1RzFhRU5lckt3
-            elROd3pHaVdyQzBZZWlGTEI5dG9pemhWMzJNCk5ZRk83TGVNbTRmczhlTlBWenVN
-            Z0pxdDBZcjVmaWFwS0xYUG5lQkhaL0UKLS0tIDU2U3JRakVEQjFpN1JsWlhTNksx
-            dVdFb2dvWFdOYjBOY0srWEd4bll0YjAKnJ8j8pYKDBXA1cpCsr/KyXtjyGzuc3Pw
-            X8K3p8Ov+VHSe1Jcz3OjJmRGEGFtuqpxwidjQjzqusffzeocLk0A8Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEUVZTNklTVytCOStIeWpF
+            ZENlckxpQ3hGUnZieGl1MlZnckljdEt3aG1vCnlTbjRYMUVlOXZPNTNRL20yZVVD
+            c2dyV2lxRlBrckhqTDd0bEM4VkFaNFkKLS0tIHdOelh2c0lGNE9qejlZdFhTdHpJ
+            bnpDNmxYTG9uNyt5REJJYisxV2dGQWcKDx8l9qxedYGstj0+a5H4OU5ecWfPsgvA
+            JKWw1EbfnELBcmL8vQvQKWj5O+BkS05amm+eT8r9gBhuAaMMk/EFmg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gsw3fsp4m6shzrv9cvztagavxevzz3pdm9xdl9fk3mturkfzhc2qf4z67e
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqelNyWjV2cURHZGpMWWNY
-            SDdTY0REZWM1b3ZNNkpDTlZUaEFxN25sT3pJCm5LWFJyV3locVlhSFk3ZkN4RkNO
-            Y2IvQmtnc2ppckowQnk2NnFvSHJHdW8KLS0tIE5HamFvV0hTZFVmUTg3ekJ5RWNW
-            TVAxekZ1VUFzdnMwNXE1MGxzcVVPNmsK9kH2xkd9g4KXWQgHBIrzVJXbnyVc+Nvk
-            nlZJPhJQIKHidOiB5dmNf7Ol2iJ72A3wBfRKLuOGlXrwDalQTCdfWA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoQTlreTM5SEtXTnBCOE95
+            UUpOTEp3T1EzaVkzWHIwKzFwTUN0S3FKS2pRClArbWlYdlJhSmJTUkdEdWNLNG1m
+            aFJ2NGs1KzE1bEI2bkdWYjVFTlR6ZmsKLS0tIGIwMFlZRWFqbDczbm5OdGpxejU4
+            V1U4MkQ3UnNLVklEZEFLb3QrYUhCbVkKr5/UWaFYkriglL0+Fk61dqjRVts83L4G
+            8LclQgG4A/5jSgCYxIsG0S8qPnsjcIRIH8Hr5SwqoZBIjD512pkhfA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T16:13:54Z"
-    mac: ENC[AES256_GCM,data:wOn72uTonRaoTE4NI7dmoe+KUjTHS6WKqZISuH/Gf7/hBZz2+I3T+vAgLDfQNDQgfdMJO+7nise5BCDxQsFQY3bH+9zjfrZon/EBsGX0uQdiCONS4KGYgJO7LVx2fmSDi1tF+FqsLXXNGeapt8rSNkrMFiobA6QIWgiIdR5hbFU=,iv:Dqt+BQnvqKjIAKb8WcMCtQe/019QdjOGF3EHDHnsSyw=,tag:xJHhWGBI4mo4LvtSNxBQeg==,type:str]
+    lastmodified: "2026-05-15T18:38:02Z"
+    mac: ENC[AES256_GCM,data:Vb38jXuHjQOOG4VUPa2bCuJ5aab8l0aqNwciC5nSDstpvxSpZAIKyYL8G6MhweQbRccSWK9ZkbWeb0AIGuQdKml6G50mcv5BmPWv0w3ShTQzURPWSqcFbP4kGYtzd+7AIsdMmSioTVP1OGzvQAS52TDU+bO6SXdVIUS6WhKEjDA=,iv:eqgctdFFGLcpYM2NAua4u/IS71rtlASrADkgiPZOHLA=,tag:UUBFphGW3hSIc2rWsQzq1A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
@@ -1,55 +1,55 @@
 actuator_allow_cidrs:
-    - ENC[AES256_GCM,data:OXxU8hVoHbAJNhuF47p4EOo=,iv:L/6auwU5LULkE5tqnoMfU3aaV8dVoKsdpuEeTP+RVi0=,tag:bxKWpKHuedm7POcj5PGEeg==,type:str]
-actuator_path: ENC[AES256_GCM,data:CSs68ZadVm5hlAQJ34Sp0kH4efwtJiRtWVFI0ndHh7WPk2bJVQ==,iv:sidNPT1pNCTFMaTk5ckraZ7fZP02x0FzeX0WWb1lcUQ=,tag:xltoglNCXmGTKJKlvBjlLQ==,type:str]
-actuator_port: ENC[AES256_GCM,data:LMKr9g==,iv:W4/YNX9pxOrDMaTKDvYecQcvpe4yQ/U33MjvHpatzCo=,tag:04YouiBxdU4mzapctUYmdw==,type:int]
-ansible_host: ENC[AES256_GCM,data:YTt4pYLSjBwUFQ0=,iv:Id89pdIkxlHUXco2IJGDtWmPreURJT3tIVaJqc/dCCc=,tag:kfrnY+qBVwqTajP5t4Vx3Q==,type:str]
-app_secret_content: ENC[AES256_GCM,data:tck34sFn1hMj9A/bcgOxPHc30tpq6yFVJZJHrfLZkPPh0WEASV9bKz2DF5tAaNSepglwEi7UeOOKzKhBv3tn3Q8vqlAuizns2vQnkBzNG8FcECKsxQ9ulimKUO8rfdeViOFlljveBOw3iufdSvyIezFgdi6TUSJ8zsaTTzZfgCFABheBUUnGc7QpimKt6XzKcUYD7FbGEYjoYTSDJF1vZK6GCGS++yiJV9HvVRwFS9EHH9R+wBJJ5Ycc4KR63gaS5vl6OWKcv5JeOBN8PdFLPFEZu+R0G2CJqlhTuB1ipXzUtl8JXZPKPCTVDlgc/sU2y7P2cFSL0w6Znh0iM38XjD3oKh7N7XjykBI5ErHN5vsYAOBGWZ2mVnRUM+GyYfs/j13rkx6P9t+IjQHoshpYJQKllX7cCfQbKKCs9F7r8uurls4Qm6/dECJJ/Ujke96JoI/ynzC9NDA7kCXMIaH35nbB6LflIzxjZ8vc5hYLvijuDHztL0I591qwgY/fatPJHg6vtf67NOGxa/owuTICopxRWOKYbiN7nUGDRB4v6AMfcZLKB7kpZRJeMup+XFR39Ap3HyYkYBEwwUWvCJFWzWCyvS+2mfLvGwuVJ6XIEo+tjMAHlxtM5fZw/5oJOjgQFem6JNxjK6yX/oe04OhTrdPJs8aadXIq8QHx+Fc443ahtF7nBOUoapJXgydfdXcVEL9g4S7MeTZUGS7Ithrohr4SlTGU8X5spkjDBeKZUD0u9V5G08HWULUzNGkPkjx5Lgw/xdUGE+gWAPZRWWzzOkviQWkijQ1jFN3QrjEnDM5PNyphsJSDxNmCY5JThWPGW7WB6TpeX+XVISV4LwlsP3xoZnrZg3t0os1BoeWAy0XTParxHjZq/7hTVcfo+/ldWTvvsRls3CDi4YjsoJOeME3ae5iQZyxUvmgXWADsGI6d8CgLOhwkjCjmRJ6M2qv4feC0WnonJ33evboD0ZXc73yCyBEMR5XBKvlMlCyzaMkj7LLJAwUByN/tfyUhDWZPTFkSW51pexM5pcMWXhhTtkwElvmLHDQb7sJ2nnESLgszA0ANODZLUyKwJkKKNmEmtDAfz5Ltf0a4TkDkdX3TUnLD2kmE1/5klcMel7tV8eFxrlYFBBQv7udyiiKx0tXUsWM3WF405ESwi3U+Vc6re5DEzCQ8s3wqnSpojQ5UYfKB6/oNdhvnxDft2y5rSmF+bQbJjE69egBvILaNPBC4FAfIUG00RB0GKdXGNmJBqfQTlXE6Ovy+o7IReVwT1ggBO6b/Hy3dUoT9YNieQKTKKAyiNZQGZwnF7ntTQzvCVwRiN02ge+880ICM6jGcHg4cAYhn0S4pNW85hiU3gsCorAnV82woAmmH59peB7jWCRBzOScRoenNdBVKfcooEaBqmVPPI4qxthk6nasvSXhxxKOBygq7p3MojFGGMR5+DeEMDA3k7WbX96WaXMsEllfgsB/5CWio+OupBUp45Z2vps7WjUiin8ulIEJ84dT+9yge6aMmlksZAq9cesHS+xHMw5sm8+99LSPx7Aiva6DnA+hUT4+qvHvVF55WRNFyqIXX+vqeSzCPYFGfEXZA6xNB63uMatdk4Qfc3MUhGnUcClU8tTvgGbWdkrJyJNmBhHM8dVohlBk1qbe9XSVhks4jHVcdOgIEiM4LWFbxSSG247wE+EhAZjlKmrUTNjnIEv9e8rgOu9LLFdNhRs1Blh7NRMfxmKu5tRsytNZZ9CKY1WEm4aR0UeDNVMqMDGYbLIQi5AlCvvccSO6ZHTD3OGL8MHyMVd79UGwbA32NfbqhtUAZebGXXmKXPtLthYe6zcz2JR4hfBS12uUS3Oo9Zxq4FPE/diCWr6qoUnReexUy7vycRoOuc2sQN1SWIEVEWc4p+sfdZB7RUB4r7lyYXXN0M0ouh9El4XbkNbjp7w7WC0VbSzlQ89QIW+Bl6dKQ/dpR6xk1GpxkuAEGuAA8IQf89PD5SyYHrkZJDJh3ZBGeTSdXur9uVAVdbiZEdg7QAe1Q9LGdgw0LLlctWvcbeWko00Q5,iv:C+kCXJNM3R/tpjurzTHdQVHGv4okzYalbW7Lyem+m0Y=,tag:ia0IuNkYGu9HI85suZ2Llg==,type:str]
-letsencrypt_cert_name: ENC[AES256_GCM,data:x7oUyiBwweSckgKQmfp2i4yr,iv:cIMdDVwwAi49DAz8/TZylTqNEPVs+GsKPWPR2WzFRIY=,tag:JXhF6e0tgYE3MkrglATWvg==,type:str]
-mysql_database: ENC[AES256_GCM,data:QFxaymM1UQ==,iv:nePO4aMkUU04GwU2AGZiR0KBAtInYqsMhjjni1JXUjc=,tag:gbSndXuT1nihJW1CAKWOfQ==,type:str]
-mysql_password: ENC[AES256_GCM,data:3b4ldQfp/5+8/PN9,iv:QaL0NzxnJjXWrXpaWEL86x2dquLeN5njx1azsmz8k58=,tag:nj+spqwMp575QkYxJ47Elg==,type:str]
-mysql_root_password: ENC[AES256_GCM,data:pl3Zq6kR4YayyHo=,iv:7ZDtSwVhVK7osLS+ucfj6aHGYYiJlsJt0+SKE0oqUMc=,tag:154tEq+g/CBKXq6iLZlGbQ==,type:str]
-mysql_user: ENC[AES256_GCM,data:CvSWHHM8VA==,iv:2md6RGBHwfbNHVL0SCGEc9xHXceizBFf3nUDm6y/dak=,tag:DlTeUHHrNeJcHIbFDQjkow==,type:str]
-nginx_server_name: ENC[AES256_GCM,data:rUZAO23Jh+9ZVKgmSjilLKB6,iv:To6MbsUtCZMtwafd6X2z8E0B074TBjzdjsS5QX79ahA=,tag:5GCH/pP4L7rSQe4glnuJHg==,type:str]
-ssh_host_fingerprint: ENC[AES256_GCM,data:hW/T8pHRBLpkZ7U3m5q4EJuP8OH3DDxj9I8GB5n7embt4QH2RiRDG3Fcgj31C6HizWo=,iv:GqY5M5tYszPvqTj2/AmD8ETfCldIO32aKgROP0Vh49E=,tag:HkTciz/L1tUsT2eII4cxwg==,type:str]
-#ENC[AES256_GCM,data:I/f2d9taZFKt5F5ucECJnAglxFm62k0zohLck+/pG1ANGAL1i3h3vvbX/Tr7pREQD2RV9SA0XFlcTJZVR1UbIysGZSeiQcpGzxahtzc3XPUWq47ADWnl0N3c7sQLcfsw,iv:enzT7KxNfE/d8HvmTkfs2strBEQ3oChpx39eO6wBLWU=,tag:P2XtM1qdFpOqiEUDSKTqYw==,type:comment]
-#ENC[AES256_GCM,data:QRbDK5dsMAcl6iZ09cc/m2C/G4cQ51T6AWdWES8oACLU4r3lZpyYzbuJgAxzq8Ej5UWzz+Fc5UpMduiw6scgxZ4WLRPFYvvVdsD6T4pj,iv:5erfmhYTiaX96X/E+hI3/b1giEASAv6y17dL4WRinlo=,tag:sZfiFP12CFCuQ5cu6SGT9A==,type:comment]
-gc_token: ENC[AES256_GCM,data:pKJ8CNJwdffc7J0izn4S3Z7DraVydgQUYitQzyFHYZGQiM/ebl3RNx8okGvlcmvXa6wVw6ZuQVGxUKZWYFztN6LjSmoh5rSXE4dUjQBS01AYFSM+tjg4+76rCmS1eLBcrP/QGSSZwU2zVcrppe6qjALaTyC0Zw0DN98a2YmCxH+WFroFsB1UC57H7Rb68CADIMRzgg==,iv:IetCguerTybbzZgpcvC7+aJZKK/fgjIsnl6W8++Grv0=,tag:WDwD4r0zbFebXPsqWavQEA==,type:str]
-gc_prom_url: ENC[AES256_GCM,data:bajl1Xr7HMP9jYFljZSVEReO/O8/yVPhhdeaRPrXslpVKetfZVq8rZhlEOY6cgPUXtUFemzKc9uCYsuMfLhKmmoVkyUmT7M2,iv:okimJLNa6wTNzwlJh8h+gZX8fikPws4fUjA1dhEaxNk=,tag:NFEyyxF2PsRf8PQa0+mfAw==,type:str]
-gc_prom_user: ENC[AES256_GCM,data:b/2rUKYHGA==,iv:alHEAQwQbap1LQY3Yldc89t3A208Dohv8frnTA/VK3A=,tag:J5GN857jHrjYUiJmYA8IRw==,type:str]
-gc_loki_url: ENC[AES256_GCM,data:tc/8rrtvz7hKk9MuaptsZLwUdDegRVYBan9VeNDKquRSlLxyHmrTYngQ0zM1XF7SpcI=,iv:ZJ2X3S/9NZpmuQPehFNjYhFP5t8LSsgo39xggfVhDuk=,tag:d2iERrvdkpl/t3CrKe/Rag==,type:str]
-gc_loki_user: ENC[AES256_GCM,data:1NDCEhr1yA==,iv:Aw4bgeJeDi5a3XJ8YOpMXHVGl0w41z4d1RoczyJfVgU=,tag:U7Yd6P/I0fO167Sz705Rqw==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:QdBYu1g+f1FjxustrhjSdwc+rQoIK4/5Oq63AHp/rZYPcPcxmAaSSJeRH8JfsVqJtg==,iv:51J5IJMtxTofK+05kHlBZww7FGxT5TfzbBudplzkTjQ=,tag:Skqirh2ldoeZtzceHjM96w==,type:str]
-gc_tempo_user: ENC[AES256_GCM,data:G9n219PIAQ==,iv:7ukcLgU9HJoVj//bU3OqFbQK5xVTPZbM7HcNsA8d7Vs=,tag:z8CfW4Tu9rXOCXNkQf0VHw==,type:str]
+    - ENC[AES256_GCM,data:aYu6DHXGOCbASps1eyDFRqQ=,iv:hl3OpFZvx+9mpWqAUls23s5+u6c4RmBLSi/6/ITcm3c=,tag:kxQZ6peQ71Wo7CID9Dvjhw==,type:str]
+actuator_path: ENC[AES256_GCM,data:HZ4sXl2d32VnbidVAMRSamUnOxOZpnjlD9aNs1F+xXXHDhhU/g==,iv:rzp1s0GejA+Ho7WPBo14cdpLdZOwsnMuGyjo3Ml7BvY=,tag:SJWJT8JWSJppKRpXRVH+dQ==,type:str]
+actuator_port: ENC[AES256_GCM,data:63kF2A==,iv:Cf7WuO6RRcEtBBF17N6JCmD3Y/Wof/jiSJ0kfjGt3v8=,tag:X7GhIrdwypiNEY2ogSl/Kg==,type:int]
+ansible_host: ENC[AES256_GCM,data:Z9j2dK5tNCFKz9Q=,iv:j0J5A35fdPBR/JBqh1SqHuVBTnGwz3tswuFZ7rI7MdM=,tag:rf1HTlaqWRJOZSKX2x+dDw==,type:str]
+app_secret_content: ENC[AES256_GCM,data:3uZCC9qk27ryvkSe2JGvveqxIR+d/vgcYgCHMH1l7ICuASOYE6Ef3FuNNGwRFS67oReYJXdqCD78WD3LTIX72/n0NPPUDOH2eON/rx+c0/VaU+kcwKy4zCrMdMIsJIDM2OpmT6l8HPukteIsT3l3Ky4UuKWTkzfaI5N2231Iy/YwF2+c1beCURDY+YAD98BQ9jJt73T4F3zgF78Wr/iTLuxzeMKH5q8pzDLnijPG/lQfkKMKa7+xS68nWUCD1En52n81fpwCIWtJD9/Ht0YLn17ImWjxf5wWZ7Fcvh7YXe0oxWox6Zl8RR4JyLGV7sJhERRks5x6KsUobeq1SYnzxZkcyK2vfSbN/MaWYQBl+3WNzYNLlne8nIkY4p43qtJaHpVczJwQLSagJg8FCwQomqmXwJshn2x5/Xr1rcKWiUqwHBJZn9T2QbmmEYoqMdOnCCagxJXxj1wRX2oUCBBjBHPBYelQJizZTSbYe6zD+eUjaQe3D3657Pf779s4wrJC1OkHwCpS0lPxCViddIh6QxZd9pZ9LUy5KfmY2BJoCZbiYA0BkuiVIupaWQkEX8g+8CC3BWU6gs1ba0kY1G5/NKDOSDMhs3RR9yTnB0SC26Dku5ABSpFOwYzVMdPiRzJBHV0JGpK6nWgeeWXgbY5EuCa+S8gAq+qzZmfKFJKeewTLG7l5DdE1lrro+baqGDDVfPEGf8SJvAgbDOzCHWCoWscNTUbPmZKaZBnOJWhjjJPjm8tJWuOKtVAJeOumiqKzpdqCMpE5bjrymvlA1UNpB4ohIVRYUWYMdKBf4LGg0R/wW1sR3Ozrud+6oh433bNTdIbh+0e+gNI8Wt1QFWUfY879Jl6Ve1b/+Z6i4nkyG4gnGpOuMzEtgYNJm/ItJCr2B7EZTX4fedPftf+roJDww9oMqyAINktK+vwFZBw3WtKP56lD5i+VETDPH2bkpcfFIUkeKzM89FBDnQM3mShsF45OTkKMkeb86eTljk7OV5F2GcCb8XYTXRbwM7z6KfhAbrDCb0XETODlg800Q6AUV5vGNeoVfxYceIbBe5sW8UsHzSGlr1lJCua1ALD/hDshcxYf2AM/lqefVZZ7derENEhX3avZRfe7p9QWSS9WSkcbP4IzbXjn2vG0NMN7liByPPH77iuSGyuu8JsDNqdR5bSfQMFGNZWXZIE6IKam55HRktJaW0UvMvUUnyFVhWTksGPMhjrmz1B2/u11xemz6nngfcuPby5OfQaUFmbbu/tZojxWZ8bCb8s3l3vvCFQ16QPUW7lip0Pfs9Gzgrsl1wJRMXClLlA6BO/t+wBlnSvdICM8Voh1bQNWvP+EQaxrPmSG0D2mRVocV81hwtAnaQwCSno3JcdI6spvniWGGD/LKvNN6u0UZGDmBeRR5nLnWr9sdGqgUBn3pOIL0jK6ymb6TYVUMixCH50R7WPzuqKZHAhpFxfEdiKO67PbOyG29ZHNi+Xsr7yJvqEORgZEZr8O978R9dw0OXLBvM0rz+PICTCxR+tYOzXNcsNS8Roji3IdXjn9yMBXWHW1BZfnTsQAFLepYwHiDrT5qoTuCpRm7XOTFU+GJSkRGJC6iw9DoydLvJAFi3HMHpmgdHPdveiY756JCO3L77ENmPjwjhveh+HF5iYns/acbDfPqfMk8bOtZPuSMkQpwy27cPm9VInC6OUobbS95TVYeLk8RFK2a7bJyyhfBsNqt5f0qx+9cYawg3ECtrADiZbY83x4HkfBI8szSzS+41lOyiCOiVHADBM0GbIKsMps2YC+7K/j9BHCI+E0EBT5Fc73ai24PC4K+hS7OpAD8PgbelYoH0g1zBcyU5edzjwzR4xAb1ZGopRBIBSZ23ZcNArYzBCFq15uGKuPNS0uqTI/k6RddUxF91LdVns=,iv:1EHB9lxgduuTjVLQMu31vEotGwSynAsoMIkp6GGGv2w=,tag:0cJeM+FqVbOLZOArC6RL4A==,type:str]
+letsencrypt_cert_name: ENC[AES256_GCM,data:teCcS52+fr/QOUIBuhwT+Rq1,iv:ks9ZRZ/nqtVyOwpp2dD0fnUYqN21+XLONpcNmlFKlwU=,tag:/mmvlJIb4yKxjCuQBdunzw==,type:str]
+mysql_database: ENC[AES256_GCM,data:VdQC3tUjVA==,iv:YESmBMWqTD4CXHFJQ81XA68hwsX43dt+TQntM0DW0F0=,tag:X8wKnjsd5MbdY1KzDffFFw==,type:str]
+mysql_password: ENC[AES256_GCM,data:F4eptD++3lobt7x2,iv:sl1BiDqzXgI+F8oQa7aYNbp6aejJHIwUYuLR8vLfKEM=,tag:ggorsxD0rOosLMQ7ZUwy2Q==,type:str]
+mysql_root_password: ENC[AES256_GCM,data:HRdngJKUeS954W4=,iv:J9V5YjkqKDuCK6jlk5YMoOcigWIRV5Vpcn5RI02yHkU=,tag:HLqH72SWBOpuWWvEYx8b+A==,type:str]
+mysql_user: ENC[AES256_GCM,data:JoeQxE0XGQ==,iv:7m+nnuExoDtcyi83chQ2LShWeUViPARSfGyqOKdoSIA=,tag:st86gcdNP07CKFsiYefCjg==,type:str]
+nginx_server_name: ENC[AES256_GCM,data:Y1ygLSHji0gdWkBlr55Vj284,iv:VCeDGxbA4/kk1gFaD/WD70RN+RXprHkIdDcLVhnbulo=,tag:nWOL2qSa/fGqloTEpwQgrg==,type:str]
+ssh_host_fingerprint: ENC[AES256_GCM,data:HWmf+ZEtbU+gD94ANxajjRxMFkUUVYfbivkYahtk39ZjH+XMjKZYR/IEpqp8CQ97h5k=,iv:Ox819xY4GZ8gTpcIWHAauH9MvQ1qdMsVft7dbeISwvg=,tag:eGnhBSRjQqKXX9aIE0up3g==,type:str]
+#ENC[AES256_GCM,data:sjTEe7ZFlrdcdLNLj2zl0LDjrODV71J6gQOvXVS5g2jLWJ2z0IYTlbGmzTU7+tRCeCNR1KnU6oAva88w+U0C7uEKxNkKIbrZqQzhk8Q+gox65lR0XnjO2chb4wR1LyUR,iv:2aQ4mTmyM7hWNk1vQuyyBHximCpxpW5HN2pmHBy0zfI=,tag:Khzp0VDNwDmTX06IrRxSLw==,type:comment]
+#ENC[AES256_GCM,data:sy7n7P5hcfVykMCEDXGF+cR/6e+2h+M3vo/VvMsC4Ezt1DkgKDaLFHH7KpWiH1yc+5kwZrsTLjpUlhu/mhMaNIBGjeapHaR7vlZI3jWu,iv:lBb5B4ZEb9bpjGsflTOTiRB15liFlJKVIJ+SfG9mBv4=,tag:uBk+DTBaTjWF+DcLWRP43A==,type:comment]
+gc_token: ENC[AES256_GCM,data:uTNT4MWeZP6tQuUyJnnm1Xm6UtqaB0tEYtF8VkSUTx7yBEsUWlhexaLzvrCtGMVAL5XKhb1JVPRSDBdYPRWd9LqB8AVg8lcdVKK52eBV3DGQPltIdJbzz9c+UiuutFRmJoyPtbXOouQuvvYzE7xl0BR0kW5D0t08zRmUQigu4EOv33E34CJdJWgzUF8Cu2tmKyOzAg==,iv:hgzacIIgaaVRcrsqgroHB+YBv/2m1DHZjrqcvRA9vgM=,tag:Ez0zQE57HuXD/WTeJVsypg==,type:str]
+gc_prom_url: ENC[AES256_GCM,data:gK+hbMcfcIaOnPl8l+zABJzEfTe8oC7HQiL+368fC/D/MKGTuWZmWWLGhJD2eCSYSGaaIg1redxgX0mV+SkIN+Ji2TDdW/oV,iv:pMCcTgocgjPWf1CVhphJPmzOJL39JY1Xa593KF0wmfo=,tag:IAKZrTSiM5032vAFxEoZxQ==,type:str]
+gc_prom_user: ENC[AES256_GCM,data:3muQp50jWg==,iv:lH8d++JukUYzWrX895t/kYue/TKyfFcgTxunBLhs3LQ=,tag:nkPDSL5NfkaGgMRew+7tbw==,type:str]
+gc_loki_url: ENC[AES256_GCM,data://Hnf53RscDb/X4Vm7cqQERgVT++BZ39eflLoZmVqj1gUK2Z9iIL11ouCxkeyyo5Jxs=,iv:h4WiP1yw0JlHLamB0w7cl7Z7VgkFMiKlWCSIqND+ZMs=,tag:q6kDIKDwa3OJcu/Rp7WDYw==,type:str]
+gc_loki_user: ENC[AES256_GCM,data:h7Kl7Azk8Q==,iv:3jPAzUtzBZLjWOo1sh8LAlpdrZ7Cucnx4eCc5s3zEfg=,tag:KJI7P8BkGLnytDaAbW/jSw==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:ZqBDCX17PE7eG74xCn0CuhIAEmGEqpLuCbfNp42RSWzET1bMtvWVA60jR5ZDednugQ==,iv:WU2imMJYD/hE2Su2F2rinfWzx3z8z5vYkn27/ch5L84=,tag:n85LGXawR2tYTArmLpyZoQ==,type:str]
+gc_tempo_user: ENC[AES256_GCM,data:AEbok3tftA==,iv:2Kd0+FZ5ihh4Qs1/FwhH9W0m0apgItdoCgPbVkAakwc=,tag:X1fY1bFdk5UaQpkWWo0Sag==,type:str]
 sops:
     age:
         - recipient: age10ku4fy9jalda7pkqwmgnywjnmeqdknv0fkt5a7dgs5egk9xf7atsa6vnpa
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0QVFsblFWbGpXRXIxNVBi
-            VytMVlQ3VE1zcnRUTWxreUtHQSt0MlhtTGtzCithc1FIMytKUHprbzdENTUvRlVG
-            RHhJM3ZBUWw1YUp3TnRKKzc0R3JoTm8KLS0tIFI1UmNkaHNVem9zV1BFVkFaSGNa
-            WmhlbzdkbFZ1YnFZNXZyNWlRNnREYjAKiW8P2WwbMZI06wj1FVP49JzFm6uu84rF
-            w5xarp67SfBi9oW5M7GNbVXnmiaxti00/APNLPewCCpv5rIljzDfgg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1NlFEakx4ZE44U2FqTUF4
+            UXVZd0I2NmZYNXh2RlpGaWhPclYzSjh4ZkdJClpuOTVSMndHUlhBaTdxQy9FaVFD
+            dSt6aUxTV0M4YWs5YXYwYlpzOW1mUTQKLS0tIDJ2anI0cDhSRndMbHlHTFpIT1d6
+            T0labXVZUm0vV3dqRDZnRTd1VkpqZWsK6J9NDGWtamLW8YmjS7oP5YJTv8ZiAh4S
+            LtWHx4kE+LJHovgAay7zahm3AiLqlxeMNX/pHoreHFHodGlyuC4DSA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gagkvs6ur249muxexemtwumzqsvgpc74yxu7sfkhhsqyw7t8asesgsyyfn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEUVZTNklTVytCOStIeWpF
-            ZENlckxpQ3hGUnZieGl1MlZnckljdEt3aG1vCnlTbjRYMUVlOXZPNTNRL20yZVVD
-            c2dyV2lxRlBrckhqTDd0bEM4VkFaNFkKLS0tIHdOelh2c0lGNE9qejlZdFhTdHpJ
-            bnpDNmxYTG9uNyt5REJJYisxV2dGQWcKDx8l9qxedYGstj0+a5H4OU5ecWfPsgvA
-            JKWw1EbfnELBcmL8vQvQKWj5O+BkS05amm+eT8r9gBhuAaMMk/EFmg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6cFBsMW5jQ3hQRzczWnBM
+            NlltLzNEd1U4SVdLbzVwcVNSczZDN1ZDRlhVCjBFakZMd294WGtNbThnaHpZUitx
+            bkw2K1Z0anBhQzhCOG9CeEY3OVBXM0UKLS0tIHBESkExbGVSNjRqaXJCZG1jMHpw
+            VTVzckRLdDUrOURnazBMdEFNTTIzVlkKwI1Qsmoa87hmMsK2li3xQ2YvqsEqGjgR
+            PTaXCpgZE9i3A3UGLt50itzEdfiFjj+KiwEFjDc12hf1hoVBc3LAmw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gsw3fsp4m6shzrv9cvztagavxevzz3pdm9xdl9fk3mturkfzhc2qf4z67e
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoQTlreTM5SEtXTnBCOE95
-            UUpOTEp3T1EzaVkzWHIwKzFwTUN0S3FKS2pRClArbWlYdlJhSmJTUkdEdWNLNG1m
-            aFJ2NGs1KzE1bEI2bkdWYjVFTlR6ZmsKLS0tIGIwMFlZRWFqbDczbm5OdGpxejU4
-            V1U4MkQ3UnNLVklEZEFLb3QrYUhCbVkKr5/UWaFYkriglL0+Fk61dqjRVts83L4G
-            8LclQgG4A/5jSgCYxIsG0S8qPnsjcIRIH8Hr5SwqoZBIjD512pkhfA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDRENCMVdNVWJKbldwMGFW
+            UkpiRGZ3clZCcmlXdml6N3dFckVJVWNNZkFVCmhyN2JyME96Q21zd1hHb2lRZGZr
+            VHNYRHRIaWx2dGp1ZTBlTitWUGFpR2sKLS0tIGRGUk10Um9hUVVKZTFSSEp0VHdD
+            aThPTEVkZ3k1TFZhWFdWaGF1Q3F0TU0K5bpZQewMIh8Fa/l2wMhMpeQpakm/OPZP
+            d9ev5czGQm28TquHDAQEPyFS1l3mUrEdA8rmw6Eui9BxfctrLfCe2w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T18:38:02Z"
-    mac: ENC[AES256_GCM,data:Vb38jXuHjQOOG4VUPa2bCuJ5aab8l0aqNwciC5nSDstpvxSpZAIKyYL8G6MhweQbRccSWK9ZkbWeb0AIGuQdKml6G50mcv5BmPWv0w3ShTQzURPWSqcFbP4kGYtzd+7AIsdMmSioTVP1OGzvQAS52TDU+bO6SXdVIUS6WhKEjDA=,iv:eqgctdFFGLcpYM2NAua4u/IS71rtlASrADkgiPZOHLA=,tag:UUBFphGW3hSIc2rWsQzq1A==,type:str]
+    lastmodified: "2026-05-15T18:58:29Z"
+    mac: ENC[AES256_GCM,data:77v+u0BlmZjnUwCwKc2d037Pb27XEIDu4pd5RSoEeNBu1zg4TIkjZj6S5z+UqshLMgOvKxzMsO70s9OQocZHCZgAhvht5d+YS/cjfV2onsr2Rhb4HEb+o79KAAcAPZkFK/Z0IJZf3W9Ili9BdoCaX6suos1OH9Sv0OdOXgU8d6g=,iv:0MH/mEBgCx4eBZzlJmHjLPeRD++H3Ust56uuiLtIl4I=,tag:fH87VAkO81Lkm2lGlIh6cA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/inventories/prod/group_vars/all/main.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/main.yml
@@ -78,3 +78,18 @@ modules:
     app_port: 4002
     container_name: batch
     scheduler_owner: true
+
+# observability_alloy — prod는 metrics+logs+traces 풀스택
+# t3a.small 2GB에 apis(BG)+admin+batch+redis+nginx+alloy 공존 — 보수적 256m로 시작
+# 1주차 운영 후 부족하면 inventory에서 384m로 증액
+observability_alloy_mem_limit: "256m"
+observability_alloy_cpus: "1.0"
+observability_alloy_scrape_interval: "30s"
+observability_alloy_wal_truncate: "12h"
+observability_alloy_enable_logs: true
+observability_alloy_enable_traces: true
+observability_alloy_enable_cadvisor: true
+observability_alloy_published_ports:
+  - "127.0.0.1:12345:12345"
+  - "127.0.0.1:4317:4317"
+  - "127.0.0.1:4318:4318"

--- a/infra/ansible/inventories/prod/group_vars/all/main.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/main.yml
@@ -93,3 +93,6 @@ observability_alloy_published_ports:
   - "127.0.0.1:12345:12345"
   - "127.0.0.1:4317:4317"
   - "127.0.0.1:4318:4318"
+
+# Spring Boot OTel exporter endpoint (app 컨테이너에 환경변수로 주입)
+otel_otlp_tracing_endpoint: "http://alloy:4318/v1/traces"

--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -1,46 +1,55 @@
 actuator_allow_cidrs:
-    - ENC[AES256_GCM,data:ROHmYHvlNplYZeNND0WoGFg=,iv:X4cK/BUg8gN2odQpwCeJkeaWu0Vhc4tEBu9BN6cdbU8=,tag:teohvEPyDumdqWNMUnJdOQ==,type:str]
-actuator_path: ENC[AES256_GCM,data:Bxc5ht4zcWf6raUH+cSclfE3gr0OLnJVaPisDRpi433p+3Ph3Q==,iv:v6JfZrI+CviDrDwwWWIDLOgnUOGImhY9XOUpEPxldlw=,tag:EpClU22YISubjA8Tn6RqDQ==,type:str]
-actuator_port: ENC[AES256_GCM,data:jMzR/A==,iv:KStceM58iSk0HrhFteqgeD1tXcy2hcWajbDhZCKZSwA=,tag:5HMCTCo2QAz4dA30hfUWcg==,type:int]
-ansible_host: ENC[AES256_GCM,data:TWFwgS8x23JnbR0=,iv:201TnC9NTzE+hdn3CoVdnLyGgEP1Ncrg75qM0XxOHdM=,tag:ZqbwfN8M9pIcTcjKOAaLzQ==,type:str]
-app_secret_content: ENC[AES256_GCM,data:3bNSIHi9dNaB9MnZ/OsIgtoCjwXN1FP9Vbc7m0QGPl57af2n3vE+71kRbutkHt1WS1nCUiGG4kONaHq5mKi0YJCzRTj/fjrgewWTY2PqWOyNCjXtp6XFJN8Zy+EDOUaG1V64NCFLDU/5kEvmRpJAEPmJ0UoUR97xGw0E2JbOiTTDdvX4qSjeLQJIp2qOv/ZqYhcYp1se9BnZul6c7KK0o0lBVQHmRZS6roHYYrlyZ7UapWegDR0ZKUnK4Q2hpsgpIg5wanKIAPuaAePx1+43Bcb4eLXq+W7O11PnXaidwiHcVQzBIsLoV84T9wQS6H6JIulGPmaSGPrUUnwHrSy2HCVBB6z4z55HSLKuwsX0ffy20pg9pvGhl0LZk6wFmKgRI1bylXnBFa4ahs7kZ+PmieSdG22M1JXy2Cyco3+SxRBbsU5g3G78gNb1hMSIvgrC49efbPPVXfgOn4S1fAoNUd3VkRligKz4hA6G34VLOIMu8mLuUNSM4vw0ZuKr/cf2rOyt9tGFDQ96DU1aItcOc71XZTN7ghWoG/mplLzZjlE5ZrgJr8me6ZWWN5gODjlyGZHICqkiU79XjWsf3pIG1e5svjEO/kYbKLM3kyFuTEGT78/9C202mfmwTAG35kgTKGKO/2NQuoXN6czy3CR+CsYYbnCqf3KqsGYe1Eir7iEASqXo1uTlhQEhCHBDzIgNjM9fj65qJHQtCaVtrVNP0U5BsNFlBvK5Z5UXfCqAxPt0UhnJI+jUUu1rqECvxWXB1kT0v6ZrspypnLQ/Vlht0ywuWydksTZjWa0OtJcGla/MZvtLITafnK+0q91BLNulAehXOx75Ij/8tjPHj0ILLRSQUbQflU3cEUqcxOxjVFm838tttdxAGAxG+ctDQwEfdVlxY+nRILlqgHVInFKHrnySBbkbyhMfJ31dDNZThmoDoiFuEpO6z6K2ZEJ7Ii99uOh7y0tcUjExTChv0bIPmc4d0pvKR2SfxW+RtAYHV3s/gf40y2UkuVSS4tG6wm50TP6Wiwu7E6LbK5AR8y9WeEQzd7MvBZVnDNTZ8m3MFF3CLijuso9x229rX5Q3NvhncJ9Mq3RBL7t5OPZZBxa53uMZHbG8VnUzfdWdZ8YAaFXTD7l3hf+Y+QCqU3Q8YlXhgrmaPeTWGspztDmzhBPqU5IUYLdgCuA9gNTjiNUEaeuz31uHNHyCsTIZJdvGHjLBOo0n4kaUUtbvE/A2qca0Wp045wFh0DXjhMn6aLCL8oIyarYfOBYhzUbwbRLk/t7uNC0+WD0fyZ7/Jc+40IfHUY5K5nIawrMwt8GtQ4C0cGFgLRFzRIyrGzM/UlxReYj2dLFzG186zpG8H+//MXk2bp8QODrIuclyZRk1uNGH2FgmLM8m+Ps3e9/Vc7tGosFLvVVDU/EEqRXYn0a81RbPSoqs4JFSvS0w7s8MM0lB/g+/ZyEtb5vellSAZ291MMPPD0BxIzOFQoqRfhPZ0FtZplWf9WS3snVI1LkbnOpBPixGj6fpN0MuhnB58tKYcAcpY5V82tjejRgNm83nUw9QGvMch3Y9To285tBw2ajTtZdsc8aNdBMGAomlsqWyOOyQEy8Gp662RHBC2bY0LYaJlEkrxof+ZKSkrAzLf9hNz+lrYdE3pTG/xFz6draL5O6XRbf9vndOIPvkIBcRdetCEPe0zO4xxzVJ4ZdD3wlTwmdPdofT7ufnTRKbO0cTapMPb3T9qNTePyAJxTK4iPACkwJ42ttsMVy0Fh9ikgNSu9y5A16LuOTZudka8I5dqp1t8Nn4d7hj3q0PbqBFwb2odeNXevDU78B2TXRejQLW/xQUbrevemJAvuTVYTALiJJoKaHLLNTkcNRciul4Ag0RvFcDKFL3h7KuppfFVK6I6KJNth2WN57ZrMPAGiG2fU5KjxIpT6w+LjP4pFClXPMA9HXUrf/2qNdXimNF2jkqcKy9XUWkzOPN4hNTIDRLGc10dIoZCN6xN2jKj8tgXTd7QCQo4bZRqvNoBkdC1wRhF1HLako3N5iyYRHjFe+L1HFoGKnl7HRLvdypEV8GUxs7DjKVcTERH47T2ti/Ns9zMXsEydXK4FIEy/WYolIIpEkKcc0BuHLQgaGuery0TGAzJeKIHPG4vFs0ia5F2RvhYLwWx7flT50l,iv:cPYEMXqGmXcV2OCDnwXqo0OoOZe2fB9GZeRgZeaYVOQ=,tag:/9FjC0HRzxlvspbs87w0Zg==,type:str]
-letsencrypt_cert_name: ENC[AES256_GCM,data:nf3B5PEFc6KYQLHI3Nwe,iv:kkOqFBoAkzZCHwu3l+C9M2TDK9COC8c+qOY1OSYRxDg=,tag:dtIvmw3VbBAoZ1NOW1fCzA==,type:str]
-mysql_database: ENC[AES256_GCM,data:P4zkrR9NP3Zks828XDcpJg==,iv:4gE8RswWr3ARHNXcofvoUS3gsMymjfpOCBGxIPJ4e2Q=,tag:kabTHlACUa+8NA8deFa6yA==,type:str]
-mysql_password: ENC[AES256_GCM,data:wyAmaQq1l6BMTJuVczha8A==,iv:Th3Q4+iXGxrOqBCReM/VECYAAWlb7QUz4NhgQQIgWa4=,tag:W8BSxbWBAZ7m7W4mZLAdng==,type:str]
-mysql_root_password: ENC[AES256_GCM,data:ZPGJvewGdIS8yvbj2i11DA==,iv:Wij4K9OAQPvaREYWzxrqEcB/yu32hG5rIoU1B5MRLyQ=,tag:i5aDZdUEA///klEDR9Tc3A==,type:str]
-mysql_user: ENC[AES256_GCM,data:0rSQzooYJ9v0fLnKaySvMg==,iv:+GTAjZve138X+1pC2HzhP9aFhJ0Wvb5CZ2Uo/AY46t0=,tag:cns6srYzD0kT3k3oVMJeYQ==,type:str]
-nginx_server_name: ENC[AES256_GCM,data:GieAAXg6O3w0mE9C/2/d,iv:cHBEaouZtTAS9FXguQ48tizwKWooNc9MWKURk8bMHuk=,tag:YpKi/fF3S8BDg1kL+4Okbg==,type:str]
-ssh_host_fingerprint: ENC[AES256_GCM,data:OP6JPkK37IVA/A+P61FTH9j6xGqpeZuhuPLXHQ9ayNwrDgRnlEtKlkZQHyOLVU15xqw=,iv:RsVb6ansUbDDTbItxWLSL4Vqv5CEsDGIHCSOjR1F49w=,tag:HbMlDSsM3FjtbJI0df+GwA==,type:str]
+    - ENC[AES256_GCM,data:NhN7b89wdAm56dwhLCcFE+Y=,iv:Jk/qEXUjCoh3BdDam5saJfzJAR9VMrMHConHwuFMvj0=,tag:UdG5QO3slzOIAjm6a1kmAw==,type:str]
+actuator_path: ENC[AES256_GCM,data:3XjfoQrnEbZKh9oIRFBElqi/RfCH4FMTDsJxXfvx4mTGvQuwMw==,iv:8vUwM3ZassPSIvK7Zr7+i+wwWMfjmmedZDmhA/CEhdM=,tag:GDDrH4MDH5ggTcQPtCQWuA==,type:str]
+actuator_port: ENC[AES256_GCM,data:iHlbtQ==,iv:B6dqOHuZkBPyV5M5ZZzdL5CXaHgKIM+RIS8akvAK8CI=,tag:ezVmRnCDqzpdjOF3UvvgtA==,type:int]
+ansible_host: ENC[AES256_GCM,data:R+ypHyHhoU7TEkw=,iv:9I2ME4WFoqgC6OLtsN/xXcjZSY1igq7ylzjY2IYEOcQ=,tag:ojcbxzvy3fRRkNqRu7p+rg==,type:str]
+app_secret_content: ENC[AES256_GCM,data:BkpeK3Hpi62tlILgz48W2eO4ROC1eeenm6lXcknBa6JHGYzt5QN/ije/1P+WDUgRASRAh82OQv+Zyk9MUCDs6tipRtxr3NQGwjy29X15kXZmSU67g02t+8N4EJkQrp6rFK8p7RmmlgjrUi0jM06WYywnY7QVkxeJUW6/VzR74Le8qu4ZE9o5MLfoEkoJvnaIjl22c/Ni4b1yPgq+BpavhKyt1uzOCqTAQonrMnGdkMjmgRJCpJ827TUHtpf9jcKT2AZTEQzC2Rk5O6jnYY0dKBMdhhCZyXFqkbVB9fco0movMFzpYDmdQrcqzy0kucL7hCPjmHD6AIPxn4Ed1V4uI1iHM126neOrBl1LdM02gghdooymCQVcFue2sBizEk6ypXf3qkdnn1k5qDJdgS9RO+sdx4y3QD8Xcd6AYSfgWgcpTc04BEihj/mtbKSZQg5DRelwPMq1wjE4fN3OXFjQk+4HMYyJxPT9bqCibOk93DT/cLU13GaxXgjJbHTuQOU2EBGINXkPxtByj9cmytm2PJq0PtS9PsbZv0CiGjksdl0a7EL7r4RCHI8Fy7Ajd8M4yUaE2azkVDdpf8U9i9pgSmR1bViBY2YS0tnxGnPAKiDCfp+3P0Ser8tnIKHIIgNNk1mdN2sRmJuvDMTYLtY0+cGZQQqMwoV1pAv1Nkh39oow4bWz+QOUcKTESJFGJipO6feVCC4d2fBDUVCG0JNfAb3BfR4xLg3iLilRmbnje6dqaAo2jCWg3spuGShd/D7rqgvDWBw1Q2JLjkexVM/nonbX9MNxg1lpZ3fejpIW6hkUvCFYo12u3172YoYlIqR72odU1Jfn3ii/kZZrXOPM4y4MXmkXKgcIWfSBeMiTs8Af+bvE9xmfd6+kYyNKLWiYy6wCdL2sqM3ypUJYav9Wvavcvu5eOeIOa9G1N39KtzAFNMSCGJzd/ze+kMgU7D8m23sl3nFAtUgwNiD2sYBCKd256IRYna8/dje/dJfBa1utw/7Rcblxn0SqZzz8XSVflmcZ6a3M2ZA/ZCVOYhzuawHRgxL/RG8r2cBUMQhi9ozmrY6lJ/JxiRuI5PsYMbZ43sN09H16LGZLXYHat2BeR0+9P8+Bu46G44aCOLbDW7/QefGX8Yup1q7v/oy62JmAJ36GY+8GNV+nziGFlCn/muwYPTw8nJAISWLiIzDXZH1uS4UNGcnJdXZuRWfm94e8+qFDm8gS7g8f+amraUjYudDpBRD2dVuI6l/BcD19erwvSSR6qiBUlX8zFbQ9FOO8xgy4DqnP9KWJpHRVTi6IqEEFTeY6noWk+zpJ0JAD2+Eokbqwgor0lnTUSz2aGM6cSCury8izvGxpbF9tJ8jLtGdQxW3xper/yveYABaXby5SBWAiiRZY1awEX3eQ/WIG91GAt3rmTGrfn4qP/WjHiitIHDnoq/J/tvziPVvkOYpWahk+6KN0cf8H+rQVJLCWztASXrTK0n7b29UCuT10RPNQycDZjmordf0X1RR/JD721Gvax6KBzZes6xmLN0/PQpMqMQ3oq2CQAy2Njg/9GpPGko0ADhgchIyG8JsJXUhjLKwSgqohCDZIliCIWR40T+cepRYR8TaS4xwBCgIrORuT6RnHPaSll02Zn7enUAQEDI+8NsG9EjY6L6HPaIi4+rhsJ62ZVGiroKYSnW1fRn3Q2+/2Y4qd3m2GBH6YIkDTiJ2BN65d+9KTZF3AqgVN2VJ85mWT2ydRfJ27HfDlFphIEFCB7rWwAsnt2mgJC5zwGO7LZdbmbvQo/fbyOrtM8VG0lk8ZSTARGO65oaiHVnH8LonKNlQEFhsosDR9qzLvYDD4NnuGGTAnzGyirFQBiZmYXMRRAl3TAhxD/2jekVsxraYBW65RrXYJsLMYDXewb7uGnrFpz+qvmqSJUQv5GDZrHoqLL7FXV/2pE3QRRv5IwV8CKzn2FJZuDNnUO7pJ2JvBjv2DpHj8LAnvkXghx1rNgi07MBnRHLOx0FvO3GKvuMVOBBtaRCqhDQXLyHR2pE1Z8jvtmqHYJIY/4K+EJ6joRhm8QLTPwWQNVMKHEu6N8vqGmotURWrSeJ3D1Qq2mmUwNUmiq1Sl+kjjGUu82Xx9sEMDW9EBXA5A3hCNKmjfXhcpcKzLPTalWjkg0w2JDc7zaxxD,iv:I77nYhOZwrf7Xe8SBBDs0jdvrxRv0YO8QEoo7NJQAas=,tag:iz1LWP+7dyyFxJhsAJN+vw==,type:str]
+letsencrypt_cert_name: ENC[AES256_GCM,data:Biv7I0fnc3XhkYJv/ZTi,iv:OBoNxr2ziW88DtQpIk63LRLGPLi0FkDoGdGIhoe1g8k=,tag:H9cYuP0T6n+DrR/CKs2t8A==,type:str]
+mysql_database: ENC[AES256_GCM,data:5zyet2y3IDTgqKU3tCAssw==,iv:DivpPLAFHBfQe997yne34fdGjnyHP9XpxxmHUZmNL5I=,tag:tR4rYANqu2UP/jgfO2JaYA==,type:str]
+mysql_password: ENC[AES256_GCM,data:kiO1TEwaSmuYJJPiXqxhIA==,iv:b8p5huYZTVsHqSpKhTDI59FVU+nCTVxgCTBRYBq8vCs=,tag:5UuLkhIrnvameJBkuB1VMg==,type:str]
+mysql_root_password: ENC[AES256_GCM,data:yFhtEUQkzybHjJZ/egAchw==,iv:TDFw/GGJyQ47d5rG9s1JGXmjKMyMwU5gDDjk7o1IdEA=,tag:ikpzb47wYB9e4POSA49lPw==,type:str]
+mysql_user: ENC[AES256_GCM,data:WbnOcaenA4HkOQdluhyF2w==,iv:tAJukjzA1vwxWEpggVL1lU8JVxqkqeNdDzIW2nUnp5w=,tag:nIj5xXm4voQ6QFLSiLv0GQ==,type:str]
+nginx_server_name: ENC[AES256_GCM,data:wiiYV0tx1eGMq5npBBQU,iv:51d9UwJapSMpapbBgQSz/j5skOBPsDeKxSVYUhhmg3k=,tag:ehitfkj2+BaAbMIfuNxkHA==,type:str]
+ssh_host_fingerprint: ENC[AES256_GCM,data:w4vgJwZUWNwMguUJkXzpt3Wcl5Re2x3tea/G5kKpc3rvRclkxYQF5IQTjyfbFIOU/7w=,iv:1jCVVPp7/7201T1tTUiuKZDgGwGvUp24+tXmeGf/Ipo=,tag:BjLUZAiAGmHSuMawalNjyg==,type:str]
+#ENC[AES256_GCM,data:U02Nz0AyUiMNfbev75d/m0x16F8rG8pyAwQkZYRYWQCmRISZvFa1/XPr9MF9PuUvqGMjjQ6E1Yy+xs3NJShkHqPWIpULLmsms8rrLymito68qYlVnBty6HJH4mqvpf8v,iv:WUuDylfyEhXdnwDYoH+FJ2oKc6xtGQwPANE6jKnpxlk=,tag:O5b9Vyuo3fPxW3ph4WupHQ==,type:comment]
+#ENC[AES256_GCM,data:HV5citfisjAQoeOgdz3bGTPiPkR2HH3FePxjHVi15wZ5ssN3QeYJB0ftCkMDVagC5kGFYDUeZDRswUyOocniynCB/5jM1tdEUbs5L5z0,iv:EKYhvD3nW/rJDx2vnSwAin/dQh8/GWgRR+cMSwErxXA=,tag:himAPDG8VdfGPnbXu1RIIQ==,type:comment]
+gc_token: ENC[AES256_GCM,data:IuJrWWUvzpodu756tHO+/dvBISLef5Uk+p6UMIBNCUZ/3s5D3uU4Gogr483MQqHe7qciAvGOt58KBxC5d5DtaSf+3RgqIYtfK+fXowbZmM5q2aEOcY5AFsFNUcwuRDp6OnWhB8t1GyxdyYHDSZYBbBNey33hyMVwZ435j6Z9CfCiH/kc5k1JXaR0XFDdT1sSUQ5RYw==,iv:BcwbG5pQUFRQd5HDB6r/hCWHGKTxTlmInLDRLBn3w20=,tag:bIB4LiOY/tISapvcsngdyA==,type:str]
+gc_prom_url: ENC[AES256_GCM,data:4GQ3tnHnNHqGnBhf4HOCuJkIxCio58XRixN+JGqJhl+2LOVww4MQawCX0QtohWgfipksvbLLWJki9XqQzDaG+qIG1tT5nzyN,iv:bLU0BtnM3pg9dQKtSydgp5xH4OJF85qmoS8CeBtMGno=,tag:T08My2loq0eVdBReN7xlrw==,type:str]
+gc_prom_user: ENC[AES256_GCM,data:7IYGmkakPg==,iv:CQZf7MU9DICooDgc8o+ZgSmECFUpxtTtpy2q9ZE93+Q=,tag:WyJ99iUwVnpGkpgnm+ElDw==,type:str]
+gc_loki_url: ENC[AES256_GCM,data:hkXroFcLqi5XChK+jfkOFufwjh4K5bc07UIBhfBIN6n5ZWm+Y3KfGlCL/GeKYK/FfvQ=,iv:TxAPIkYulvBprsSyxeXmo6FmzOeoXBAq6IVu5P99tSs=,tag:TFjiZvvLevNr5NegYubWdA==,type:str]
+gc_loki_user: ENC[AES256_GCM,data:CREEEAM51A==,iv:x34/cgdi9EbO/MmGPJvyH3MydUKCCODUf7fhpCwfyAQ=,tag:R/wmmbrmL1RNs1oZaj47jg==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:AT3ovkNcJCqKBL9+xe65k4Atz5hq5RUZgkNe6KUiPf+AKni8+zemutNQb5dOFvnkJg==,iv:mF7Op3M0RVyffxayQIK4COcLCg2aVft6qLLcHakqGd8=,tag:6KWRLbLGcVZ32dM4ILLnTA==,type:str]
+gc_tempo_user: ENC[AES256_GCM,data:H5r7OVRSyQ==,iv:llPWyYXFAKXEt17RUI6WeYtzUqFTwdc7DEP8UmY6n7I=,tag:rDVgqdeCvJf/mWSzh2FNNg==,type:str]
 sops:
     age:
         - recipient: age10ku4fy9jalda7pkqwmgnywjnmeqdknv0fkt5a7dgs5egk9xf7atsa6vnpa
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFd2pTekJ3Qys4SFJiZGsx
-            M2R5bUg5aWRVZ3FhL2JESURKR2tMSHA2TkNBCjVTdm5OSW9NaFNrMzJLbkhveita
-            eThBaFFnWU5kS0llS3FEbTJaeXMzZUkKLS0tIG92MzcxSzNUc3hTQ1VZVE14NEJG
-            UzY3R0IrVkhLOSt4eUlLMFNXRG9ja1UKVll6p/0Qxa8fyOx2RrKVO/Gfb3jorxFS
-            cS6v7kgh8yPupLLC6GdGQnX+l9ZdVgue4MBQnJRSJLmwQrxfSQwXvw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuVFYwNjh5bHhydHRsSWw3
+            cDJJSlZFdDZTSVlseEQ1RXVyZkFXT01hbVVVCmVjVy9yNE1QcXlreTV0UXZXOWZP
+            Q2NuR1BKZDdoc2swL245VEVPMDUvYXMKLS0tIGdic3lhRHEwSEFVZGY5ZlNhYSs1
+            NERqUVlmc3hqRWJ2aG4rMVdRNVRZWnMKukd4X+sZbhM1B2tlPZ4Z4sxKBkWtquf1
+            wMMj/CjhFF2mpYAgdl3b3ZY7AlvM6/RYnMaesMa+NzdKQVnaCpRSdg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gagkvs6ur249muxexemtwumzqsvgpc74yxu7sfkhhsqyw7t8asesgsyyfn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHNTRzR3FiUFRJaUI2d0lB
-            dWRIZUNYSjNsY1AwTG9PdFR6TXRNT3kzSXlBCmIyZHNKYm5xK0ZkWG5IdHdZOXNV
-            bG1qRXF0TE1YYTZsTXEyT2tlQkpoSzgKLS0tIHlmcnF5MkQ1MWdaVnBkcUE4blFo
-            M1BZcnNYa3NISE4zQnhnUWYwM1Zja00KqnVezPlaX9AmTaWzJZcQcb790eI6Hprg
-            ZJ7dqD/JZBSaOSL9pog+xcowM+jASH2mVOIpK8MHvRF7HiBTnzZpVQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrQVVhYTZwTzA2STF0b0NL
+            TWw3c2RVYUJsSmJMbE8zU3oyZzNxQlVxMWc4CjRhT3cvZTdzTDhhenFhZEIyei9M
+            aksvdXN1cDFkczRHSGFwWTl1VDhjUUkKLS0tIFU2dXQ3cC9PTzZabjFVUWxMYlVs
+            V01JclpSTytUVjl0MVYwZU1IUWhwa1kKuaTepaoIC+462MjBr38rHF4O6MCsPcjG
+            h4k0C/JhfKIMeOVDucsNb0S/nbGOD3SiCSiejMu4XVEFEX8cgkS1Ww==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gsw3fsp4m6shzrv9cvztagavxevzz3pdm9xdl9fk3mturkfzhc2qf4z67e
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMdTZVcThjVllUcXNKbWMy
-            WC9YOXovRE5qNjhvMXJGck1wS3BZVE5FK1d3Clc4VGEvbEUzeHZ4b2FTbDZEcEVa
-            YnVyNEczSVQxZ2xQem56QVFxd2pXeUkKLS0tIDVNVXJrekYxbTRYYjZvRmVqN1lE
-            UGFueDhSUDhoUGxCVUxRNlY1YXlLeEUKni8d9Ft1ZUjiSy4fjh41jttJcuqEtCX8
-            okjZnnPxaYCq550DB7x34llS41ORZLXkPmOnWkw4zjLqxqO7LP/CVg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNXFCWkg2MnZyeDdHU2RB
+            YzBEZ1B3TjNiVC9STTJSeVpobWpycVZyTkI4CmRVVDdYR1EvYlA2NzZIamFCZmY4
+            NUxHSnprUDNLZHZTcXJqZ21Rd3F5dlkKLS0tIFlsZTJxZUFESHlMUFJBZ05TQVV5
+            MkU3NHAwSFN4VkZrWnRzNHd0Z0dtSUkKvsG424D9L34OGPMjdnPEuRSmy2Nk8RL8
+            Pt5LnmLClswRsClapPDMyblwj6caIQGAhGsn70OLABtHAJv8+ADqvw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T16:14:04Z"
-    mac: ENC[AES256_GCM,data:QvV4bhTPQQduXhaBb6A6GveAZbrT8I/x5/U7FPS8tK4A0Qsya94ekxIC4UcdLmbX9DgnY22JW54POXaG/NwnjX9tpoRsVQtNua6Lwkd4CIMYNnEmCv50MqGMYxUsPCggv3ZMig/Gd4KnY2J7pMU4ufV1zeGj0U8UotY5x3LS3KA=,iv:4zQVB78PCD7sBPSAPkE7GQ7r/ld/TL0C0yFVtlcFCTY=,tag:x3n6xM6zrFnbhdL/NZyBuw==,type:str]
+    lastmodified: "2026-05-15T18:38:02Z"
+    mac: ENC[AES256_GCM,data:SVqa0WUAZjqJUE0U3HfyjRhnoU1HsZdvicttHcknAoXrdIeutM66F4rafO9lfJ9aaHyHxCeoplufc0gfzrTH0iUC/Lqwd7lndByTnOLXP6puqhGGrtF8/PcI5JMKlRCxT+vpwK9C5S3dPiq2I5mqoe17W8iAZfWx31GrRn+GNFI=,iv:3H93MsK2+nSrORGxwQVqbZjDAu+Dvk2aXgL31nxY5Ls=,tag:ZLcrE5xCKSe5ezH/CrUuMw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -1,55 +1,55 @@
 actuator_allow_cidrs:
-    - ENC[AES256_GCM,data:NhN7b89wdAm56dwhLCcFE+Y=,iv:Jk/qEXUjCoh3BdDam5saJfzJAR9VMrMHConHwuFMvj0=,tag:UdG5QO3slzOIAjm6a1kmAw==,type:str]
-actuator_path: ENC[AES256_GCM,data:3XjfoQrnEbZKh9oIRFBElqi/RfCH4FMTDsJxXfvx4mTGvQuwMw==,iv:8vUwM3ZassPSIvK7Zr7+i+wwWMfjmmedZDmhA/CEhdM=,tag:GDDrH4MDH5ggTcQPtCQWuA==,type:str]
-actuator_port: ENC[AES256_GCM,data:iHlbtQ==,iv:B6dqOHuZkBPyV5M5ZZzdL5CXaHgKIM+RIS8akvAK8CI=,tag:ezVmRnCDqzpdjOF3UvvgtA==,type:int]
-ansible_host: ENC[AES256_GCM,data:R+ypHyHhoU7TEkw=,iv:9I2ME4WFoqgC6OLtsN/xXcjZSY1igq7ylzjY2IYEOcQ=,tag:ojcbxzvy3fRRkNqRu7p+rg==,type:str]
-app_secret_content: ENC[AES256_GCM,data:BkpeK3Hpi62tlILgz48W2eO4ROC1eeenm6lXcknBa6JHGYzt5QN/ije/1P+WDUgRASRAh82OQv+Zyk9MUCDs6tipRtxr3NQGwjy29X15kXZmSU67g02t+8N4EJkQrp6rFK8p7RmmlgjrUi0jM06WYywnY7QVkxeJUW6/VzR74Le8qu4ZE9o5MLfoEkoJvnaIjl22c/Ni4b1yPgq+BpavhKyt1uzOCqTAQonrMnGdkMjmgRJCpJ827TUHtpf9jcKT2AZTEQzC2Rk5O6jnYY0dKBMdhhCZyXFqkbVB9fco0movMFzpYDmdQrcqzy0kucL7hCPjmHD6AIPxn4Ed1V4uI1iHM126neOrBl1LdM02gghdooymCQVcFue2sBizEk6ypXf3qkdnn1k5qDJdgS9RO+sdx4y3QD8Xcd6AYSfgWgcpTc04BEihj/mtbKSZQg5DRelwPMq1wjE4fN3OXFjQk+4HMYyJxPT9bqCibOk93DT/cLU13GaxXgjJbHTuQOU2EBGINXkPxtByj9cmytm2PJq0PtS9PsbZv0CiGjksdl0a7EL7r4RCHI8Fy7Ajd8M4yUaE2azkVDdpf8U9i9pgSmR1bViBY2YS0tnxGnPAKiDCfp+3P0Ser8tnIKHIIgNNk1mdN2sRmJuvDMTYLtY0+cGZQQqMwoV1pAv1Nkh39oow4bWz+QOUcKTESJFGJipO6feVCC4d2fBDUVCG0JNfAb3BfR4xLg3iLilRmbnje6dqaAo2jCWg3spuGShd/D7rqgvDWBw1Q2JLjkexVM/nonbX9MNxg1lpZ3fejpIW6hkUvCFYo12u3172YoYlIqR72odU1Jfn3ii/kZZrXOPM4y4MXmkXKgcIWfSBeMiTs8Af+bvE9xmfd6+kYyNKLWiYy6wCdL2sqM3ypUJYav9Wvavcvu5eOeIOa9G1N39KtzAFNMSCGJzd/ze+kMgU7D8m23sl3nFAtUgwNiD2sYBCKd256IRYna8/dje/dJfBa1utw/7Rcblxn0SqZzz8XSVflmcZ6a3M2ZA/ZCVOYhzuawHRgxL/RG8r2cBUMQhi9ozmrY6lJ/JxiRuI5PsYMbZ43sN09H16LGZLXYHat2BeR0+9P8+Bu46G44aCOLbDW7/QefGX8Yup1q7v/oy62JmAJ36GY+8GNV+nziGFlCn/muwYPTw8nJAISWLiIzDXZH1uS4UNGcnJdXZuRWfm94e8+qFDm8gS7g8f+amraUjYudDpBRD2dVuI6l/BcD19erwvSSR6qiBUlX8zFbQ9FOO8xgy4DqnP9KWJpHRVTi6IqEEFTeY6noWk+zpJ0JAD2+Eokbqwgor0lnTUSz2aGM6cSCury8izvGxpbF9tJ8jLtGdQxW3xper/yveYABaXby5SBWAiiRZY1awEX3eQ/WIG91GAt3rmTGrfn4qP/WjHiitIHDnoq/J/tvziPVvkOYpWahk+6KN0cf8H+rQVJLCWztASXrTK0n7b29UCuT10RPNQycDZjmordf0X1RR/JD721Gvax6KBzZes6xmLN0/PQpMqMQ3oq2CQAy2Njg/9GpPGko0ADhgchIyG8JsJXUhjLKwSgqohCDZIliCIWR40T+cepRYR8TaS4xwBCgIrORuT6RnHPaSll02Zn7enUAQEDI+8NsG9EjY6L6HPaIi4+rhsJ62ZVGiroKYSnW1fRn3Q2+/2Y4qd3m2GBH6YIkDTiJ2BN65d+9KTZF3AqgVN2VJ85mWT2ydRfJ27HfDlFphIEFCB7rWwAsnt2mgJC5zwGO7LZdbmbvQo/fbyOrtM8VG0lk8ZSTARGO65oaiHVnH8LonKNlQEFhsosDR9qzLvYDD4NnuGGTAnzGyirFQBiZmYXMRRAl3TAhxD/2jekVsxraYBW65RrXYJsLMYDXewb7uGnrFpz+qvmqSJUQv5GDZrHoqLL7FXV/2pE3QRRv5IwV8CKzn2FJZuDNnUO7pJ2JvBjv2DpHj8LAnvkXghx1rNgi07MBnRHLOx0FvO3GKvuMVOBBtaRCqhDQXLyHR2pE1Z8jvtmqHYJIY/4K+EJ6joRhm8QLTPwWQNVMKHEu6N8vqGmotURWrSeJ3D1Qq2mmUwNUmiq1Sl+kjjGUu82Xx9sEMDW9EBXA5A3hCNKmjfXhcpcKzLPTalWjkg0w2JDc7zaxxD,iv:I77nYhOZwrf7Xe8SBBDs0jdvrxRv0YO8QEoo7NJQAas=,tag:iz1LWP+7dyyFxJhsAJN+vw==,type:str]
-letsencrypt_cert_name: ENC[AES256_GCM,data:Biv7I0fnc3XhkYJv/ZTi,iv:OBoNxr2ziW88DtQpIk63LRLGPLi0FkDoGdGIhoe1g8k=,tag:H9cYuP0T6n+DrR/CKs2t8A==,type:str]
-mysql_database: ENC[AES256_GCM,data:5zyet2y3IDTgqKU3tCAssw==,iv:DivpPLAFHBfQe997yne34fdGjnyHP9XpxxmHUZmNL5I=,tag:tR4rYANqu2UP/jgfO2JaYA==,type:str]
-mysql_password: ENC[AES256_GCM,data:kiO1TEwaSmuYJJPiXqxhIA==,iv:b8p5huYZTVsHqSpKhTDI59FVU+nCTVxgCTBRYBq8vCs=,tag:5UuLkhIrnvameJBkuB1VMg==,type:str]
-mysql_root_password: ENC[AES256_GCM,data:yFhtEUQkzybHjJZ/egAchw==,iv:TDFw/GGJyQ47d5rG9s1JGXmjKMyMwU5gDDjk7o1IdEA=,tag:ikpzb47wYB9e4POSA49lPw==,type:str]
-mysql_user: ENC[AES256_GCM,data:WbnOcaenA4HkOQdluhyF2w==,iv:tAJukjzA1vwxWEpggVL1lU8JVxqkqeNdDzIW2nUnp5w=,tag:nIj5xXm4voQ6QFLSiLv0GQ==,type:str]
-nginx_server_name: ENC[AES256_GCM,data:wiiYV0tx1eGMq5npBBQU,iv:51d9UwJapSMpapbBgQSz/j5skOBPsDeKxSVYUhhmg3k=,tag:ehitfkj2+BaAbMIfuNxkHA==,type:str]
-ssh_host_fingerprint: ENC[AES256_GCM,data:w4vgJwZUWNwMguUJkXzpt3Wcl5Re2x3tea/G5kKpc3rvRclkxYQF5IQTjyfbFIOU/7w=,iv:1jCVVPp7/7201T1tTUiuKZDgGwGvUp24+tXmeGf/Ipo=,tag:BjLUZAiAGmHSuMawalNjyg==,type:str]
-#ENC[AES256_GCM,data:U02Nz0AyUiMNfbev75d/m0x16F8rG8pyAwQkZYRYWQCmRISZvFa1/XPr9MF9PuUvqGMjjQ6E1Yy+xs3NJShkHqPWIpULLmsms8rrLymito68qYlVnBty6HJH4mqvpf8v,iv:WUuDylfyEhXdnwDYoH+FJ2oKc6xtGQwPANE6jKnpxlk=,tag:O5b9Vyuo3fPxW3ph4WupHQ==,type:comment]
-#ENC[AES256_GCM,data:HV5citfisjAQoeOgdz3bGTPiPkR2HH3FePxjHVi15wZ5ssN3QeYJB0ftCkMDVagC5kGFYDUeZDRswUyOocniynCB/5jM1tdEUbs5L5z0,iv:EKYhvD3nW/rJDx2vnSwAin/dQh8/GWgRR+cMSwErxXA=,tag:himAPDG8VdfGPnbXu1RIIQ==,type:comment]
-gc_token: ENC[AES256_GCM,data:IuJrWWUvzpodu756tHO+/dvBISLef5Uk+p6UMIBNCUZ/3s5D3uU4Gogr483MQqHe7qciAvGOt58KBxC5d5DtaSf+3RgqIYtfK+fXowbZmM5q2aEOcY5AFsFNUcwuRDp6OnWhB8t1GyxdyYHDSZYBbBNey33hyMVwZ435j6Z9CfCiH/kc5k1JXaR0XFDdT1sSUQ5RYw==,iv:BcwbG5pQUFRQd5HDB6r/hCWHGKTxTlmInLDRLBn3w20=,tag:bIB4LiOY/tISapvcsngdyA==,type:str]
-gc_prom_url: ENC[AES256_GCM,data:4GQ3tnHnNHqGnBhf4HOCuJkIxCio58XRixN+JGqJhl+2LOVww4MQawCX0QtohWgfipksvbLLWJki9XqQzDaG+qIG1tT5nzyN,iv:bLU0BtnM3pg9dQKtSydgp5xH4OJF85qmoS8CeBtMGno=,tag:T08My2loq0eVdBReN7xlrw==,type:str]
-gc_prom_user: ENC[AES256_GCM,data:7IYGmkakPg==,iv:CQZf7MU9DICooDgc8o+ZgSmECFUpxtTtpy2q9ZE93+Q=,tag:WyJ99iUwVnpGkpgnm+ElDw==,type:str]
-gc_loki_url: ENC[AES256_GCM,data:hkXroFcLqi5XChK+jfkOFufwjh4K5bc07UIBhfBIN6n5ZWm+Y3KfGlCL/GeKYK/FfvQ=,iv:TxAPIkYulvBprsSyxeXmo6FmzOeoXBAq6IVu5P99tSs=,tag:TFjiZvvLevNr5NegYubWdA==,type:str]
-gc_loki_user: ENC[AES256_GCM,data:CREEEAM51A==,iv:x34/cgdi9EbO/MmGPJvyH3MydUKCCODUf7fhpCwfyAQ=,tag:R/wmmbrmL1RNs1oZaj47jg==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:AT3ovkNcJCqKBL9+xe65k4Atz5hq5RUZgkNe6KUiPf+AKni8+zemutNQb5dOFvnkJg==,iv:mF7Op3M0RVyffxayQIK4COcLCg2aVft6qLLcHakqGd8=,tag:6KWRLbLGcVZ32dM4ILLnTA==,type:str]
-gc_tempo_user: ENC[AES256_GCM,data:H5r7OVRSyQ==,iv:llPWyYXFAKXEt17RUI6WeYtzUqFTwdc7DEP8UmY6n7I=,tag:rDVgqdeCvJf/mWSzh2FNNg==,type:str]
+    - ENC[AES256_GCM,data:sk+0sMKl6trxVGjAcqvuxRs=,iv:2/rlKS+Ta8sULJgR4x7tap4rRcgoi0WRpIASov/LEBQ=,tag:9NeUo/KzN7mcBCZgyzcpow==,type:str]
+actuator_path: ENC[AES256_GCM,data:NiCWFWXY8UNeCTxAH6cFsA+rYMa4ScfrqaUhh+p8tfHsyKruOw==,iv:jq1DDtlPoIngtwf2cau5F+QMRNa0PgPUYUvlcAMNIcc=,tag:XWFXx2vQwYoBj6tXqagQNQ==,type:str]
+actuator_port: ENC[AES256_GCM,data:dWXwOA==,iv:3EN6vB/Dw2uGgZ7Gg+6N03UsRvddGF78NuMTrZ9hFeA=,tag:w249EXztvlc/SInyt8/FCg==,type:int]
+ansible_host: ENC[AES256_GCM,data:VYwhdBZjFqQ05Vc=,iv:VMfvzyMHDEggMbal/ra5A4M6iaBJhpMi1mw2syiVZps=,tag:9fahFHvfKKX7uQKy2+yJww==,type:str]
+app_secret_content: ENC[AES256_GCM,data:2kUwHX81X1GseLJY7X4Q/ZnxOF81BTkJtJHfegNEJlV3FaDNVia5kXyT0uVhv2XV+gEyXf+t1VBXZwd8KYZ9o2kMmiPECV2HRDaz3piQIbeTN+bzFf8D7CH97v2u0GjOx2do8mgmWkCyZCDEZx8FmE19V4XJlY9f0KYnC7pjZ5y73Zi3iQaLh4LdN43fiK11A1yG2Jas23S5pvOdZFytd6WbMVLIOeSmr0P/3K5tJNafhDfqF2kjLKN2hXpsUGKTrKZff9pvr9J5vzLPlaXfrUgjIgNDvuFv5VMxlNXXkm2y6/Ar069TbaJejS3bk3OMpeSSzTOfXEaUAvH9oaZPeau8/jiG8HI4LxfYlw59YGV7w01C6VA3VcTIC9uYLJwIajdJGlNTGQZp1AW5PIF3T5yidfd9ZVOagJwKq2jcY64XXAPliD1q1U5YqoO9NhQSJ6PTI7qfIjFripJc4A721ZqzLuxsxrBsS8ra5/F24ZMkyvRmjoO1OeciYH/wAfJJmEQHYuBfpXuItOKqO2hKDx1BPIX8CF+2KkgByY8LodvEX9KVorPPKE/MkAGiikpftu2VW10xnfrUdjodJlViCGy0tFwe+gXlI1Hg5AujfkQXPPY374Jk09sTJKvmnW4BABGGEpYax9JS2gGx3iCynW0JtjvljE2zUiDS6kRV3v0x6qpNfAR/8KTOoaWI1+GI9qGKZVCsaI4Lv1QuhG8qIccOtHtPdxXkztMnK7qBMbheIP3f6kk8UXaaEHlLwWC4h8CjFKfK3lWWPDI3PC1JJHKQ5CXWabcsDPa2BRDhdJnQhicyFuS/HO39zIpRzVcOD9xJExuxeZ2B1L+z7KUkDNol+59+OYyhoLOxHo9J+DiYhM3clrlahU10Hw17WccnUtxwq3/+7AzKMjxt7+TAcdYBC6V9YWl7aV4AXx0jyrOdUVsgm0JUy9ngLzbuwDqe/IzmFUU74Cfj+cfJ58CePVQZ6Bn/WHtz3RGATciriiOWU9LGw+dniQqHBJlc0xGpSno13+VNR2MIRSuFkdqzZF0p4VsH5BpCBXt3R5KbYH68YjeDx57JdkT3FHx8JnMbbYj+k4aKrz6/apBObGXHe7aze7gmvNpKufg+YmW0uGQwy7K/FvzsxchxkY5CtzcETnLMRWvA6AEv0YQpO1bvf/LmKJewWWkZ2Qb6iq92yrWIM2btQhnsWjNpP+DKSRwEwBXZz+UckuRIwqmcnfaWDqU/0SNVMOK9pVosDFi7Xix5oDORbtHeb0trVMVlNGjUelr76vbqqf8F1dpGMqn3MOn1FocIqu6HdJyHl7p9YKtkPwCuz6VZJLKWwF18mV/YRUDt7fzR5zBVXHLfR08YG7OjInVKZGnDlr03IW3a+lBlmbflKoNu5XEO3M5Z8Cf44cXTsIaQhVJl3nMBPn/Hcfq7ZMiKn3KAPBNYreEpDAvluX7+5UsbTOiS3Ttr69wcFnqMC5O/+BEko2heY/IoPnTtbzK0yFUT/4kYXE1RGrpSapvfcQTyC0d8mODLySgdSnR131pUXzxUSOHOnnuAhK4SpT8NZ2P31BVj+bNwSFmqwUXkWM3l9VZfxYi5nfmnqdIrPzMEyEAEuL3dq+FK3JFsfpHiyT933zDRTnEXcDwpSBSqT7lNFKUtNeDc4UwyFaX6PuSyXVVyQmmx2wnGVcRLwy3x5ZlJkqXwlJlBn21N9poKGZtDAmu1WM6LssIOfBRcElxKeVBOnqsbVZx/+h+brv0MRMsNyvDWcSDCo75y//XhFbroJKp3Dvz1yWuWX8atr5uhQSpKDOQYERMczbLeX6oU1YnpIki4jA52js+FEVWb2bk+Wc+je2hnQwbwZWhXmLQ8AboeCLtKYZ/oz9sfAFMVLNp8BLC39/GoxZ6c93PZqAcr79GQkAmMlaJ99SY0wQe/AeSwi6kRYlgRhnH3vbgMnr+AL0pnJ+jnDyBl4qpzHmzq1VVlJZb4qKu1XYXpFaBErt5f2nFArhGuIH6o4bLrcF8=,iv:lm7jWCP07I3FbDgHq08JuYUiGjoGUOmjnt2XxjeekVA=,tag:79wc2jvoK8mNRm/uVyzlkQ==,type:str]
+letsencrypt_cert_name: ENC[AES256_GCM,data:AEld/fbx7VDY/PTUUrkI,iv:2GlPWkjZPpjYHvWo0bqitCai6f6eHMKvo1Z7PWVzUW4=,tag:7yjwGdlbM3O54OPdNsUv5g==,type:str]
+mysql_database: ENC[AES256_GCM,data:f+ATV++6TK6HjaukBS2tkA==,iv:/0ZadvnOXoVPccpjdHVrSRY/q0Xqk7JljrU7WKnxnaM=,tag:mfKgWcCroYLWwr/kwOobKQ==,type:str]
+mysql_password: ENC[AES256_GCM,data:qAkUqiMbYjzH2YJTKbh/JA==,iv:D27c2HRk8/YZ0F+vdX/0sKZKQNvrdhCDgAOttLig7UQ=,tag:Z8LHzDcOzZLiuHSU7+bPNA==,type:str]
+mysql_root_password: ENC[AES256_GCM,data:EhYXl/M+BWZMbGLfyVGZsg==,iv:xj/KSjabmedmI+YAthJTxW/atS7IKcHUSb+bcZH9b4g=,tag:cuB+ayQdHwce9EVregz3Xw==,type:str]
+mysql_user: ENC[AES256_GCM,data:U01a/WZy22ZCBfhG3avpgQ==,iv:fJBt9oYljuZc+BQULx13ShXow7C1O0d4Q2+wGbre/TE=,tag:d1maZGasUl6htY9bf54GxA==,type:str]
+nginx_server_name: ENC[AES256_GCM,data:cVFu3eYrnjRWIyVVJhQe,iv:mwIagUvnF8ZEWpA6lG2H/041ucnTnMTSOyS2SG6plTc=,tag:/Stst5A9xrNzOOXgaPB8kA==,type:str]
+ssh_host_fingerprint: ENC[AES256_GCM,data:b/9IUgmqePUV/fxvb0t9Awq6OI2nsYyBOa5/AS6GR27PtmgJyEL3u5XGWw/NW95xWlY=,iv:fFrCYltfVzRQvwxgayTWVYONVdWdlOo9axOkAfGeD+Y=,tag:45v0QvqosckDTDOU5n3KdA==,type:str]
+#ENC[AES256_GCM,data:O7RwcWF18+byIEorwmoDJBvQow5qMUoClbw8iz24P3zrsMIS88dMClN3Bs6M5R7+VnZJOMG9wf7Fs2DY5HHMjuRIKUDMsS88ZNfaGwEQA9uFdR6AcxL9YLDaDPJSIgWr,iv:MUrwxNQTTsyUPqGDT60XfSX75wZ1tDqpgYdtgq/cC5A=,tag:rYOFyuecb9LQFzq8FR+7IA==,type:comment]
+#ENC[AES256_GCM,data:OtrdBiMbyXcK7Y2XKb83l0faib0HGo5WUfHInh3xtddyU8+h+Fn4/qzenmvPQRzb/dFTS9pnhHtWdGiw+7gbN7yPN7Y/cAyzJNiDDSX7,iv:ZHYLa4f/SCqKtTsbRzy6IqTzp4pVoX5SCbSfLCEKwwA=,tag:HdqM4c2zFjWAYW0gxDhFKg==,type:comment]
+gc_token: ENC[AES256_GCM,data:dOVNGRa7sQXKF/M/qFvm8Ez/oLycHLuTyVI+vxrONEGam9bTsBC4Ivdvh9+TrfgnyjKHHpTpxFYszVxqqZHO/Mc44SWZnGzNuuV9FonerK7c50q8gitmFAflEIqD9YQOq7EZHbUudWVvks3Q0gnmsKvht3z2DEvYCOg4a9t3FX49tsuT9BvIRD26kg3q9R78L2ousg==,iv:rZiOcmFnKvfYpRlpdRasX4zTh2WqVH5qVGQ9JmwV4fE=,tag:402DCekvBbTyTHt+d3hmXg==,type:str]
+gc_prom_url: ENC[AES256_GCM,data:5fh8H/wMoRwWlJoTZB8g2bl4bh45tM67VQMNPMyDJjxUNRNs/rFs2fLE1Al7dMTAI0uzWDIs2vqLfNTkrpA0Olh1o9XOIx+t,iv:Vj7uccERl9lMwK4ho4vu1jI1JdTiUTF6yYnraxdWaK8=,tag:HVKjD8jQ6NvuVEQ96GBCEQ==,type:str]
+gc_prom_user: ENC[AES256_GCM,data:TcGKnQorNg==,iv:4jo+Wm+PcGAe9qMsaavut1hWYn0NIJCjs0gxRfN8V/I=,tag:TegGzniU44LyMrQ5K8X9AA==,type:str]
+gc_loki_url: ENC[AES256_GCM,data:sZd2kjVlsgq+dZYe2k6om/kAEb+ucClwtvuHBwzO0tiRekcewZ3tM4ZuHQvmjv6DMYw=,iv:h85g+jCffYjC8LPs/1M+PW6jC6P0EHEl6wRGfztR5aI=,tag:mm/cdp+obplZhdzSMO3xNw==,type:str]
+gc_loki_user: ENC[AES256_GCM,data:yLvEHkWzkw==,iv:B6HlktMi+ZcDT0R8YxkCLfvh24yvUKZNuFw0JVvFSmY=,tag:MpLzAmGDnGbHBsFAK18wgQ==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:6eBIzuKTzCM2Da0IQocir1LcBUgMorTk3dcoJfuVw2cGARd7sUpmMK4Wum2FhHl/3Q==,iv:8vPgnEpx5FggzacGMKsaNZ5fEwYOb3G72HrS0cgpWg4=,tag:6ZbWTt6bqfVyi0nXyEISjQ==,type:str]
+gc_tempo_user: ENC[AES256_GCM,data:bIyvm3fbHQ==,iv:AkqtoSA87U4lwhbuU4gNou0A/UU6a/C8UMI19OA6HxU=,tag:T/51hMF6OwGFzFEel1+9JA==,type:str]
 sops:
     age:
         - recipient: age10ku4fy9jalda7pkqwmgnywjnmeqdknv0fkt5a7dgs5egk9xf7atsa6vnpa
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuVFYwNjh5bHhydHRsSWw3
-            cDJJSlZFdDZTSVlseEQ1RXVyZkFXT01hbVVVCmVjVy9yNE1QcXlreTV0UXZXOWZP
-            Q2NuR1BKZDdoc2swL245VEVPMDUvYXMKLS0tIGdic3lhRHEwSEFVZGY5ZlNhYSs1
-            NERqUVlmc3hqRWJ2aG4rMVdRNVRZWnMKukd4X+sZbhM1B2tlPZ4Z4sxKBkWtquf1
-            wMMj/CjhFF2mpYAgdl3b3ZY7AlvM6/RYnMaesMa+NzdKQVnaCpRSdg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4Y0dUR3pQZTNhTWNDRW9h
+            aHJSMThuM01JblpTQWQrcmc4a3kwWmQ4aEhrCmU3T3ErbE93eW5NVkFycVpjRUJw
+            QStSNEFZT2lHUkhRbXIyL0NqUmtWbGMKLS0tIDhZaHI3QldFVmxtWmMxVzhWdlFJ
+            QlRUZmc2U2dGZEZxR1ZUZGV3bWcvMlEKIcP09N11sxIcMYTFmtg9thj3aIRuMJ3K
+            xsWG78fyJtz+ePJd2fK2+kh0NgMNi3DMihMFIrjUjSSf04dvVjypBw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gagkvs6ur249muxexemtwumzqsvgpc74yxu7sfkhhsqyw7t8asesgsyyfn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrQVVhYTZwTzA2STF0b0NL
-            TWw3c2RVYUJsSmJMbE8zU3oyZzNxQlVxMWc4CjRhT3cvZTdzTDhhenFhZEIyei9M
-            aksvdXN1cDFkczRHSGFwWTl1VDhjUUkKLS0tIFU2dXQ3cC9PTzZabjFVUWxMYlVs
-            V01JclpSTytUVjl0MVYwZU1IUWhwa1kKuaTepaoIC+462MjBr38rHF4O6MCsPcjG
-            h4k0C/JhfKIMeOVDucsNb0S/nbGOD3SiCSiejMu4XVEFEX8cgkS1Ww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlQVNmRWk1YUhta1BlTW5F
+            Y1ZnZC9DYWtuVjR5NUlzOXpJWWRzd29FcG0wClM4SkoxMmM3enRhSXE4L2dBSkxh
+            OEtHNy9zcG94QTFGN09RSHhsUEVvVmMKLS0tIFlleEFCNjIxZXBpMXhRS25Da1Iw
+            KzNMUzVaNHIyeGppb0EzQ2tQN2Y3WUUKJpaEtbvNEXAIWgvgxU6o9QPd6avJ5EeS
+            axlWCl5YG6fgjCxM5ryej7RrbTqVomL7c4uVpQvNaw/qi9jSNDF/bg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gsw3fsp4m6shzrv9cvztagavxevzz3pdm9xdl9fk3mturkfzhc2qf4z67e
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNXFCWkg2MnZyeDdHU2RB
-            YzBEZ1B3TjNiVC9STTJSeVpobWpycVZyTkI4CmRVVDdYR1EvYlA2NzZIamFCZmY4
-            NUxHSnprUDNLZHZTcXJqZ21Rd3F5dlkKLS0tIFlsZTJxZUFESHlMUFJBZ05TQVV5
-            MkU3NHAwSFN4VkZrWnRzNHd0Z0dtSUkKvsG424D9L34OGPMjdnPEuRSmy2Nk8RL8
-            Pt5LnmLClswRsClapPDMyblwj6caIQGAhGsn70OLABtHAJv8+ADqvw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2Z29HOGVHanY1NkhOcklQ
+            WnJtTmVJRk1leUM2ajhDTGdDRmJMYm5wb1RJClhpdFFJOWtYSjgxczZJdUl0czdj
+            UGtUays4RERsTFJwdGYwcGR0c0laSkEKLS0tIGl2SkdmV050ZUl4N1VHcmx0L0k5
+            aUN2T3hNWjdwcjNqU3dUTlAyZzFJbmsK2bTsKpT44/awG0X/saXSECmmo2e/aw50
+            g2zPnVp3MExcNYXGY2t03ndkBM0HYcZjSm5VowOzJel2eYfPWhzNMA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T18:38:02Z"
-    mac: ENC[AES256_GCM,data:SVqa0WUAZjqJUE0U3HfyjRhnoU1HsZdvicttHcknAoXrdIeutM66F4rafO9lfJ9aaHyHxCeoplufc0gfzrTH0iUC/Lqwd7lndByTnOLXP6puqhGGrtF8/PcI5JMKlRCxT+vpwK9C5S3dPiq2I5mqoe17W8iAZfWx31GrRn+GNFI=,iv:3H93MsK2+nSrORGxwQVqbZjDAu+Dvk2aXgL31nxY5Ls=,tag:ZLcrE5xCKSe5ezH/CrUuMw==,type:str]
+    lastmodified: "2026-05-15T18:58:29Z"
+    mac: ENC[AES256_GCM,data:lgW6DmBJVyIsRRpWD9OZkoqYRIh0hTmegcGJJJx5WSm6acWaSrtjAk0vAeSs56L8r7JT8or2qzlRIWEn1OJ6s9Mdv2qACY3ZMAPOyclK6XgLGKWYT11yRZwVNrdOGu9nMSm9qqCW6NVory5bd0eW4c/ek3MrCTxOSx9ey5RclyA=,iv:urfMm4vi3b+5HF0vL8uJ+8nKEUSinLHaALfPDPL1uJo=,tag:nEmDimpEV0+mg1C3ag7t6Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -1,55 +1,55 @@
 actuator_allow_cidrs:
-    - ENC[AES256_GCM,data:sk+0sMKl6trxVGjAcqvuxRs=,iv:2/rlKS+Ta8sULJgR4x7tap4rRcgoi0WRpIASov/LEBQ=,tag:9NeUo/KzN7mcBCZgyzcpow==,type:str]
-actuator_path: ENC[AES256_GCM,data:NiCWFWXY8UNeCTxAH6cFsA+rYMa4ScfrqaUhh+p8tfHsyKruOw==,iv:jq1DDtlPoIngtwf2cau5F+QMRNa0PgPUYUvlcAMNIcc=,tag:XWFXx2vQwYoBj6tXqagQNQ==,type:str]
-actuator_port: ENC[AES256_GCM,data:dWXwOA==,iv:3EN6vB/Dw2uGgZ7Gg+6N03UsRvddGF78NuMTrZ9hFeA=,tag:w249EXztvlc/SInyt8/FCg==,type:int]
-ansible_host: ENC[AES256_GCM,data:VYwhdBZjFqQ05Vc=,iv:VMfvzyMHDEggMbal/ra5A4M6iaBJhpMi1mw2syiVZps=,tag:9fahFHvfKKX7uQKy2+yJww==,type:str]
-app_secret_content: ENC[AES256_GCM,data:2kUwHX81X1GseLJY7X4Q/ZnxOF81BTkJtJHfegNEJlV3FaDNVia5kXyT0uVhv2XV+gEyXf+t1VBXZwd8KYZ9o2kMmiPECV2HRDaz3piQIbeTN+bzFf8D7CH97v2u0GjOx2do8mgmWkCyZCDEZx8FmE19V4XJlY9f0KYnC7pjZ5y73Zi3iQaLh4LdN43fiK11A1yG2Jas23S5pvOdZFytd6WbMVLIOeSmr0P/3K5tJNafhDfqF2kjLKN2hXpsUGKTrKZff9pvr9J5vzLPlaXfrUgjIgNDvuFv5VMxlNXXkm2y6/Ar069TbaJejS3bk3OMpeSSzTOfXEaUAvH9oaZPeau8/jiG8HI4LxfYlw59YGV7w01C6VA3VcTIC9uYLJwIajdJGlNTGQZp1AW5PIF3T5yidfd9ZVOagJwKq2jcY64XXAPliD1q1U5YqoO9NhQSJ6PTI7qfIjFripJc4A721ZqzLuxsxrBsS8ra5/F24ZMkyvRmjoO1OeciYH/wAfJJmEQHYuBfpXuItOKqO2hKDx1BPIX8CF+2KkgByY8LodvEX9KVorPPKE/MkAGiikpftu2VW10xnfrUdjodJlViCGy0tFwe+gXlI1Hg5AujfkQXPPY374Jk09sTJKvmnW4BABGGEpYax9JS2gGx3iCynW0JtjvljE2zUiDS6kRV3v0x6qpNfAR/8KTOoaWI1+GI9qGKZVCsaI4Lv1QuhG8qIccOtHtPdxXkztMnK7qBMbheIP3f6kk8UXaaEHlLwWC4h8CjFKfK3lWWPDI3PC1JJHKQ5CXWabcsDPa2BRDhdJnQhicyFuS/HO39zIpRzVcOD9xJExuxeZ2B1L+z7KUkDNol+59+OYyhoLOxHo9J+DiYhM3clrlahU10Hw17WccnUtxwq3/+7AzKMjxt7+TAcdYBC6V9YWl7aV4AXx0jyrOdUVsgm0JUy9ngLzbuwDqe/IzmFUU74Cfj+cfJ58CePVQZ6Bn/WHtz3RGATciriiOWU9LGw+dniQqHBJlc0xGpSno13+VNR2MIRSuFkdqzZF0p4VsH5BpCBXt3R5KbYH68YjeDx57JdkT3FHx8JnMbbYj+k4aKrz6/apBObGXHe7aze7gmvNpKufg+YmW0uGQwy7K/FvzsxchxkY5CtzcETnLMRWvA6AEv0YQpO1bvf/LmKJewWWkZ2Qb6iq92yrWIM2btQhnsWjNpP+DKSRwEwBXZz+UckuRIwqmcnfaWDqU/0SNVMOK9pVosDFi7Xix5oDORbtHeb0trVMVlNGjUelr76vbqqf8F1dpGMqn3MOn1FocIqu6HdJyHl7p9YKtkPwCuz6VZJLKWwF18mV/YRUDt7fzR5zBVXHLfR08YG7OjInVKZGnDlr03IW3a+lBlmbflKoNu5XEO3M5Z8Cf44cXTsIaQhVJl3nMBPn/Hcfq7ZMiKn3KAPBNYreEpDAvluX7+5UsbTOiS3Ttr69wcFnqMC5O/+BEko2heY/IoPnTtbzK0yFUT/4kYXE1RGrpSapvfcQTyC0d8mODLySgdSnR131pUXzxUSOHOnnuAhK4SpT8NZ2P31BVj+bNwSFmqwUXkWM3l9VZfxYi5nfmnqdIrPzMEyEAEuL3dq+FK3JFsfpHiyT933zDRTnEXcDwpSBSqT7lNFKUtNeDc4UwyFaX6PuSyXVVyQmmx2wnGVcRLwy3x5ZlJkqXwlJlBn21N9poKGZtDAmu1WM6LssIOfBRcElxKeVBOnqsbVZx/+h+brv0MRMsNyvDWcSDCo75y//XhFbroJKp3Dvz1yWuWX8atr5uhQSpKDOQYERMczbLeX6oU1YnpIki4jA52js+FEVWb2bk+Wc+je2hnQwbwZWhXmLQ8AboeCLtKYZ/oz9sfAFMVLNp8BLC39/GoxZ6c93PZqAcr79GQkAmMlaJ99SY0wQe/AeSwi6kRYlgRhnH3vbgMnr+AL0pnJ+jnDyBl4qpzHmzq1VVlJZb4qKu1XYXpFaBErt5f2nFArhGuIH6o4bLrcF8=,iv:lm7jWCP07I3FbDgHq08JuYUiGjoGUOmjnt2XxjeekVA=,tag:79wc2jvoK8mNRm/uVyzlkQ==,type:str]
-letsencrypt_cert_name: ENC[AES256_GCM,data:AEld/fbx7VDY/PTUUrkI,iv:2GlPWkjZPpjYHvWo0bqitCai6f6eHMKvo1Z7PWVzUW4=,tag:7yjwGdlbM3O54OPdNsUv5g==,type:str]
-mysql_database: ENC[AES256_GCM,data:f+ATV++6TK6HjaukBS2tkA==,iv:/0ZadvnOXoVPccpjdHVrSRY/q0Xqk7JljrU7WKnxnaM=,tag:mfKgWcCroYLWwr/kwOobKQ==,type:str]
-mysql_password: ENC[AES256_GCM,data:qAkUqiMbYjzH2YJTKbh/JA==,iv:D27c2HRk8/YZ0F+vdX/0sKZKQNvrdhCDgAOttLig7UQ=,tag:Z8LHzDcOzZLiuHSU7+bPNA==,type:str]
-mysql_root_password: ENC[AES256_GCM,data:EhYXl/M+BWZMbGLfyVGZsg==,iv:xj/KSjabmedmI+YAthJTxW/atS7IKcHUSb+bcZH9b4g=,tag:cuB+ayQdHwce9EVregz3Xw==,type:str]
-mysql_user: ENC[AES256_GCM,data:U01a/WZy22ZCBfhG3avpgQ==,iv:fJBt9oYljuZc+BQULx13ShXow7C1O0d4Q2+wGbre/TE=,tag:d1maZGasUl6htY9bf54GxA==,type:str]
-nginx_server_name: ENC[AES256_GCM,data:cVFu3eYrnjRWIyVVJhQe,iv:mwIagUvnF8ZEWpA6lG2H/041ucnTnMTSOyS2SG6plTc=,tag:/Stst5A9xrNzOOXgaPB8kA==,type:str]
-ssh_host_fingerprint: ENC[AES256_GCM,data:b/9IUgmqePUV/fxvb0t9Awq6OI2nsYyBOa5/AS6GR27PtmgJyEL3u5XGWw/NW95xWlY=,iv:fFrCYltfVzRQvwxgayTWVYONVdWdlOo9axOkAfGeD+Y=,tag:45v0QvqosckDTDOU5n3KdA==,type:str]
-#ENC[AES256_GCM,data:O7RwcWF18+byIEorwmoDJBvQow5qMUoClbw8iz24P3zrsMIS88dMClN3Bs6M5R7+VnZJOMG9wf7Fs2DY5HHMjuRIKUDMsS88ZNfaGwEQA9uFdR6AcxL9YLDaDPJSIgWr,iv:MUrwxNQTTsyUPqGDT60XfSX75wZ1tDqpgYdtgq/cC5A=,tag:rYOFyuecb9LQFzq8FR+7IA==,type:comment]
-#ENC[AES256_GCM,data:OtrdBiMbyXcK7Y2XKb83l0faib0HGo5WUfHInh3xtddyU8+h+Fn4/qzenmvPQRzb/dFTS9pnhHtWdGiw+7gbN7yPN7Y/cAyzJNiDDSX7,iv:ZHYLa4f/SCqKtTsbRzy6IqTzp4pVoX5SCbSfLCEKwwA=,tag:HdqM4c2zFjWAYW0gxDhFKg==,type:comment]
-gc_token: ENC[AES256_GCM,data:dOVNGRa7sQXKF/M/qFvm8Ez/oLycHLuTyVI+vxrONEGam9bTsBC4Ivdvh9+TrfgnyjKHHpTpxFYszVxqqZHO/Mc44SWZnGzNuuV9FonerK7c50q8gitmFAflEIqD9YQOq7EZHbUudWVvks3Q0gnmsKvht3z2DEvYCOg4a9t3FX49tsuT9BvIRD26kg3q9R78L2ousg==,iv:rZiOcmFnKvfYpRlpdRasX4zTh2WqVH5qVGQ9JmwV4fE=,tag:402DCekvBbTyTHt+d3hmXg==,type:str]
-gc_prom_url: ENC[AES256_GCM,data:5fh8H/wMoRwWlJoTZB8g2bl4bh45tM67VQMNPMyDJjxUNRNs/rFs2fLE1Al7dMTAI0uzWDIs2vqLfNTkrpA0Olh1o9XOIx+t,iv:Vj7uccERl9lMwK4ho4vu1jI1JdTiUTF6yYnraxdWaK8=,tag:HVKjD8jQ6NvuVEQ96GBCEQ==,type:str]
-gc_prom_user: ENC[AES256_GCM,data:TcGKnQorNg==,iv:4jo+Wm+PcGAe9qMsaavut1hWYn0NIJCjs0gxRfN8V/I=,tag:TegGzniU44LyMrQ5K8X9AA==,type:str]
-gc_loki_url: ENC[AES256_GCM,data:sZd2kjVlsgq+dZYe2k6om/kAEb+ucClwtvuHBwzO0tiRekcewZ3tM4ZuHQvmjv6DMYw=,iv:h85g+jCffYjC8LPs/1M+PW6jC6P0EHEl6wRGfztR5aI=,tag:mm/cdp+obplZhdzSMO3xNw==,type:str]
-gc_loki_user: ENC[AES256_GCM,data:yLvEHkWzkw==,iv:B6HlktMi+ZcDT0R8YxkCLfvh24yvUKZNuFw0JVvFSmY=,tag:MpLzAmGDnGbHBsFAK18wgQ==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:6eBIzuKTzCM2Da0IQocir1LcBUgMorTk3dcoJfuVw2cGARd7sUpmMK4Wum2FhHl/3Q==,iv:8vPgnEpx5FggzacGMKsaNZ5fEwYOb3G72HrS0cgpWg4=,tag:6ZbWTt6bqfVyi0nXyEISjQ==,type:str]
-gc_tempo_user: ENC[AES256_GCM,data:bIyvm3fbHQ==,iv:AkqtoSA87U4lwhbuU4gNou0A/UU6a/C8UMI19OA6HxU=,tag:T/51hMF6OwGFzFEel1+9JA==,type:str]
+    - ENC[AES256_GCM,data:s23/wEC8Mc2dL+4/ckmm7j4=,iv:QxPfOrjuwyTcmU1lOYbT122EWas5tlfG5HtuaDKcASo=,tag:iSE2EQQOV6MYvP2/HYdsDw==,type:str]
+actuator_path: ENC[AES256_GCM,data:FWjB9IPnbHnx+xIcYNozlLHLXfrlXpgV5UD7MndvSSmBGij/MQ==,iv:DgWaSld3Jx1UP+H9D0l9bUgwKRjtikVpvlbeBUaRXhI=,tag:EOCndvMq1BmStVctsrLPzA==,type:str]
+actuator_port: ENC[AES256_GCM,data:+iPcWw==,iv:XY/Eg7TIg+lc31HrXwwudIz5plbSGZPMrRWfn5Ic0H8=,tag:Q3FzZWQ7XE/HfdX8neBlcA==,type:int]
+ansible_host: ENC[AES256_GCM,data:hyu3B6g3wWI1BG0=,iv:o3ooA5i72lAJTqeRDzJ4k6rEXw4OWMHDsccxYC05sSk=,tag:4h+ZzCcHWOCNqe9ghmeAoA==,type:str]
+app_secret_content: ENC[AES256_GCM,data:d6g+EdxDHDLhU7vGPkVM3hkaJ6s309zDDEl6BbkLpYoyzoA7v/1r4Bek8d0x5JtOee9t8g6WfyiR7/CsS9ge5twxfjLZeK4P8xsnn8GZ3FwBvfXhfHnhngowZ+UXrW13wAjhFLsU3Z/pY1kJordqGUTQPVTml7h278tGAJ4HTluPFkR8ahAZoUyDPB7fIKJK9A7xEDPwa/QUzYVupHZ5LGgY69VvouxwRlDvwBvSJBukGwAfIulcTALrepI/Tj1s4C7Pe3OzVZ10c+RMn/Q4INN8+2WWuwIDUlbVcTgClLG7n+tlch2UFA8PNnlyudLzjOTxMLAsbUgBNDki9Gds+QfslBepYFTO08jOdZU8NPpivkhqPo5U36FME0abnZptaeVuC0XxtAOCJlhF7eEtmZMyO+dMjn4hkKDr5VcRLhsgjZXT8NZWmv0rY0k+ylzB7l9EstUQeu0hFizVCTtu4SpxkfWOW+Bpv9a0s3eOCqjHUz+7XNGtQ26VW3EeJI9nNMYlit5leJgpev2g0GFdRnooYJHFHfmAwWVRaDWWBoBPg4FzRrwEPVE9Jbey2jVC1msANYtKipSSYWAQeclgo9j+BtXrtDt5KTRmdq5wj1jxypqNYwZ+HutRH5I8XuvUYih7uUBDMgidQrcrQisnyfWgPpsT3Kcbm5UxuFrXsWZY9xg63m9mjkXRT0XEWYhQBgK6Yv9nuW8YPbNFPN3grOLwadZMj2IJxScpsg6VjjtwuRkVR8dZx9B+8h1+MyvOmK2kVTWtyB629iribnhap1A4J3quook/JA6WUwpBB8UyJPLunyWgDbvPZAz8fh3OxLiGnJAlum+0lzoHV7B27NzelyCKpO3+pJm4iC2Qi585N4LcLsIszJp+JZQhOZ9i0hnIWOR+T6JPI5/Ppy04OYovu7uGQYDZlJwjBLWkkDDWQ+oSB+nLN7g76Sdn7m9MfeZRmT3x+x01JrmDWxCy5LpNj8ZMjD+dwIoEgBRnIhSwDPgNvuStpaTCSDp7ntbfBWFA9kut+s+VVWCxRsDrvx2K4Kf4Z1g0MDOQYvcxVYjVjgqUhgm37wrQWQx2OJJNCFwfnIb3luPkEo/p0uuhT1ctqI437Za5S72PLD23EVvbV8y5eQ2EAGcUd3zRSOhQfqk07QdECCGxL42WLF+fe3IipxT6y0OSnZHH1igHCdvlVo9kuuVUwWRnDhJWnQObhW4pjV4ITKTcv0jNJEep1x+iloEo5Znx+CpIE7YE7d86FWXYUIeB7/f4tOQbE0PVS8Gahj2DpwIDBo9MMe6YVPg273TtdIEZdS5z93D94xyKIuwGg/reABbaqN4f1IArnHQG7FqNa1OCIlC0eUfbklQEiMzuvzeUJMSHAcUAzfj8OpTaoaFTCGKlazv8tLgrjWuSGcpMCjjCC7wJ4wQvAvQRCHTKR8A0XzlKUghjNTXtq/ywCn/BQdVlrlsUs7sH+RlQaFRJds/tBGKFbFj0IRN+R6kqihCFlolPsfT1QXl9WnNLAirEwKfcrghhnRd+3kdTz6PcPRfod1k5A3MMvBXPnH9VosGWJuRMMaxn/qoEGdEOlpe3hoya5wwolZmkxh107eiqOCX4pwR+pighRbrvWcd7sM3Wf/oQ5pXNXnC00QGqamog602a1n9iuc2+S+06wUKvSKsvviMX0em4pVEwEfxkZitGLckBKFjywdx5FV7nHg38wQfOLDcOpCk+o7HhcLAmG+QIJTVCNMVn7NVcEjKJc1sRB6RXzA+NQ9OUHifrlOoPvzqJ1IEmkOGrN20EPlVGy+53GpjmkTs2uyMiBZq+id2i/vYqdIfhAOu4b1nwiOUvxoGVfPgCgtaTR/NuqiOa+iyDuhv/kLCyXSLAQxiM9Ip9J+0+0CMJWedjwWlCqKYq2kd2KDhlQHWcAbeXjzox4JVm/sWtz+TheUTHfwOSbnpAr2W/jwftlXgF0lDuHfk4zk+AvQAK9OQ8cdIAOf6qrLSDMcdLbA==,iv:dwxPjASUzJNSG28tGOPhsLRd2uuEPbRdgDL54lji/ag=,tag:2K/YOeeGp1sZ3VkcT3VfiQ==,type:str]
+letsencrypt_cert_name: ENC[AES256_GCM,data:9mri3QlSiEdmifblXtks,iv:XfnxGkMWotmt9xct5pF/FzqIZiTuuQkj8sxvTu9rieU=,tag:dnDMlEca4rYihxnj5BXLsA==,type:str]
+mysql_database: ENC[AES256_GCM,data:2gO990ltDbjd5pHgiiH+Bg==,iv:wdZQaVYidpn6W5HG0tr4UneSZv8X8v2c4BbhF5ulbKQ=,tag:MksskHIM/s7iz0arug5zrA==,type:str]
+mysql_password: ENC[AES256_GCM,data:B32tq3bhoI6BlCx6/IbNcg==,iv:0m7vNSDof6LSsqqJWBxBbNl/AvSvw9HRNj5pr2M4VuQ=,tag:Zi116MWvVefiy1pwXnpihw==,type:str]
+mysql_root_password: ENC[AES256_GCM,data:JbrgQjNhWKxF4hdGfU9FHg==,iv:uY27LD51Fxjv6krfg4EAeM8cQTI0lUO+STalrBYtr2c=,tag:JnQ+5Rsz4TXjv+fdWCwEow==,type:str]
+mysql_user: ENC[AES256_GCM,data:XKX1Y/swC7qTSbAj6BWYtA==,iv:WWlvLpI/Spo7cO/rwx9Rnmeg8uB46ssPovCHRZGPNAk=,tag:pfRQt6xQZJNLs+UK5+iqQA==,type:str]
+nginx_server_name: ENC[AES256_GCM,data:CXjctB7cIkGTqcICW5kN,iv:6+OrNNb6+I8iDZvya5B2TEEk7v9c5533auY5It775Zw=,tag:wpwuq2rL2UuumkIkc7S57g==,type:str]
+ssh_host_fingerprint: ENC[AES256_GCM,data:tpZqAUYwR7drHjC1H4MRWUydh27kUaytIEm8+dbPhOryTBoDVgudD9TffmSE1SINEZQ=,iv:J2JTuTTyKJBgmrgMmK4SeUHKHUbrKB4BTnbe9iy683E=,tag:DmthMTOfrDQ9nFz0W3OwMQ==,type:str]
+#ENC[AES256_GCM,data:VvvXU9MO4Wcad85D6TNsBojDpC2BsJ429okWf4qlFJOdL6EIv6mI+ZDyVO2NhxnvlPv1lDLKwCGeUAxMwo82uecuqjrZbuwb7hR5Ypb3UoujZG1+Ouy9EeryM0E6j+yF,iv:QCHhaOWNKMiLLxAjRavcnq0MNhjJUFHKhGREkFBUd60=,tag:3rRxP6pR1f9tQsXo5zWFZQ==,type:comment]
+#ENC[AES256_GCM,data:+ErvmzVWqGUD/UymkiESkmC1Y5dZSDpwg2lcvZm3NMJGKA9NgWkYFF7s2/s4gyj1DE/mBGFBkJvPL9tFgaabtWH7SED9eQTB9A2F0CVu,iv:wGFCFfH9FfMt+Rxoge/S0LlX4e7K78LvTRo8t/6i+I4=,tag:dL23OJlx1EE6wahrBZK/mw==,type:comment]
+gc_token: ENC[AES256_GCM,data:nxXQqDI187bQjgHwewGbuxuYOhKCJNe0LGQRHWvv9blgXiEVeKxXLrmEcO5AdQsDtBXzTuGB+th7f2sbqb8AF9HA1c53ZHgM7Q/3p1D+lR4FJVUkjRFE9dPwH7IwXiQwmJFA/evFRc5UVGU5Qo+Kwrw0f02YTRzzEUgYVXbGuQ4sEcFNdAseGcURtn0EY/zUfHewGg==,iv:GpwuWVpES9lbg8uhXs3SYELy+OloMvrbOEfLVzTHybk=,tag:CGQkw7R3vPFBoV3l6/5YzA==,type:str]
+gc_prom_url: ENC[AES256_GCM,data:yyZGtCz9Oqm+QdtvXVj2Gs1TtMz5VmaHFSroveLvx66/HQ/wPSMcynKcuU71E7dOO0ikQXdv04nrNFvAlKtispYr8V24xTj9,iv:JUbi7eDJTMdJYugK3RJp4PeOfgDPp638sPWYtNDUThg=,tag:QhrQpSoWlntuVadTetTQ6w==,type:str]
+gc_prom_user: ENC[AES256_GCM,data:2OfoWdnEGg==,iv:9FqMdViPbcA/ZWEnVKxvDm7+NhuCIFhJ1/3e8buUCws=,tag:i6/DhO+SbFAFhef2nulH9A==,type:str]
+gc_loki_url: ENC[AES256_GCM,data:i5X6xRWXzoLBI3ICg4zfN/6U/kD3eRoxl+3CWIE250TTrMLkFc+slYVV2A35ZI3yLE8=,iv:TCiUkq5cRFhiJpDE2Q5bodcolfWjvvVLd8jTIx3Qqog=,tag:D/IFIKMhw0UBv7M+BnSmRg==,type:str]
+gc_loki_user: ENC[AES256_GCM,data:lgyX9ipumg==,iv:wPprqqwjN/CWCpdK8FLrdjNewWzSmJOkznochrxWOjU=,tag:BGHKvRmG7Fe9jz8xVGEtoQ==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:fXx85m6a3qS0OvEIAMFSTprY//PsGCihyFcsATu6jqOu+P3BjHAkwI215J/IJ0jH7Q==,iv:r6fhFJn+E44/t7SyCuuY5WvmcMskgqv2DI710t/DNzk=,tag:LLHk95Wa3j/TvlG9Fg++fg==,type:str]
+gc_tempo_user: ENC[AES256_GCM,data:B2ylR7xOVw==,iv:k8+pJnzdBp+PCIJtK+KJ6HgW//niqqoP5BgVVdFSYjc=,tag:yDjdWDrmTQx9yKXZAM+i7Q==,type:str]
 sops:
     age:
         - recipient: age10ku4fy9jalda7pkqwmgnywjnmeqdknv0fkt5a7dgs5egk9xf7atsa6vnpa
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4Y0dUR3pQZTNhTWNDRW9h
-            aHJSMThuM01JblpTQWQrcmc4a3kwWmQ4aEhrCmU3T3ErbE93eW5NVkFycVpjRUJw
-            QStSNEFZT2lHUkhRbXIyL0NqUmtWbGMKLS0tIDhZaHI3QldFVmxtWmMxVzhWdlFJ
-            QlRUZmc2U2dGZEZxR1ZUZGV3bWcvMlEKIcP09N11sxIcMYTFmtg9thj3aIRuMJ3K
-            xsWG78fyJtz+ePJd2fK2+kh0NgMNi3DMihMFIrjUjSSf04dvVjypBw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHNVFjbyszcTZqQTZXZmFD
+            aStnY253MUJOc3VmNGRva3FnSUdqNjdSdm5nClpPeXhsUHdZZElRRmg2Ri9Bd0Y3
+            VFZZMGc2OXYzcGsvNTU4cUNpdTZUMm8KLS0tIGNiUUhGK2dkTmxiRTd3RXZEQjBR
+            NGdGU2R5cDE0Y2tkVFpGZjJteUZmUmMKzNHOifP3+9e9P/BGTXvNFb4h0TCSeX0N
+            Gj/lJgCQTcWxzqzuwfbwTeld68ynWd8R2aneioTtTZzV+QhulZi5DA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gagkvs6ur249muxexemtwumzqsvgpc74yxu7sfkhhsqyw7t8asesgsyyfn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlQVNmRWk1YUhta1BlTW5F
-            Y1ZnZC9DYWtuVjR5NUlzOXpJWWRzd29FcG0wClM4SkoxMmM3enRhSXE4L2dBSkxh
-            OEtHNy9zcG94QTFGN09RSHhsUEVvVmMKLS0tIFlleEFCNjIxZXBpMXhRS25Da1Iw
-            KzNMUzVaNHIyeGppb0EzQ2tQN2Y3WUUKJpaEtbvNEXAIWgvgxU6o9QPd6avJ5EeS
-            axlWCl5YG6fgjCxM5ryej7RrbTqVomL7c4uVpQvNaw/qi9jSNDF/bg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvTks1TE5NUlBJWFRHNW9T
+            bW1rQzFKZmFIaVBHUFdJYWtlVExlemlxSUhzCndnbnpTYTlhZFk3YStuS0RqbXBX
+            bVRKYy81Qk9EZ05uV1BTalJUTEp1VGsKLS0tIHBsdW8reDZobWs1U0RKbE1nV3B6
+            Ly9WSkJqYnZjYktyc3ZOemRRUnp3cUEKk9VhYX31EEmajcIWSnK/jBXafnxFQo2f
+            CBspjc9b25axi1gQrpKppTV4Uhtu6Ue0kYFB9yaNw0tWRDZEj/vEGw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gsw3fsp4m6shzrv9cvztagavxevzz3pdm9xdl9fk3mturkfzhc2qf4z67e
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2Z29HOGVHanY1NkhOcklQ
-            WnJtTmVJRk1leUM2ajhDTGdDRmJMYm5wb1RJClhpdFFJOWtYSjgxczZJdUl0czdj
-            UGtUays4RERsTFJwdGYwcGR0c0laSkEKLS0tIGl2SkdmV050ZUl4N1VHcmx0L0k5
-            aUN2T3hNWjdwcjNqU3dUTlAyZzFJbmsK2bTsKpT44/awG0X/saXSECmmo2e/aw50
-            g2zPnVp3MExcNYXGY2t03ndkBM0HYcZjSm5VowOzJel2eYfPWhzNMA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqdFhHZm9XSTJIQUo3TmJj
+            WHFEdDhVSTlLTGo1NUZrVEViWWU0TTZYd1dnCnphYTlHdkFMWFowSmFDRmpxeHBt
+            RHNyaWZUVU50bG5LNUJ3K0hxOUpDOTQKLS0tIDZRVDFENEFEUEdUM2pVaHJFNW04
+            aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
+            FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T18:58:29Z"
-    mac: ENC[AES256_GCM,data:lgW6DmBJVyIsRRpWD9OZkoqYRIh0hTmegcGJJJx5WSm6acWaSrtjAk0vAeSs56L8r7JT8or2qzlRIWEn1OJ6s9Mdv2qACY3ZMAPOyclK6XgLGKWYT11yRZwVNrdOGu9nMSm9qqCW6NVory5bd0eW4c/ek3MrCTxOSx9ey5RclyA=,iv:urfMm4vi3b+5HF0vL8uJ+8nKEUSinLHaALfPDPL1uJo=,tag:nEmDimpEV0+mg1C3ag7t6Q==,type:str]
+    lastmodified: "2026-05-16T03:07:07Z"
+    mac: ENC[AES256_GCM,data:Fyo65VlLrNuKylwhx5286S+u5970ksmw2KGz1JR6Y6urLZg+65sz2Q5pPK1kY0+oSpufKgyuM3PhBxKS2AtLxWx2EGhzT0mu2VwMyI8D0y81tXYeVapxpF67CrkLYwr577Z9G6u0cT4n2VpXtFlA3azQNyjQF8+2uOATj3/lHFg=,iv:yQijr/96QEKUb33CgbWsmMLh2xEDUEof9FVe3vx1NYo=,tag:RtJz5Fmwru206ektYe5XLg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/playbooks/observability.yml
+++ b/infra/ansible/playbooks/observability.yml
@@ -1,0 +1,10 @@
+---
+- name: Deploy Grafana Alloy edge agent
+  hosts: all
+  become: true
+  gather_facts: false
+  roles:
+    - role: observability_alloy
+      tags:
+        - observability
+        - alloy

--- a/infra/ansible/roles/app_container_runtime/tasks/env.yml
+++ b/infra/ansible/roles/app_container_runtime/tasks/env.yml
@@ -8,7 +8,8 @@
           'SENTRY_RELEASE': 'beat-server@' ~ (
             app_container_runtime_release_ref
             | default(commit_sha | default(image_tag | default('unknown', true), true), true)
-          )
+          ),
+          'OTLP_TRACING_ENDPOINT': 'http://alloy:4318/v1/traces'
         }
         | combine({
           (app_container_runtime_module_cfg.spring_profile | upper ~ '_ACTUATOR_PORT'): actuator_port | string,

--- a/infra/ansible/roles/app_container_runtime/tasks/env.yml
+++ b/infra/ansible/roles/app_container_runtime/tasks/env.yml
@@ -9,7 +9,7 @@
             app_container_runtime_release_ref
             | default(commit_sha | default(image_tag | default('unknown', true), true), true)
           ),
-          'OTLP_TRACING_ENDPOINT': 'http://alloy:4318/v1/traces'
+          'OTLP_TRACING_ENDPOINT': otel_otlp_tracing_endpoint
         }
         | combine({
           (app_container_runtime_module_cfg.spring_profile | upper ~ '_ACTUATOR_PORT'): actuator_port | string,

--- a/infra/ansible/roles/observability_alloy/defaults/main.yml
+++ b/infra/ansible/roles/observability_alloy/defaults/main.yml
@@ -1,0 +1,55 @@
+---
+# Grafana Alloy edge agent — defaults
+# 환경별 override는 inventories/{dev,prod}/group_vars/all/main.yml에서 처리.
+
+# Image — 2026-05 기준 latest stable (Docker Hub `latest` 태그 포인터)
+observability_alloy_image: "grafana/alloy:v1.16.1"
+observability_alloy_container_name: "alloy"
+observability_alloy_data_volume: "alloy-data"
+
+# Paths on host (where Ansible writes files)
+observability_alloy_config_dir: "/opt/beat/alloy"
+observability_alloy_secret_dir: "/opt/beat/alloy/secrets"
+
+# Paths inside container (where alloy reads files via volume mount)
+observability_alloy_container_secret_dir: "/etc/alloy/secrets"
+
+# Resource limits (dev t3.micro 1GB / prod t3a.small 2GB 기준)
+observability_alloy_mem_limit: "128m"
+observability_alloy_cpus: "0.5"
+
+# Telemetry pipeline switches (dev=metrics only, prod=full)
+observability_alloy_enable_logs: false
+observability_alloy_enable_traces: false
+observability_alloy_enable_cadvisor: false
+
+# Scraping
+observability_alloy_scrape_interval: "30s"
+observability_alloy_wal_truncate: "2h"
+
+# Cluster label (e.g. beat-dev, beat-prod) — group_vars에서 deploy_environment 기반 override
+observability_alloy_cluster: "beat-{{ deploy_environment }}"
+
+# OTLP receiver bind addresses (prod에서만 활성화됨)
+observability_alloy_otlp_grpc_addr: "0.0.0.0:4317"
+observability_alloy_otlp_http_addr: "0.0.0.0:4318"
+
+# Published ports — 호스트에 외부 노출 (default는 alloy UI만, prod override에서 OTLP 추가)
+observability_alloy_published_ports:
+  - "127.0.0.1:12345:12345"
+
+# Spring Boot scrape targets — 단일 호스트에 apis (BG: blue/green) + admin + batch
+# actuator_port와 actuator_path는 secrets.sops.yml의 app_secret_content와 동일 값
+observability_alloy_spring_targets:
+  - name: apis-blue
+    module: apis
+    color: blue
+  - name: apis-green
+    module: apis
+    color: green
+  - name: admin
+    module: admin
+    color: ""
+  - name: batch
+    module: batch
+    color: ""

--- a/infra/ansible/roles/observability_alloy/handlers/main.yml
+++ b/infra/ansible/roles/observability_alloy/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart alloy container
+  community.docker.docker_container:
+    name: "{{ observability_alloy_container_name }}"
+    restart: true
+  listen: Restart alloy container
+  when: not ansible_check_mode

--- a/infra/ansible/roles/observability_alloy/tasks/main.yml
+++ b/infra/ansible/roles/observability_alloy/tasks/main.yml
@@ -62,6 +62,10 @@
     state: started
     restart_policy: unless-stopped
     pull: true
+    # docker_container 기본 spec 비교는 privileged/volumes 같은 옵션 변경 감지 못해
+    # changed=0으로 떨어져 컨테이너 재생성 누락. strict 비교로 모든 spec 변경을 정확히 감지.
+    comparisons:
+      '*': strict
     networks:
       - name: "{{ docker_network }}"
     memory: "{{ observability_alloy_mem_limit }}"

--- a/infra/ansible/roles/observability_alloy/tasks/main.yml
+++ b/infra/ansible/roles/observability_alloy/tasks/main.yml
@@ -61,7 +61,6 @@
     image: "{{ observability_alloy_image }}"
     state: started
     restart_policy: unless-stopped
-    privileged: true
     pull: true
     networks:
       - name: "{{ docker_network }}"
@@ -74,14 +73,22 @@
       - "--storage.path=/var/lib/alloy/data"
       - "--stability.level=generally-available"
       - "/etc/alloy/config.alloy"
-    volumes:
-      - "{{ observability_alloy_config_dir }}/config.alloy:/etc/alloy/config.alloy:ro"
-      - "{{ observability_alloy_secret_dir }}:{{ observability_alloy_container_secret_dir }}:ro"
-      - "{{ observability_alloy_data_volume }}:/var/lib/alloy/data"
-      - "/proc:/host/proc:ro"
-      - "/sys:/host/sys:ro"
-      - "/:/host/rootfs:ro,rslave"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    # docker.sock은 docker discovery가 필요한 logs/cAdvisor 활성 시에만 마운트 (최소권한)
+    # privileged는 제거 — host /proc /sys 는 read-only bind mount로 node_exporter 동작 가능
+    volumes: >-
+      {{
+        [
+          observability_alloy_config_dir ~ '/config.alloy:/etc/alloy/config.alloy:ro',
+          observability_alloy_secret_dir ~ ':' ~ observability_alloy_container_secret_dir ~ ':ro',
+          observability_alloy_data_volume ~ ':/var/lib/alloy/data',
+          '/proc:/host/proc:ro',
+          '/sys:/host/sys:ro',
+          '/:/host/rootfs:ro,rslave'
+        ]
+        + (['/var/run/docker.sock:/var/run/docker.sock:ro']
+           if (observability_alloy_enable_logs | bool) or (observability_alloy_enable_cadvisor | bool)
+           else [])
+      }}
 
 - name: Wait for alloy ready endpoint
   ansible.builtin.uri:

--- a/infra/ansible/roles/observability_alloy/tasks/main.yml
+++ b/infra/ansible/roles/observability_alloy/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+- name: Ensure alloy config directory
+  ansible.builtin.file:
+    path: "{{ observability_alloy_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Ensure alloy secret directory (private)
+  ansible.builtin.file:
+    path: "{{ observability_alloy_secret_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+
+- name: Render Grafana Cloud secrets to host
+  ansible.builtin.copy:
+    content: "{{ item.value }}"
+    dest: "{{ observability_alloy_secret_dir }}/{{ item.name }}"
+    owner: root
+    group: root
+    mode: "0600"
+  loop:
+    - name: gc_token
+      value: "{{ gc_token }}"
+    - name: gc_prom_user
+      value: "{{ gc_prom_user }}"
+    - name: gc_loki_user
+      value: "{{ gc_loki_user }}"
+    - name: gc_tempo_user
+      value: "{{ gc_tempo_user }}"
+  loop_control:
+    label: "{{ item.name }}"
+  no_log: true
+  notify: Restart alloy container
+
+- name: Render alloy config
+  ansible.builtin.template:
+    src: config.alloy.j2
+    dest: "{{ observability_alloy_config_dir }}/config.alloy"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart alloy container
+
+- name: Ensure alloy data volume exists
+  community.docker.docker_volume:
+    name: "{{ observability_alloy_data_volume }}"
+    state: present
+
+- name: Ensure beat docker network exists
+  community.docker.docker_network:
+    name: "{{ docker_network }}"
+    state: present
+
+- name: Start alloy edge agent
+  community.docker.docker_container:
+    name: "{{ observability_alloy_container_name }}"
+    image: "{{ observability_alloy_image }}"
+    state: started
+    restart_policy: unless-stopped
+    privileged: true
+    pull: true
+    networks:
+      - name: "{{ docker_network }}"
+    memory: "{{ observability_alloy_mem_limit }}"
+    cpus: "{{ observability_alloy_cpus }}"
+    published_ports: "{{ observability_alloy_published_ports }}"
+    command:
+      - "run"
+      - "--server.http.listen-addr=0.0.0.0:12345"
+      - "--storage.path=/var/lib/alloy/data"
+      - "--stability.level=generally-available"
+      - "/etc/alloy/config.alloy"
+    volumes:
+      - "{{ observability_alloy_config_dir }}/config.alloy:/etc/alloy/config.alloy:ro"
+      - "{{ observability_alloy_secret_dir }}:{{ observability_alloy_container_secret_dir }}:ro"
+      - "{{ observability_alloy_data_volume }}:/var/lib/alloy/data"
+      - "/proc:/host/proc:ro"
+      - "/sys:/host/sys:ro"
+      - "/:/host/rootfs:ro,rslave"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+- name: Wait for alloy ready endpoint
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:12345/-/ready"
+    status_code: 200
+  register: alloy_ready
+  retries: 15
+  delay: 2
+  until: alloy_ready.status == 200

--- a/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -211,9 +211,12 @@ otelcol.receiver.otlp "apps" {
 }
 
 otelcol.processor.tail_sampling "policy" {
+  // BEAT 트래픽 실측 기반 보수적 buffer. trace당 평균 5 spans 가정 시 25k spans (~50MB).
+  // expected_new_traces_per_sec는 평상시 10~30 추정, 50으로 여유.
+  // 실측 후 부족하면 num_traces 단계적 증액.
   decision_wait               = "10s"
-  num_traces                  = 50000
-  expected_new_traces_per_sec = 200
+  num_traces                  = 5000
+  expected_new_traces_per_sec = 50
 
   policy {
     name = "errors"

--- a/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -1,0 +1,256 @@
+// =============================================================================
+// Grafana Alloy edge agent — BEAT
+// Rendered by ansible role observability_alloy
+// env={{ deploy_environment }} cluster={{ observability_alloy_cluster }} host={{ inventory_hostname }}
+// =============================================================================
+
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+// -----------------------------------------------------------------------------
+// 1. Secrets (호스트에 root:0600 으로 떨어진 파일 참조)
+// -----------------------------------------------------------------------------
+// token은 진짜 secret. user IDs는 numeric ID라 plain string 필드에 직접 들어가야 함 (is_secret=false)
+local.file "gc_token" {
+  filename  = "{{ observability_alloy_container_secret_dir }}/gc_token"
+  is_secret = true
+}
+
+local.file "gc_prom_user" {
+  filename  = "{{ observability_alloy_container_secret_dir }}/gc_prom_user"
+  is_secret = false
+}
+
+{% if observability_alloy_enable_logs %}
+local.file "gc_loki_user" {
+  filename  = "{{ observability_alloy_container_secret_dir }}/gc_loki_user"
+  is_secret = false
+}
+{% endif %}
+{% if observability_alloy_enable_traces %}
+local.file "gc_tempo_user" {
+  filename  = "{{ observability_alloy_container_secret_dir }}/gc_tempo_user"
+  is_secret = false
+}
+{% endif %}
+
+// -----------------------------------------------------------------------------
+// 2. Host metrics — node_exporter 대체 (Alloy 내장 unix exporter)
+// -----------------------------------------------------------------------------
+prometheus.exporter.unix "node" {
+  rootfs_path = "/host/rootfs"
+  procfs_path = "/host/proc"
+  sysfs_path  = "/host/sys"
+  disable_collectors = ["wifi", "ipvs", "infiniband", "btrfs", "zfs"]
+}
+
+prometheus.scrape "node" {
+  targets         = prometheus.exporter.unix.node.targets
+  scrape_interval = "{{ observability_alloy_scrape_interval }}"
+  forward_to      = [prometheus.relabel.cleanup.receiver]
+}
+
+{% if observability_alloy_enable_cadvisor %}
+// -----------------------------------------------------------------------------
+// 3. Container metrics — cAdvisor 대체 (prod only)
+// -----------------------------------------------------------------------------
+prometheus.exporter.cadvisor "containers" {
+  docker_host = "unix:///var/run/docker.sock"
+  storage_duration = "5m"
+}
+
+prometheus.scrape "containers" {
+  targets         = prometheus.exporter.cadvisor.containers.targets
+  scrape_interval = "{{ observability_alloy_scrape_interval }}"
+  forward_to      = [prometheus.relabel.cleanup.receiver]
+}
+{% endif %}
+
+// -----------------------------------------------------------------------------
+// 4. Spring Boot Actuator scrape — 정적 target, BG 미동작 색은 up=0 으로 처리
+// -----------------------------------------------------------------------------
+prometheus.scrape "spring_boot" {
+  targets = [
+{% for t in observability_alloy_spring_targets %}
+    { __address__ = "{{ t.name }}:{{ actuator_port }}", job = "{{ t.module }}", module = "{{ t.module }}"{% if t.color %}, color = "{{ t.color }}"{% endif %} },
+{% endfor %}
+  ]
+  metrics_path    = "{{ actuator_path }}/prometheus"
+  scrape_interval = "{{ observability_alloy_scrape_interval }}"
+  forward_to      = [prometheus.relabel.cleanup.receiver]
+}
+
+// -----------------------------------------------------------------------------
+// 5. Cardinality 보호 (drop high-cardinality 시리즈/라벨)
+// -----------------------------------------------------------------------------
+prometheus.relabel "cleanup" {
+  rule {
+    source_labels = ["__name__"]
+    regex         = "jvm_(buffer_pool|memory_pool|classes_unloaded)_.*"
+    action        = "drop"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex         = "tomcat_(global|cache|servlet)_.*"
+    action        = "drop"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex         = "container_(cpu_schedstat|hugetlb|fs_inodes|memory_failures)_.*"
+    action        = "drop"
+  }
+  rule {
+    source_labels = ["__name__", "le"]
+    separator     = ";"
+    regex         = "http_server_requests_seconds_bucket;(0\\.01|0\\.025|0\\.05|10\\.0|30\\.0).*"
+    action        = "drop"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "(exception|outcome|instance_name)"
+  }
+
+  forward_to = [prometheus.remote_write.gc.receiver]
+}
+
+// -----------------------------------------------------------------------------
+// 6. Remote write → Grafana Cloud Prometheus
+// -----------------------------------------------------------------------------
+prometheus.remote_write "gc" {
+  external_labels = {
+    env     = "{{ deploy_environment }}",
+    cluster = "{{ observability_alloy_cluster }}",
+    host    = "{{ inventory_hostname }}",
+  }
+  endpoint {
+    url = "{{ gc_prom_url }}"
+    basic_auth {
+      username = local.file.gc_prom_user.content
+      password = local.file.gc_token.content
+    }
+    queue_config {
+      max_shards           = 8
+      capacity             = 10000
+      max_samples_per_send = 2000
+    }
+  }
+  wal {
+    truncate_frequency = "{{ observability_alloy_wal_truncate }}"
+  }
+}
+
+{% if observability_alloy_enable_logs %}
+// -----------------------------------------------------------------------------
+// 7. Docker stdout/stderr → Loki (prod only)
+// -----------------------------------------------------------------------------
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.docker.containers.targets
+  labels = {
+    env     = "{{ deploy_environment }}",
+    cluster = "{{ observability_alloy_cluster }}",
+    host    = "{{ inventory_hostname }}",
+  }
+  forward_to = [loki.process.module.receiver]
+}
+
+loki.process "module" {
+  // 컨테이너 이름에서 module 라벨 추출 (회귀 안전 패턴)
+  //  - apis-blue / apis-green → apis
+  //  - admin / batch / nginx → 그대로
+  //  - beat-prod-redis / redis → redis (prod의 환경 prefix 허용)
+  //  - mysql → mysql
+  stage.regex {
+    expression = "^/.*?(?P<module>apis|admin|batch|mysql|redis|nginx).*$"
+    source     = "__meta_docker_container_name"
+  }
+  stage.labels {
+    values = {
+      module = "",
+    }
+  }
+  // stale stream 자동 drop
+  stage.drop {
+    older_than          = "12h"
+    drop_counter_reason = "stale"
+  }
+  forward_to = [loki.write.gc.receiver]
+}
+
+loki.write "gc" {
+  endpoint {
+    url = "{{ gc_loki_url }}"
+    basic_auth {
+      username = local.file.gc_loki_user.content
+      password = local.file.gc_token.content
+    }
+  }
+}
+{% endif %}
+
+{% if observability_alloy_enable_traces %}
+// -----------------------------------------------------------------------------
+// 8. OTLP traces 수신 + tail sampling → Grafana Cloud Tempo (prod only)
+// -----------------------------------------------------------------------------
+otelcol.receiver.otlp "apps" {
+  grpc {
+    endpoint = "{{ observability_alloy_otlp_grpc_addr }}"
+  }
+  http {
+    endpoint = "{{ observability_alloy_otlp_http_addr }}"
+  }
+  output {
+    traces = [otelcol.processor.tail_sampling.policy.input]
+  }
+}
+
+otelcol.processor.tail_sampling "policy" {
+  decision_wait               = "10s"
+  num_traces                  = 50000
+  expected_new_traces_per_sec = 200
+
+  policy {
+    name = "errors"
+    type = "status_code"
+    status_code {
+      status_codes = ["ERROR"]
+    }
+  }
+  policy {
+    name = "slow"
+    type = "latency"
+    latency {
+      threshold_ms = 1000
+    }
+  }
+  policy {
+    name = "sample"
+    type = "probabilistic"
+    probabilistic {
+      sampling_percentage = 10
+    }
+  }
+
+  output {
+    traces = [otelcol.exporter.otlp.gc.input]
+  }
+}
+
+otelcol.exporter.otlp "gc" {
+  client {
+    endpoint = "{{ gc_tempo_endpoint }}"
+    auth     = otelcol.auth.basic.gc.handler
+  }
+}
+
+otelcol.auth.basic "gc" {
+  username = local.file.gc_tempo_user.content
+  password = local.file.gc_token.content
+}
+{% endif %}

--- a/observability/build.gradle.kts
+++ b/observability/build.gradle.kts
@@ -10,6 +10,9 @@ dependencies {
     runtimeOnly(libs.sentry.async.profiler)
     runtimeOnly(libs.sentry.log4j2)
 
+    implementation(libs.micrometer.tracing.bridge.otel)
+    implementation(libs.opentelemetry.exporter.otlp)
+
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.spring.boot.starter.web)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/observability/src/main/resources/application-observability.yml
+++ b/observability/src/main/resources/application-observability.yml
@@ -21,6 +21,31 @@ management:
       export:
         enabled: true
 
+  metrics:
+    tags:
+      application: ${spring.application.name}
+      module: ${spring.application.name}
+      env: ${spring.profiles.active:unknown}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      slo:
+        http.server.requests: 100ms, 200ms, 500ms, 1s, 2s
+      percentiles:
+        http.server.requests: 0.95, 0.99
+
+  tracing:
+    enabled: ${MANAGEMENT_TRACING_ENABLED:false}
+    sampling:
+      probability: ${MANAGEMENT_TRACING_SAMPLING:1.0}
+    propagation:
+      type: W3C
+  otlp:
+    tracing:
+      endpoint: ${OTLP_TRACING_ENDPOINT:http://localhost:4318/v1/traces}
+      transport: http
+      timeout: 10s
+
 logging:
   level:
     root: info
@@ -36,11 +61,11 @@ sentry:
   send-default-pii: true
   logs:
     enabled: true
-  traces-sample-rate: ${SENTRY_TRACES_SAMPLE_RATE:1.0}
-  profile-session-sample-rate: ${SENTRY_PROFILE_SESSION_SAMPLE_RATE:1.0}
+  traces-sample-rate: 0.0
+  profile-session-sample-rate: 0.0
   profile-lifecycle: TRACE
   metrics:
-    enabled: ${SENTRY_METRICS_ENABLED:true}
+    enabled: false
 
 ---
 spring:
@@ -54,13 +79,15 @@ management:
   endpoints:
     web:
       base-path: ${DEV_ACTUATOR_PATH}
+  tracing:
+    enabled: false
 
 sentry:
   environment: dev
-  traces-sample-rate: ${DEV_SENTRY_TRACES_SAMPLE_RATE:1.0}
-  profile-session-sample-rate: ${DEV_SENTRY_PROFILE_SESSION_SAMPLE_RATE:1.0}
+  traces-sample-rate: 0.0
+  profile-session-sample-rate: 0.0
   metrics:
-    enabled: ${DEV_SENTRY_METRICS_ENABLED:true}
+    enabled: false
 
 ---
 spring:
@@ -74,13 +101,17 @@ management:
   endpoints:
     web:
       base-path: ${PROD_ACTUATOR_PATH}
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0
 
 sentry:
   environment: prod
-  traces-sample-rate: ${PROD_SENTRY_TRACES_SAMPLE_RATE:1.0}
-  profile-session-sample-rate: ${PROD_SENTRY_PROFILE_SESSION_SAMPLE_RATE:1.0}
+  traces-sample-rate: 0.0
+  profile-session-sample-rate: 0.0
   metrics:
-    enabled: ${PROD_SENTRY_METRICS_ENABLED:true}
+    enabled: false
 
 ---
 spring:
@@ -94,6 +125,8 @@ management:
   endpoints:
     web:
       base-path: /actuator-test
+  tracing:
+    enabled: false
 
 sentry:
   dsn: ""

--- a/observability/src/main/resources/application-observability.yml
+++ b/observability/src/main/resources/application-observability.yml
@@ -24,7 +24,6 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
-      module: ${spring.application.name}
       env: ${spring.profiles.active:unknown}
     distribution:
       percentiles-histogram:

--- a/observability/src/main/resources/log4j2-spring.xml
+++ b/observability/src/main/resources/log4j2-spring.xml
@@ -2,13 +2,13 @@
 <Configuration status="INFO">
     <Properties>
         <Property name="LOG_PATTERN">
-            %style{%d{yyyy-MM-dd HH:mm:ss,SSS}}{blue} %highlight{[%-5p]}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=bright_blue, TRACE=cyan} [%t] [traceId=%equals{%X{traceId}}{}{NO_TRACE}] [userId=%equals{%X{userId}}{}{GUEST}] [clientIp=%equals{%X{clientIp}}{}{UNKNOWN}] [request=%equals{%X{requestInfo}}{}{NO_REQUEST}] [route=%equals{%X{routePattern}}{}{NO_ROUTE}] %style{[%c{1}.%M():%L]}{BRIGHT_BLACK} - %m%n
+            %style{%d{yyyy-MM-dd HH:mm:ss,SSS}}{blue} %highlight{[%-5p]}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green, DEBUG=bright_blue, TRACE=cyan} [%t] %style{[traceId=%equals{%X{traceId}}{}{NO_TRACE}]}{cyan} %style{[spanId=%equals{%X{spanId}}{}{NO_SPAN}]}{bright_blue} %style{[userId=%equals{%X{userId}}{}{GUEST}]}{yellow} %style{[clientIp=%equals{%X{clientIp}}{}{UNKNOWN}]}{magenta} %style{[request=%equals{%X{requestInfo}}{}{NO_REQUEST}]}{green} %style{[route=%equals{%X{routePattern}}{}{NO_ROUTE}]}{bright_green} %style{[%c{1}.%M():%L]}{BRIGHT_BLACK} - %m%n
         </Property>
     </Properties>
 
     <Appenders>
         <Console name="ConsoleAppender" target="SYSTEM_OUT">
-            <PatternLayout pattern="${LOG_PATTERN}"/>
+            <PatternLayout pattern="${LOG_PATTERN}" disableAnsi="${env:LOG_DISABLE_ANSI:-false}"/>
         </Console>
         <Sentry name="SentryAppender" minimumBreadcrumbLevel="INFO" minimumEventLevel="ERROR" minimumLevel="INFO"/>
     </Appenders>

--- a/observability/src/test/kotlin/com/beat/observability/logging/Log4j2PatternContractTest.kt
+++ b/observability/src/test/kotlin/com/beat/observability/logging/Log4j2PatternContractTest.kt
@@ -12,6 +12,7 @@ class Log4j2PatternContractTest {
         val log4j2 = Files.readString(Path.of("src/main/resources/log4j2-spring.xml"))
 
         assertTrue(log4j2.contains("[traceId=%equals{%X{traceId}}{}{NO_TRACE}]"))
+        assertTrue(log4j2.contains("[spanId=%equals{%X{spanId}}{}{NO_SPAN}]"))
         assertTrue(log4j2.contains("[userId=%equals{%X{userId}}{}{GUEST}]"))
         assertTrue(log4j2.contains("[clientIp=%equals{%X{clientIp}}{}{UNKNOWN}]"))
         assertTrue(log4j2.contains("[request=%equals{%X{requestInfo}}{}{NO_REQUEST}]"))


### PR DESCRIPTION
## Summary

- BEAT-SERVER에 **Grafana Cloud Free Tier + Alloy edge agent 기반 observability 파이프라인** 도입

- 단일 GC stack(Japan ap-northeast-1)에 dev/prod 통합, 환경 격리는 외부 라벨로 관리

- dev = metrics-only / prod = full (metrics + logs + traces + cAdvisor)

- 4–7k active series 한도 안에서 \$0 운영 (카드 미등록, 한도 초과 자동 drop)

- Sentry는 errors 전용 유지 (traces/profiles off → Tempo가 distributed tracing 단독 담당)

## Why

- 사내 모니터링 VM이 956MiB RAM + swap 2GiB 환경으로 self-host LGTM 풀스택 운영 불가

- BEAT 트래픽 규모(active series 추정 4–7k)가 Grafana Cloud Free Tier(10k series, 50GB logs/traces, 14일 보존) 범위 내

- dev t3.micro에 full observability self-host는 메모리 비효율 → edge agent(80MB)만 운영하는 구조가 합리적

## Key changes

### Spring Boot

- `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp` 의존성 추가

- `management.tracing.enabled` 환경별 분기 (dev=false, prod=true)

- HTTP server SLO bucket 축소 (100ms / 200ms / 500ms / 1s / 2s)

- Spring common tag에서 `module` 제거 (Alloy scrape config를 SoT로 유지)

- admin 모듈에 누락된 `beat.prometheus-runtime` plugin 적용 (Prometheus endpoint 자동 등록 누락 fix)

### Alloy (`infra/ansible/roles/observability_alloy`)

- `prometheus.exporter.unix` (node)

- `prometheus.exporter.cadvisor` (prod only)

- `prometheus.scrape` spring_boot

- `prometheus.relabel` cleanup

  - high-cardinality drop:

    - `jvm_buffer_pool`

    - `jvm_memory_pool`

    - `jvm_classes_unloaded`

    - `tomcat_global/cache/servlet`

    - `container_cpu_schedstat`

    - 일부 HTTP bucket

- `prometheus.remote_write` → Grafana Cloud (Tokyo)

- `loki.source.docker` → Grafana Cloud Loki (prod only)

- `otelcol.receiver.otlp`

- tail sampling

  - errors/slow requests = 100%

  - others = 10%

- `privileged` 제거

- `docker.sock` 조건부 마운트

- docker_container `comparisons: '*': strict` 적용 — spec drift 정확 감지

### Container runtime

- app 컨테이너에 `OTLP_TRACING_ENDPOINT` 환경변수 주입

- (`infra/ansible/roles/app_container_runtime/tasks/env.yml`)

- inventory 변수 `otel_otlp_tracing_endpoint`로 추상화

### GitHub Actions

- `deploy-observability-dev.yml`

  - develop push

  - paths-filter

  - workflow_dispatch

- `deploy-observability-prod.yml`

  - workflow_dispatch only

  - origin/main ancestor 검증

### Environment differences

| Item | dev | prod |
|---|---|---|
| mem_limit | 128m | 256m |
| cpus | 0.5 | 1.0 |
| scrape | 60s | 30s |
| WAL | 1h | 12h |
| logs/traces/cadvisor | off | on |
| OTLP receiver | hidden | 127.0.0.1:4317/4318 |

## Verification (dev complete)

- alloy 컨테이너 `Up`, `/-/ready` OK

- `Privileged=false`

- mounts 6개 확인 (`docker.sock` 제외)

- `prometheus_remote_storage_samples_total` 누적 35k+, failed=0

- scrape 사이클 정상

  - node: 60s

  - spring_boot: 60s × 4 targets

- admin `/47a9d6bf-.../prometheus` → HTTP 200 (기존 404 해결)

- admin/apis-green/batch 모두:

  - `OTLP_TRACING_ENDPOINT=http://alloy:4318/v1/traces`

- Grafana Cloud Explore:

  - `up{cluster="beat-dev"}`

  - apis(green)=1

  - admin=1

  - batch=1

  - node=1

  - apis(blue)=0

- module label 정리 완료

  - `apis`

  - `admin`

  - `batch`

- Cardinality 안정 확인

  - 최고 195 series (`http_server_requests_seconds_bucket`)

  - URI cardinality 안전 (`UNKNOWN`, `/api/main` 수준)

## CodeRabbit feedback addressed

| Review | Commit |
|---|---|
| #1 OTLP endpoint hardcoded → inventory variable | `6670e1c2` |
| #2 alloy privileged + unconditional docker.sock | `a608ae2f` |
| #3 Spring common tag module = application | `733870b6` |

## Post-merge plan

1. develop merge 시 자동 트리거

   - `deploy-dev.yml`

   - `deploy-observability-dev.yml`

2. develop → main merge 후 release tag `vX.Y.Z` publish

   - `deploy-prod.yml` 자동 실행

3. `deploy-observability-prod.yml` 수동 dispatch

   - 동일 commit SHA 입력

4. prod 검증

   - `up{cluster="beat-prod"}`

   - traces/logs ingestion

   - Sentry errors-only 확인

5. Grafana Cloud dashboard + alert rule 구성

   - `absent(up)` alloy down alert 포함

6. 24–72h Free Tier usage 추적

7. 24h 후 cardinality 및 tail sampling buffer 재조정

## Test plan

- [x] ansible-lint production profile pass (39 files)

- [x] dev observability.yml 실배포 + alloy ready endpoint

- [x] admin prometheus endpoint HTTP 200

- [x] alloy → Grafana Cloud remote_write 성공 (`failed=0`)

- [x] `OTLP_TRACING_ENDPOINT` 환경변수 주입 확인

- [x] module label 정리 확인

- [x] privileged 제거 후 node_exporter 정상 동작

- [x] CI 전체 통과 (lint / scan-images / verify / verify-dev)

- [ ] prod 배포 후 `up{cluster="beat-prod"}` 검증

- [ ] prod Tempo trace + Loki log 도달

- [ ] Grafana Cloud dashboard + alert rule 셋업

- [ ] 24h 후 Free Tier usage 추세 확인