### PR TITLE
chore: prod ssh_host_fingerprint t4g.small 갱신

### DIFF
--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -10,7 +10,7 @@ mysql_password: ENC[AES256_GCM,data:B32tq3bhoI6BlCx6/IbNcg==,iv:0m7vNSDof6LSsqqJ
 mysql_root_password: ENC[AES256_GCM,data:JbrgQjNhWKxF4hdGfU9FHg==,iv:uY27LD51Fxjv6krfg4EAeM8cQTI0lUO+STalrBYtr2c=,tag:JnQ+5Rsz4TXjv+fdWCwEow==,type:str]
 mysql_user: ENC[AES256_GCM,data:XKX1Y/swC7qTSbAj6BWYtA==,iv:WWlvLpI/Spo7cO/rwx9Rnmeg8uB46ssPovCHRZGPNAk=,tag:pfRQt6xQZJNLs+UK5+iqQA==,type:str]
 nginx_server_name: ENC[AES256_GCM,data:CXjctB7cIkGTqcICW5kN,iv:6+OrNNb6+I8iDZvya5B2TEEk7v9c5533auY5It775Zw=,tag:wpwuq2rL2UuumkIkc7S57g==,type:str]
-ssh_host_fingerprint: ENC[AES256_GCM,data:tpZqAUYwR7drHjC1H4MRWUydh27kUaytIEm8+dbPhOryTBoDVgudD9TffmSE1SINEZQ=,iv:J2JTuTTyKJBgmrgMmK4SeUHKHUbrKB4BTnbe9iy683E=,tag:DmthMTOfrDQ9nFz0W3OwMQ==,type:str]
+ssh_host_fingerprint: ENC[AES256_GCM,data:Vgu8yFFK+xWVlqQNReODVIWrK2bK19DJT7N5Ms4lCkrzQF03b0UG3TVln9Cge9DIMhQ=,iv:W4Tv/EN/Gn/gbLU7rZeIMIRmenovVXC0wqbL9C91aFc=,tag:YKXOhdjPouYk4ZureGy65w==,type:str]
 #ENC[AES256_GCM,data:VvvXU9MO4Wcad85D6TNsBojDpC2BsJ429okWf4qlFJOdL6EIv6mI+ZDyVO2NhxnvlPv1lDLKwCGeUAxMwo82uecuqjrZbuwb7hR5Ypb3UoujZG1+Ouy9EeryM0E6j+yF,iv:QCHhaOWNKMiLLxAjRavcnq0MNhjJUFHKhGREkFBUd60=,tag:3rRxP6pR1f9tQsXo5zWFZQ==,type:comment]
 #ENC[AES256_GCM,data:+ErvmzVWqGUD/UymkiESkmC1Y5dZSDpwg2lcvZm3NMJGKA9NgWkYFF7s2/s4gyj1DE/mBGFBkJvPL9tFgaabtWH7SED9eQTB9A2F0CVu,iv:wGFCFfH9FfMt+Rxoge/S0LlX4e7K78LvTRo8t/6i+I4=,tag:dL23OJlx1EE6wahrBZK/mw==,type:comment]
 gc_token: ENC[AES256_GCM,data:nxXQqDI187bQjgHwewGbuxuYOhKCJNe0LGQRHWvv9blgXiEVeKxXLrmEcO5AdQsDtBXzTuGB+th7f2sbqb8AF9HA1c53ZHgM7Q/3p1D+lR4FJVUkjRFE9dPwH7IwXiQwmJFA/evFRc5UVGU5Qo+Kwrw0f02YTRzzEUgYVXbGuQ4sEcFNdAseGcURtn0EY/zUfHewGg==,iv:GpwuWVpES9lbg8uhXs3SYELy+OloMvrbOEfLVzTHybk=,tag:CGQkw7R3vPFBoV3l6/5YzA==,type:str]
@@ -49,7 +49,7 @@ sops:
             aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
             FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-16T03:07:07Z"
-    mac: ENC[AES256_GCM,data:Fyo65VlLrNuKylwhx5286S+u5970ksmw2KGz1JR6Y6urLZg+65sz2Q5pPK1kY0+oSpufKgyuM3PhBxKS2AtLxWx2EGhzT0mu2VwMyI8D0y81tXYeVapxpF67CrkLYwr577Z9G6u0cT4n2VpXtFlA3azQNyjQF8+2uOATj3/lHFg=,iv:yQijr/96QEKUb33CgbWsmMLh2xEDUEof9FVe3vx1NYo=,tag:RtJz5Fmwru206ektYe5XLg==,type:str]
+    lastmodified: "2026-05-17T03:50:08Z"
+    mac: ENC[AES256_GCM,data:08W4LF/OLUmvbw/VkiTCK7dch6vSOD/5HPG8mlLiiizfe8UOFKFy5gTluNDcfygGODe+l61kWOLhDRr1Lb7nVEKbjyr7Dh9zIdNFMuq/ouUMGojqW1ebB6H+2rOMRsOL/nWhQ47474IDOtzckWUh3NOl0exBK49tPn3Iz7/mejE=,iv:320ju0JVVbrN/hYVDV7vC4qhoT2cn2nHCGVWvVy3hfs=,tag:uM47ozp/X9XTm7/e3n8tyQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Related issue 🛠

- #477 (prod V2 전환 배포 체크리스트)
- #475 (t4g.small ARM64 마이그레이션)

## Work Description ✏️

## 작업 목적

prod EC2를 t3a.small → t4g.small로 교체함에 따라 SSH 호스트 키가 변경되어 SOPS `ssh_host_fingerprint`를 갱신한다.

## 주요 변경 사항

- `infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml`
  - `ssh_host_fingerprint` 교체
  - 구: `SHA256:59JdVKAg7DwzyOO2TbXVss+gXXUvkC7tHXagdFdMLIs` (t3a.small)
  - 신: `SHA256:od2gyJb/b3oXkYQ3yJz8ydFueqT8gpsZqVjlagBmE94` (t4g.small)

## 검증

```bash
ssh-keyscan -t ed25519 43.203.189.83 2>/dev/null | ssh-keygen -lf - -E sha256
# SHA256:od2gyJb/b3oXkYQ3yJz8ydFueqT8gpsZqVjlagBmE94
```

## Test plan

- [x] `ssh-keyscan`으로 새 서버 fingerprint 직접 확인
- [x] `sops -d` 복호화 후 값 일치 확인
- [ ] EIP 전환 후 `deploy-prod.yml` SSH 접속 성공 확인