### PR TITLE
chore: prod build-image을 ARM 네이티브 러너로 전환하고 verify JAR 재사용

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Download bootJars artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -105,10 +108,16 @@ jobs:
         shell: bash
 
       - name: Build scan image
-        run: |
-          docker build -f Dockerfile.module \
-            --build-arg MODULE=${{ matrix.module }} \
-            -t beat-scan:${{ matrix.module }} .
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile.module
+          load: true
+          tags: beat-scan:${{ matrix.module }}
+          build-args: |
+            MODULE=${{ matrix.module }}
+          cache-from: type=gha,scope=ci-pr-${{ matrix.module }}
+          cache-to: type=gha,mode=max,scope=ci-pr-${{ matrix.module }}
 
       - name: Run Trivy scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -44,6 +44,25 @@ jobs:
           ./gradlew check verifyModuleBootJars --parallel --build-cache
         shell: bash
 
+      - name: Stage bootJars for downstream image build
+        run: |
+          mkdir -p staged-jars
+          for module in apis admin batch; do
+            JAR=$(find "${module}/build/libs" -maxdepth 1 -name "${module}-*.jar" ! -name '*-plain.jar' | head -n 1)
+            [ -n "$JAR" ] || { echo "No bootJar produced for ${module}" >&2; exit 1; }
+            cp "$JAR" "staged-jars/${module}.jar"
+          done
+          ls -lh staged-jars
+        shell: bash
+
+      - name: Upload bootJars artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bootjars
+          path: staged-jars/
+          if-no-files-found: error
+          retention-days: 1
+
       # Advisory phase: buildHealth is intentionally non-blocking on first adoption.
       # Promote to a hard gate only after the report is triaged into:
       # - immediate fixes,
@@ -70,11 +89,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Download bootJars artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bootjars
+          path: staged-jars
+
+      - name: Prepare app.jar for Docker build context
+        env:
+          MODULE: ${{ matrix.module }}
+        run: |
+          [ -f "staged-jars/${MODULE}.jar" ] || { echo "Missing staged-jars/${MODULE}.jar" >&2; exit 1; }
+          cp "staged-jars/${MODULE}.jar" app.jar
+          ls -lh app.jar
+        shell: bash
+
       - name: Build scan image
         run: |
           docker build -f Dockerfile.module \
             --build-arg MODULE=${{ matrix.module }} \
-            --platform linux/amd64 \
             -t beat-scan:${{ matrix.module }} .
 
       - name: Run Trivy scan

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -208,7 +208,7 @@ jobs:
           name: bootjars
           path: staged-jars/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 3
 
   build-image:
     needs:
@@ -229,6 +229,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.resolve-ref.outputs.commit_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -266,16 +269,33 @@ jobs:
           echo "latest=$IMAGE_LATEST" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile.module
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}
+            ${{ steps.image.outputs.latest }}
+          build-args: |
+            MODULE=${{ matrix.module }}
+          cache-from: type=gha,scope=dev-${{ matrix.module }}
+          cache-to: type=gha,mode=max,scope=dev-${{ matrix.module }}
+
+      - name: Write build summary
         env:
           MODULE: ${{ matrix.module }}
