### PR TITLE
chore: prod EC2 ARM64 마이그레이션 선행 작업

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -150,6 +150,12 @@ jobs:
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -174,14 +180,13 @@ jobs:
         env:
           MODULE: ${{ matrix.module }}
         run: |
-          docker build -f Dockerfile.module \
+          docker buildx build -f Dockerfile.module \
             --build-arg MODULE=${MODULE} \
-            --platform linux/amd64 \
+            --platform linux/arm64 \
             -t "${{ steps.image.outputs.image }}" \
             -t "${{ steps.image.outputs.latest }}" \
+            --push \
             .
-          docker push "${{ steps.image.outputs.image }}"
-          docker push "${{ steps.image.outputs.latest }}"
 
   foundation:
     needs:

--- a/infra/README.md
+++ b/infra/README.md
@@ -1338,7 +1338,7 @@ ansible-playbook playbooks/rollback.yml -i inventories/prod/hosts.yml --syntax-c
 | 배포 트리거      | develop push / workflow_dispatch           | release.published (자동, shared tag)              |
 | 이미지 태그      | `dev-{resolved_sha}` + `dev-latest`        | `{release_tag}` (예: `v1.2.3`) + `prod-latest`   |
 | MySQL       | Docker 컨테이너 (foundation)                   | 비활성 (`foundation_mysql_enabled: false`, 외부 RDS) |
-| Redis 컨테이너명 | `redis`                                    | `beat-prod-redis`                               |
+| Redis 컨테이너명 | `redis`                                    | `redis`                                         |
 | 도메인         | `secrets.sops.yml`의 `nginx_server_name` 참조 | 동일                                              |
 | 롤백          | rollback-dev.yml (수동 rehearsal/복구)           | rollback-prod.yml (수동)                          |
 | concurrency | dev runtime target lock + `queue: max` (source ref와 무관) | `prod-runtime` + `queue: max` (전역 락)             |

--- a/infra/ansible/inventories/prod/group_vars/all/main.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/main.yml
@@ -44,7 +44,7 @@ mysql_container_name: mysql
 mysql_data_volume_name: mysql-data
 
 redis_image: redis:alpine
-redis_container_name: beat-prod-redis
+redis_container_name: redis
 redis_conf_path: /home/ubuntu/redis.conf
 redis_data_volume_name: redis-data
 
@@ -93,6 +93,8 @@ observability_alloy_published_ports:
   - "127.0.0.1:12345:12345"
   - "127.0.0.1:4317:4317"
   - "127.0.0.1:4318:4318"
+
+letsencrypt_cron_enabled: true
 
 # Spring Boot OTel exporter endpoint (app 컨테이너에 환경변수로 주입)
 otel_otlp_tracing_endpoint: "http://alloy:4318/v1/traces"

--- a/infra/ansible/playbooks/foundation.yml
+++ b/infra/ansible/playbooks/foundation.yml
@@ -36,6 +36,10 @@
       tags:
         - foundation
         - nginx
+    - role: letsencrypt_cron
+      tags:
+        - foundation
+        - letsencrypt
 
   post_tasks:
     - name: Mark foundation as applied

--- a/infra/ansible/roles/letsencrypt_cron/defaults/main.yml
+++ b/infra/ansible/roles/letsencrypt_cron/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+letsencrypt_cron_enabled: false
+
+letsencrypt_cron_certbot_image: "certbot/certbot"
+letsencrypt_cron_conf_dir: "{{ certbot_conf_dir }}"
+letsencrypt_cron_www_dir: "{{ certbot_www_dir }}"
+letsencrypt_cron_nginx_container: "{{ nginx_container_name }}"
+
+# 매월 20일 00:00 실행 (갱신 유효기간 90일 기준 안전 주기)
+letsencrypt_cron_minute: "0"
+letsencrypt_cron_hour: "0"
+letsencrypt_cron_day: "20"
+letsencrypt_cron_month: "*"
+letsencrypt_cron_weekday: "*"