+          IMAGE: ${{ steps.image.outputs.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          docker build -f Dockerfile.module \
-            --build-arg MODULE=${MODULE} \
-            -t "${{ steps.image.outputs.image }}" \
-            -t "${{ steps.image.outputs.latest }}" \
-            .
-          docker push "${{ steps.image.outputs.image }}"
-          docker push "${{ steps.image.outputs.latest }}"
+          {
+            echo "### Build Summary"
+            echo ""
+            echo "- Module: \`${MODULE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- Digest: \`${DIGEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   foundation:
     needs:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -191,6 +191,25 @@ jobs:
           ./gradlew check verifyModuleBootJars --parallel --build-cache
         shell: bash
 
+      - name: Stage bootJars for downstream image build
+        run: |
+          mkdir -p staged-jars
+          for module in apis admin batch; do
+            JAR=$(find "${module}/build/libs" -maxdepth 1 -name "${module}-*.jar" ! -name '*-plain.jar' | head -n 1)
+            [ -n "$JAR" ] || { echo "No bootJar produced for ${module}" >&2; exit 1; }
+            cp "$JAR" "staged-jars/${module}.jar"
+          done
+          ls -lh staged-jars
+        shell: bash
+
+      - name: Upload bootJars artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bootjars
+          path: staged-jars/
+          if-no-files-found: error
+          retention-days: 1
+
   build-image:
     needs:
       - detect-changes
@@ -198,7 +217,7 @@ jobs:
       - verify
     if: needs.detect-changes.outputs.has_modules == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       contents: read
     environment: dev
@@ -216,6 +235,21 @@ jobs:
         with:
           username: ${{ vars.DEV_DOCKER_LOGIN_USERNAME }}
           password: ${{ secrets.DEV_DOCKER_LOGIN_ACCESSTOKEN }}
+
+      - name: Download bootJars artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bootjars
+          path: staged-jars
+
+      - name: Prepare app.jar for Docker build context
+        env:
+          MODULE: ${{ matrix.module }}
+        run: |
+          [ -f "staged-jars/${MODULE}.jar" ] || { echo "Missing staged-jars/${MODULE}.jar" >&2; exit 1; }
+          cp "staged-jars/${MODULE}.jar" app.jar
+          ls -lh app.jar
+        shell: bash
 
       - name: Compute image name
         id: image
@@ -237,7 +271,6 @@ jobs:
         run: |
           docker build -f Dockerfile.module \
             --build-arg MODULE=${MODULE} \
-            --platform linux/amd64 \
             -t "${{ steps.image.outputs.image }}" \
             -t "${{ steps.image.outputs.latest }}" \
             .

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -104,7 +104,7 @@ jobs:
           name: bootjars
           path: staged-jars/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
   secret-preflight:
     needs:
@@ -159,6 +159,8 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     environment: prod
     strategy:
       fail-fast: false
@@ -208,15 +210,43 @@ jobs:
           echo "latest=$IMAGE_LATEST" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile.module
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}
+            ${{ steps.image.outputs.latest }}
+          build-args: |
+            MODULE=${{ matrix.module }}
+          cache-from: type=gha,scope=prod-${{ matrix.module }}
+          cache-to: type=gha,mode=max,scope=prod-${{ matrix.module }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: docker.io/${{ vars.PROD_DOCKER_LOGIN_USERNAME }}/beat-${{ matrix.module }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Write build summary
         env:
           MODULE: ${{ matrix.module }}
+          IMAGE: ${{ steps.image.outputs.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          docker buildx build -f Dockerfile.module \
-            --build-arg MODULE=${MODULE} \
-            -t "${{ steps.image.outputs.image }}" \
-            -t "${{ steps.image.outputs.latest }}" \
-            --push \
-            .
+          {
+            echo "### Build Summary"
+            echo ""
+            echo "- Module: \`${MODULE}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- Digest: \`${DIGEST}\`"
+            echo "- Attestation: signed via Sigstore (provenance + SBOM)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   foundation:
     needs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -87,6 +87,25 @@ jobs:
           ./gradlew check verifyModuleBootJars --parallel --build-cache
         shell: bash
 
+      - name: Stage bootJars for downstream image build
+        run: |
+          mkdir -p staged-jars
+          for module in apis admin batch; do
+            JAR=$(find "${module}/build/libs" -maxdepth 1 -name "${module}-*.jar" ! -name '*-plain.jar' | head -n 1)
+            [ -n "$JAR" ] || { echo "No bootJar produced for ${module}" >&2; exit 1; }
+            cp "$JAR" "staged-jars/${module}.jar"
+          done
+          ls -lh staged-jars
+        shell: bash
+
+      - name: Upload bootJars artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bootjars
+          path: staged-jars/
+          if-no-files-found: error
+          retention-days: 1
+
   secret-preflight:
     needs:
       - resolve-release
@@ -136,8 +155,8 @@ jobs:
       - resolve-release
       - verify
       - secret-preflight
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
     permissions:
       contents: read
     environment: prod
@@ -150,9 +169,6 @@ jobs:
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -161,6 +177,21 @@ jobs:
         with:
           username: ${{ vars.PROD_DOCKER_LOGIN_USERNAME }}
           password: ${{ secrets.PROD_DOCKER_LOGIN_ACCESSTOKEN }}
+
+      - name: Download bootJars artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bootjars
+          path: staged-jars
+
+      - name: Prepare app.jar for Docker build context
+        env:
+          MODULE: ${{ matrix.module }}
+        run: |
+          [ -f "staged-jars/${MODULE}.jar" ] || { echo "Missing staged-jars/${MODULE}.jar" >&2; exit 1; }
+          cp "staged-jars/${MODULE}.jar" app.jar
+          ls -lh app.jar
+        shell: bash
 
       - name: Compute image name
         id: image
@@ -182,7 +213,6 @@ jobs:
         run: |
           docker buildx build -f Dockerfile.module \
             --build-arg MODULE=${MODULE} \
-            --platform linux/arm64 \
             -t "${{ steps.image.outputs.image }}" \
             -t "${{ steps.image.outputs.latest }}" \
             --push \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
 
       - name: Upload bootJars artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bootjars
           path: staged-jars/
@@ -179,7 +179,7 @@ jobs:
           password: ${{ secrets.PROD_DOCKER_LOGIN_ACCESSTOKEN }}
 
       - name: Download bootJars artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bootjars
           path: staged-jars

--- a/Dockerfile.module
+++ b/Dockerfile.module
@@ -1,38 +1,3 @@
-FROM eclipse-temurin:25-jdk AS build
-
-ARG MODULE
-
-WORKDIR /workspace
-
-COPY gradlew gradlew.bat build.gradle.kts settings.gradle.kts ./
-COPY gradle ./gradle
-COPY build-logic ./build-logic
-COPY apis/build.gradle.kts ./apis/build.gradle.kts
-COPY admin/build.gradle.kts ./admin/build.gradle.kts
-COPY batch/build.gradle.kts ./batch/build.gradle.kts
-COPY domain/build.gradle.kts ./domain/build.gradle.kts
-COPY gateway/build.gradle.kts ./gateway/build.gradle.kts
-COPY global-support/build.gradle.kts ./global-support/build.gradle.kts
-COPY infra/build.gradle.kts ./infra/build.gradle.kts
-COPY module-contracts/build.gradle.kts ./module-contracts/build.gradle.kts
-COPY observability/build.gradle.kts ./observability/build.gradle.kts
-
-RUN chmod +x gradlew
-RUN ./gradlew :${MODULE}:dependencies --no-daemon >/dev/null
-
-COPY apis ./apis
-COPY admin ./admin
-COPY batch ./batch
-COPY domain ./domain
-COPY gateway ./gateway
-COPY global-support ./global-support
-COPY infra ./infra
-COPY module-contracts ./module-contracts
-COPY observability ./observability
-
-RUN ./gradlew :${MODULE}:bootJar --no-daemon \
-  && cp "$(find /workspace/${MODULE}/build/libs -maxdepth 1 -name "${MODULE}-*.jar" ! -name '*-plain.jar' | head -n 1)" /workspace/app.jar
-
 FROM eclipse-temurin:25-jre-alpine
 
 ARG MODULE
@@ -43,7 +8,7 @@ WORKDIR /app
 
 LABEL beat.module="${MODULE}"
 
-COPY --from=build --chown=beat:beat /workspace/app.jar /app/app.jar
+COPY --chown=beat:beat app.jar /app/app.jar
 
 USER beat
 

--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -49,7 +49,7 @@ sops:
             aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
             FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-17T03:50:08Z"
-    mac: ENC[AES256_GCM,data:08W4LF/OLUmvbw/VkiTCK7dch6vSOD/5HPG8mlLiiizfe8UOFKFy5gTluNDcfygGODe+l61kWOLhDRr1Lb7nVEKbjyr7Dh9zIdNFMuq/ouUMGojqW1ebB6H+2rOMRsOL/nWhQ47474IDOtzckWUh3NOl0exBK49tPn3Iz7/mejE=,iv:320ju0JVVbrN/hYVDV7vC4qhoT2cn2nHCGVWvVy3hfs=,tag:uM47ozp/X9XTm7/e3n8tyQ==,type:str]
+    lastmodified: "2026-05-17T12:12:32Z"
+    mac: ENC[AES256_GCM,data:j25UlCbh1LRkPA415pGVlzjYu7Yq4AuG29Sx55V9Pq26A9zjG6VAkbY+3X1WFtbE+hvST+77uJNGcbYyiHgq+pQqLQgH9MBy08hfklbUceuZ8wdau6PQ+LM7G4uFOXkFecjPLnOUCgF/t1CIeMX/QzWSzbne61vRADeya2hdw5Y=,iv:MpDk4CNC3IYGOJNbPy5Z5he9Dbuq7E3TwW6MvGaHDIA=,tag:lW7jDEJLS5cb7hTtGkOKDA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Related issue 🛠

- closes #482

## Work Description ✏️

## 작업 목적

prod build-image 잡이 QEMU ARM64 에뮬레이션으로 30분 이상 걸려 타임아웃 위험이 있고, Dockerfile 내부에서 `./gradlew bootJar`를 또 돌려 verify 잡과 이중 빌드되는 구조였다.

CI 빌드 시간을 단축하고, 공급망 보안 표준 (SLSA Build Provenance)을 도입한다.

## 주요 변경 사항

### 1. 빌드 구조 변경 — verify JAR 재사용 패턴

- `verify` 잡: `verifyModuleBootJars` 산출물을 staging 후 artifact 업로드
- `build-image` 잡: artifact 다운로드 → `app.jar`로 staging → Docker COPY
- Gradle 빌드 1회로 통합 (verify + build-image 이중 빌드 제거)
- 적용 워크플로우: `deploy-prod.yml`, `deploy-dev.yml`, `ci-pr.yml`

### 2. Dockerfile.module — build stage 제거

- JDK + gradlew + 전체 소스 COPY 제거
- runtime stage만 남기고 호스트에서 빌드된 `app.jar`를 COPY
- 멀티스테이지 38줄 → 단일 stage 13줄

### 3. prod build-image — ARM 네이티브 러너

- `runs-on: ubuntu-22.04` → `ubuntu-24.04-arm` (QEMU 의존성 완전 제거)
- `docker/setup-qemu-action` 제거
- `--platform linux/arm64` 플래그 제거 (네이티브)
- timeout 30분 → 15분

### 4. `docker/build-push-action@v7.1.0` 통일 + GHA layer cache

- raw `docker buildx`/`docker build` → 공식 액션
- `cache-from: type=gha` / `cache-to: type=gha,mode=max` (scope: 환경-모듈별)
- 동일 베이스 이미지 레이어 재사용

### 5. SLSA Build Provenance (prod 한정)

- `actions/attest-build-provenance@v4.1.0` 추가
- 권한: `id-token: write`, `attestations: write`
- Sigstore 서명 기반, OIDC 토큰으로 단기 인증서 발급 → registry push
- `provenance: mode=max`, `sbom: true`

### 6. 액션 메이저 버전 업데이트 (SHA pin)

- `actions/upload-artifact` v4 → v7.0.1
- `actions/download-artifact` v4 → v8.0.1

### 7. 부가 개선

- `GITHUB_STEP_SUMMARY` 출력 (module, image, digest)
- artifact retention: prod=7d, dev=3d
- dev `build-image`에 `setup-buildx-action` 추가 (cache 사용 위해)
- prod inventory `ansible_host` 임시 IP → EIP 원복 (마이그레이션 안정화 후 활성화)

## 기대 효과

| 항목 | Before | After |
|------|--------|-------|
| 러너 (prod) | ubuntu-22.04 x86 | ubuntu-24.04-arm |
| QEMU | 필요 | 불필요 |
| Gradle 빌드 횟수 | 2회 (verify + Dockerfile) | 1회 (verify) |
| Docker layer cache | 없음 | GHA cache |
| Provenance/SBOM | 없음 | 첨부 (prod) |
| 빌드 시간 (prod) | 30분+ | 2~4분 |
| 빌드 시간 (dev) | 10~15분 | 2~3분 |
| Dockerfile | 멀티스테이지 (JDK) | 런타임 only (JRE) |

## Test plan

- [ ] `chore/#482` 브랜치에서 `ci-pr` 의 verify + scan-images 통과
- [ ] develop 머지 후 `deploy-dev` 의 verify → build-image → deploy 정상 동작
- [ ] dev 컨테이너 기동 후 health check 200 확인
- [ ] main 머지 후 `v1.3.2` 릴리즈 시 prod 배포 빌드 시간 5분 이내 확인
- [ ] prod 이미지에 SLSA provenance 첨부 확인 (`gh attestation verify oci://...`)