--- a/infra/ansible/roles/letsencrypt_cron/tasks/main.yml
+++ b/infra/ansible/roles/letsencrypt_cron/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Manage certbot renewal cron
+  ansible.builtin.cron:
+    name: certbot-renew
+    state: "{{ 'present' if letsencrypt_cron_enabled | bool else 'absent' }}"
+    user: root
+    minute: "{{ letsencrypt_cron_minute }}"
+    hour: "{{ letsencrypt_cron_hour }}"
+    day: "{{ letsencrypt_cron_day }}"
+    month: "{{ letsencrypt_cron_month }}"
+    weekday: "{{ letsencrypt_cron_weekday }}"
+    job: >-
+      docker run --rm
+      -v {{ letsencrypt_cron_conf_dir }}:/etc/letsencrypt
+      -v {{ letsencrypt_cron_www_dir }}:/var/www/certbot
+      {{ letsencrypt_cron_certbot_image }} renew
+      && docker exec {{ letsencrypt_cron_nginx_container }} nginx -s reload

--- a/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -163,9 +163,7 @@ loki.source.docker "containers" {
 loki.process "module" {
   // 컨테이너 이름에서 module 라벨 추출 (회귀 안전 패턴)
   //  - apis-blue / apis-green → apis
-  //  - admin / batch / nginx → 그대로
-  //  - beat-prod-redis / redis → redis (prod의 환경 prefix 허용)
-  //  - mysql → mysql
+  //  - admin / batch / nginx / redis / mysql → 그대로
   stage.regex {
     expression = "^/.*?(?P<module>apis|admin|batch|mysql|redis|nginx).*$"
     source     = "__meta_docker_container_name"


### PR DESCRIPTION
## Related issue 🛠

- closes #475

## Work Description ✏️

## 작업 목적

prod EC2를 t3a.small(x86_64) → t4g.small(ARM64 Graviton2)로 전환하기 위한 Phase 1 선행 작업이다.

실제 인스턴스 교체 전에 GHA 빌드 플랫폼, 운영 설정, 인증서 갱신 자동화를 정비한다.

## 주요 변경 사항

### GHA 빌드 플랫폼 (`deploy-prod.yml`)

- `docker/setup-qemu-action@v4.0.0` + `docker/setup-buildx-action@v4.0.0` 추가
- `docker build --platform linux/amd64` → `docker buildx build --platform linux/arm64 --push`
- 별도 `docker push` 제거 (buildx `--push` 인라인 처리)

### prod inventory

- `redis_container_name: beat-prod-redis` → `redis` (dev와 통일)
- `letsencrypt_cron_enabled: true` 추가

### `letsencrypt_cron` Ansible role (신규)

- `defaults/main.yml` — 변수 기본값 (`enabled: false`, 매월 20일 00:00)
- `tasks/main.yml` — `ansible.builtin.cron` present/absent 토글로 관리
- `foundation.yml`에 role 추가

기존 서버의 수동 crontab:
```
0 0 20 * * docker run --rm \
  -v /home/ubuntu/data/certbot/conf:/etc/letsencrypt \
  -v /home/ubuntu/data/certbot/www:/var/www/certbot \
  certbot/certbot renew \
  && docker exec nginx nginx -s reload
```
을 Ansible로 코드화하여 새 인스턴스 구성 시 자동 적용.

### 기타

- `config.alloy.j2`: 더 이상 사용하지 않는 `beat-prod-redis` 주석 정리
- `infra/README.md`: Redis 컨테이너명 비교 표 업데이트

## 빌드 플랫폼 결정 근거

| 옵션 | dev | prod | 결정 이유 |
|------|-----|------|----------|
| amd64 only | amd64 | amd64 (에뮬레이션 실행) | prod 런타임 오버헤드 |
| **환경별 분리** | **amd64** | **arm64 (QEMU 크로스빌드)** | **선택** |
| multi-arch | amd64+arm64 | amd64+arm64 | 빌드 시간 2배+ |
| ARM self-hosted | — | native arm64 | public repo 보안 위험으로 거부 |

GitHub-hosted ARM runner는 TEAM 플랜에서 self-hosted만 지원 → public repo에 부적합.

## Test plan

- [x] ansible-lint production profile pass
- [ ] prod 인스턴스 교체 후 arm64 이미지 정상 기동
- [ ] `docker inspect` 확인 — `Architecture: arm64`
- [ ] `up{cluster="beat-prod"}` 전체 1
- [ ] certbot cron 등록 확인 (`sudo crontab -l`)