### PR TITLE
fix: 로그 MDC에 OTel traceId/spanId 주입 (Tempo correlation 복구)

### DIFF
--- a/gateway/src/main/java/com/beat/gateway/internal/config/GatewaySecurityServletConfig.java
+++ b/gateway/src/main/java/com/beat/gateway/internal/config/GatewaySecurityServletConfig.java
@@ -4,6 +4,8 @@ import com.beat.gateway.security.internal.servlet.CustomAccessDeniedHandler;
 import com.beat.gateway.security.internal.servlet.CustomJwtAuthenticationEntryPoint;
 import com.beat.gateway.security.internal.servlet.JwtAuthenticationFilter;
 import com.beat.gateway.security.internal.servlet.SecurityMdcLoggingFilter;
+import io.micrometer.tracing.Tracer;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,8 +20,8 @@ import org.springframework.context.annotation.Import;
 public class GatewaySecurityServletConfig {
 
 	@Bean(name = "gatewaySecurityMdcLoggingFilter")
-	public SecurityMdcLoggingFilter gatewaySecurityMdcLoggingFilter() {
-		return new SecurityMdcLoggingFilter();
+	public SecurityMdcLoggingFilter gatewaySecurityMdcLoggingFilter(ObjectProvider<Tracer> tracerProvider) {
+		return new SecurityMdcLoggingFilter(tracerProvider.getIfAvailable());
 	}
 
 	@Bean

--- a/gateway/src/main/java/com/beat/gateway/internal/config/GatewaySecurityServletConfig.java
+++ b/gateway/src/main/java/com/beat/gateway/internal/config/GatewaySecurityServletConfig.java
@@ -4,8 +4,7 @@ import com.beat.gateway.security.internal.servlet.CustomAccessDeniedHandler;
 import com.beat.gateway.security.internal.servlet.CustomJwtAuthenticationEntryPoint;
 import com.beat.gateway.security.internal.servlet.JwtAuthenticationFilter;
 import com.beat.gateway.security.internal.servlet.SecurityMdcLoggingFilter;
-import io.micrometer.tracing.Tracer;
-import org.springframework.beans.factory.ObjectProvider;
+import com.beat.observability.tracing.TraceContextResolver;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,8 +19,8 @@ import org.springframework.context.annotation.Import;
 public class GatewaySecurityServletConfig {
 
 	@Bean(name = "gatewaySecurityMdcLoggingFilter")
-	public SecurityMdcLoggingFilter gatewaySecurityMdcLoggingFilter(ObjectProvider<Tracer> tracerProvider) {
-		return new SecurityMdcLoggingFilter(tracerProvider.getIfAvailable());
+	public SecurityMdcLoggingFilter gatewaySecurityMdcLoggingFilter(TraceContextResolver traceContextResolver) {
+		return new SecurityMdcLoggingFilter(traceContextResolver);
 	}
 
 	@Bean

--- a/gateway/src/main/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilter.java
+++ b/gateway/src/main/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilter.java
@@ -1,10 +1,20 @@
 package com.beat.gateway.security.internal.servlet;
 
 import com.beat.observability.logging.filter.BaseMdcLoggingFilter;
+import io.micrometer.tracing.Tracer;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityMdcLoggingFilter extends BaseMdcLoggingFilter {
+
+	public SecurityMdcLoggingFilter() {
+		super(null);
+	}
+
+	public SecurityMdcLoggingFilter(@Nullable Tracer tracer) {
+		super(tracer);
+	}
 
 	@Override
 	protected String resolveUserId() {

--- a/gateway/src/main/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilter.java
+++ b/gateway/src/main/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilter.java
@@ -1,15 +1,14 @@
 package com.beat.gateway.security.internal.servlet;
 
 import com.beat.observability.logging.filter.BaseMdcLoggingFilter;
-import io.micrometer.tracing.Tracer;
-import org.springframework.lang.Nullable;
+import com.beat.observability.tracing.TraceContextResolver;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityMdcLoggingFilter extends BaseMdcLoggingFilter {
 
-	public SecurityMdcLoggingFilter(@Nullable Tracer tracer) {
-		super(tracer);
+	public SecurityMdcLoggingFilter(TraceContextResolver traceContextResolver) {
+		super(traceContextResolver);
 	}
 
 	@Override

--- a/gateway/src/main/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilter.java
+++ b/gateway/src/main/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilter.java
@@ -8,10 +8,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityMdcLoggingFilter extends BaseMdcLoggingFilter {
 
-	public SecurityMdcLoggingFilter() {
-		super(null);
-	}
-
 	public SecurityMdcLoggingFilter(@Nullable Tracer tracer) {
 		super(tracer);
 	}

--- a/gateway/src/test/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilterTest.java
+++ b/gateway/src/test/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilterTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.beat.observability.logging.filter.BaseMdcLoggingFilter;
+import com.beat.observability.tracing.NoOpTraceContextResolver;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.AfterEach;
@@ -20,7 +21,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 class SecurityMdcLoggingFilterTest {
 
-	private final SecurityMdcLoggingFilter filter = new SecurityMdcLoggingFilter(null);
+	private final SecurityMdcLoggingFilter filter = new SecurityMdcLoggingFilter(NoOpTraceContextResolver.INSTANCE);
 
 	@AfterEach
 	void clearContext() {

--- a/gateway/src/test/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilterTest.java
+++ b/gateway/src/test/java/com/beat/gateway/security/internal/servlet/SecurityMdcLoggingFilterTest.java
@@ -20,7 +20,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 class SecurityMdcLoggingFilterTest {
 
-	private final SecurityMdcLoggingFilter filter = new SecurityMdcLoggingFilter();
+	private final SecurityMdcLoggingFilter filter = new SecurityMdcLoggingFilter(null);
 
 	@AfterEach
 	void clearContext() {

--- a/observability/build.gradle.kts
+++ b/observability/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     runtimeOnly(libs.sentry.async.profiler)
     runtimeOnly(libs.sentry.log4j2)
 
-    implementation(libs.micrometer.tracing.bridge.otel)
+    api(libs.micrometer.tracing.bridge.otel)
     implementation(libs.opentelemetry.exporter.otlp)
 
     testImplementation(libs.spring.boot.starter.test)

--- a/observability/src/main/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilter.kt
+++ b/observability/src/main/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilter.kt
@@ -1,5 +1,6 @@
 package com.beat.observability.logging.filter
 
+import io.micrometer.tracing.Tracer
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -7,7 +8,9 @@ import org.slf4j.MDC
 import org.springframework.web.filter.OncePerRequestFilter
 import java.util.UUID
 
-abstract class BaseMdcLoggingFilter : OncePerRequestFilter() {
+abstract class BaseMdcLoggingFilter(
+    private val tracer: Tracer? = null,
+) : OncePerRequestFilter() {
 
     companion object {
         const val TRACE_ID_HEADER = "X-Request-ID"
@@ -15,6 +18,7 @@ abstract class BaseMdcLoggingFilter : OncePerRequestFilter() {
         const val X_REAL_IP_HEADER = "X-Real-IP"
 
         const val TRACE_ID_KEY = "traceId"
+        const val SPAN_ID_KEY = "spanId"
         const val USER_ID_KEY = "userId"
         const val CLIENT_IP_KEY = "clientIp"
         const val REQUEST_INFO_KEY = "requestInfo"
@@ -25,6 +29,7 @@ abstract class BaseMdcLoggingFilter : OncePerRequestFilter() {
 
         private const val MAX_TRACE_ID_LENGTH = 128
         private val TRACE_ID_PATTERN = Regex("^[A-Za-z0-9._:-]+$")
+        private const val NOOP_TRACE_ID = "00000000000000000000000000000000"
     }
 
     override fun doFilterInternal(
@@ -32,10 +37,8 @@ abstract class BaseMdcLoggingFilter : OncePerRequestFilter() {
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        val traceId = resolveTraceId(request)
-        response.setHeader(TRACE_ID_HEADER, traceId)
-
-        populateMdc(request, traceId)
+        val effectiveTraceId = populateMdc(request)
+        response.setHeader(TRACE_ID_HEADER, effectiveTraceId)
 
         try {
             filterChain.doFilter(request, response)
@@ -44,7 +47,7 @@ abstract class BaseMdcLoggingFilter : OncePerRequestFilter() {
         }
     }
 
-    private fun resolveTraceId(request: HttpServletRequest): String =
+    private fun resolveFallbackTraceId(request: HttpServletRequest): String =
         request.getHeader(TRACE_ID_HEADER)
             ?.trim()
             ?.takeIf { it.length in 1..MAX_TRACE_ID_LENGTH }
@@ -53,13 +56,27 @@ abstract class BaseMdcLoggingFilter : OncePerRequestFilter() {
 
     private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "")
 
-    private fun populateMdc(request: HttpServletRequest, traceId: String) {
-        MDC.put(TRACE_ID_KEY, traceId)
+    private fun populateMdc(request: HttpServletRequest): String {
+        val fallbackTraceId = resolveFallbackTraceId(request)
+        val otelContext = tracer?.currentSpan()?.context()
+        val effectiveTraceId = if (otelContext != null &&
+            otelContext.traceId().isNotBlank() &&
+            otelContext.traceId() != NOOP_TRACE_ID
+        ) {
+            MDC.put(SPAN_ID_KEY, otelContext.spanId())
+            otelContext.traceId()
+        } else {
+            fallbackTraceId
+        }
+
+        MDC.put(TRACE_ID_KEY, effectiveTraceId)
         MDC.put(CLIENT_IP_KEY, extractClientIp(request))
         MDC.put(REQUEST_INFO_KEY, "${request.method} ${request.requestURI}")
 
         val userId = resolveUserId()
         MDC.put(USER_ID_KEY, userId?.takeIf { it.isNotBlank() } ?: DEFAULT_GUEST_USER)
+
+        return effectiveTraceId
     }
 
     private fun extractClientIp(request: HttpServletRequest): String {

--- a/observability/src/main/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilter.kt
+++ b/observability/src/main/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilter.kt
@@ -1,6 +1,7 @@
 package com.beat.observability.logging.filter
 
-import io.micrometer.tracing.Tracer
+import com.beat.observability.tracing.NoOpTraceContextResolver
+import com.beat.observability.tracing.TraceContextResolver
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -9,7 +10,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 import java.util.UUID
 
 abstract class BaseMdcLoggingFilter(
-    private val tracer: Tracer? = null,
+    private val traceContextResolver: TraceContextResolver = NoOpTraceContextResolver,
 ) : OncePerRequestFilter() {
 
     companion object {
@@ -29,7 +30,6 @@ abstract class BaseMdcLoggingFilter(
 
         private const val MAX_TRACE_ID_LENGTH = 128
         private val TRACE_ID_PATTERN = Regex("^[A-Za-z0-9._:-]+$")
-        private const val NOOP_TRACE_ID = "00000000000000000000000000000000"
     }
 
     override fun doFilterInternal(
@@ -47,6 +47,26 @@ abstract class BaseMdcLoggingFilter(
         }
     }
 
+    private fun populateMdc(request: HttpServletRequest): String {
+        val traceId = applyTraceContext(request)
+        MDC.put(CLIENT_IP_KEY, extractClientIp(request))
+        MDC.put(REQUEST_INFO_KEY, "${request.method} ${request.requestURI}")
+        MDC.put(USER_ID_KEY, resolveUserId()?.takeIf { it.isNotBlank() } ?: DEFAULT_GUEST_USER)
+        return traceId
+    }
+
+    private fun applyTraceContext(request: HttpServletRequest): String {
+        val resolved = traceContextResolver.resolve()
+        val traceId = if (resolved != null) {
+            MDC.put(SPAN_ID_KEY, resolved.spanId)
+            resolved.traceId
+        } else {
+            resolveFallbackTraceId(request)
+        }
+        MDC.put(TRACE_ID_KEY, traceId)
+        return traceId
+    }
+
     private fun resolveFallbackTraceId(request: HttpServletRequest): String =
         request.getHeader(TRACE_ID_HEADER)
             ?.trim()
@@ -55,29 +75,6 @@ abstract class BaseMdcLoggingFilter(
             ?: generateTraceId()
 
     private fun generateTraceId(): String = UUID.randomUUID().toString().replace("-", "")
-
-    private fun populateMdc(request: HttpServletRequest): String {
-        val fallbackTraceId = resolveFallbackTraceId(request)
-        val otelContext = tracer?.currentSpan()?.context()
-        val effectiveTraceId = if (otelContext != null &&
-            otelContext.traceId().isNotBlank() &&
-            otelContext.traceId() != NOOP_TRACE_ID
-        ) {
-            MDC.put(SPAN_ID_KEY, otelContext.spanId())
-            otelContext.traceId()
-        } else {
-            fallbackTraceId
-        }
-
-        MDC.put(TRACE_ID_KEY, effectiveTraceId)
-        MDC.put(CLIENT_IP_KEY, extractClientIp(request))
-        MDC.put(REQUEST_INFO_KEY, "${request.method} ${request.requestURI}")
-
-        val userId = resolveUserId()
-        MDC.put(USER_ID_KEY, userId?.takeIf { it.isNotBlank() } ?: DEFAULT_GUEST_USER)
-
-        return effectiveTraceId
-    }
 
     private fun extractClientIp(request: HttpServletRequest): String {
         val forwardedFor = request.getHeader(X_FORWARDED_FOR_HEADER)

--- a/observability/src/main/kotlin/com/beat/observability/logging/filter/SimpleMdcLoggingFilter.kt
+++ b/observability/src/main/kotlin/com/beat/observability/logging/filter/SimpleMdcLoggingFilter.kt
@@ -1,5 +1,7 @@
 package com.beat.observability.logging.filter
 
-class SimpleMdcLoggingFilter : BaseMdcLoggingFilter() {
+import io.micrometer.tracing.Tracer
+
+class SimpleMdcLoggingFilter(tracer: Tracer? = null) : BaseMdcLoggingFilter(tracer) {
     override fun resolveUserId(): String? = null
 }

--- a/observability/src/main/kotlin/com/beat/observability/logging/filter/SimpleMdcLoggingFilter.kt
+++ b/observability/src/main/kotlin/com/beat/observability/logging/filter/SimpleMdcLoggingFilter.kt
@@ -1,7 +1,10 @@
 package com.beat.observability.logging.filter
 
-import io.micrometer.tracing.Tracer
+import com.beat.observability.tracing.NoOpTraceContextResolver
+import com.beat.observability.tracing.TraceContextResolver
 
-class SimpleMdcLoggingFilter(tracer: Tracer? = null) : BaseMdcLoggingFilter(tracer) {
+class SimpleMdcLoggingFilter(
+    resolver: TraceContextResolver = NoOpTraceContextResolver,
+) : BaseMdcLoggingFilter(resolver) {
     override fun resolveUserId(): String? = null
 }

--- a/observability/src/main/kotlin/com/beat/observability/tracing/TraceContextResolver.kt
+++ b/observability/src/main/kotlin/com/beat/observability/tracing/TraceContextResolver.kt
@@ -1,0 +1,29 @@
+package com.beat.observability.tracing
+
+import io.micrometer.tracing.Tracer
+
+fun interface TraceContextResolver {
+    fun resolve(): ResolvedTraceContext?
+
+    data class ResolvedTraceContext(val traceId: String, val spanId: String)
+}
+
+object NoOpTraceContextResolver : TraceContextResolver {
+    override fun resolve(): TraceContextResolver.ResolvedTraceContext? = null
+}
+
+class MicrometerTraceContextResolver(
+    private val tracer: Tracer,
+) : TraceContextResolver {
+
+    override fun resolve(): TraceContextResolver.ResolvedTraceContext? {
+        val context = tracer.currentSpan()?.context() ?: return null
+        val traceId = context.traceId()
+        if (traceId.isBlank() || traceId == NOOP_TRACE_ID) return null
+        return TraceContextResolver.ResolvedTraceContext(traceId, context.spanId())
+    }
+
+    private companion object {
+        const val NOOP_TRACE_ID = "00000000000000000000000000000000"
+    }
+}

--- a/observability/src/main/kotlin/com/beat/observability/tracing/TracingConfig.kt
+++ b/observability/src/main/kotlin/com/beat/observability/tracing/TracingConfig.kt
@@ -1,6 +1,16 @@
 package com.beat.observability.tracing
 
+import io.micrometer.tracing.Tracer
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration(proxyBeanMethods = false)
-class TracingConfig
+class TracingConfig {
+
+    @Bean
+    fun traceContextResolver(tracerProvider: ObjectProvider<Tracer>): TraceContextResolver {
+        val tracer = tracerProvider.ifAvailable
+        return tracer?.let(::MicrometerTraceContextResolver) ?: NoOpTraceContextResolver
+    }
+}

--- a/observability/src/test/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilterTest.kt
+++ b/observability/src/test/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilterTest.kt
@@ -1,12 +1,18 @@
 package com.beat.observability.logging.filter
 
+import io.micrometer.tracing.Span
+import io.micrometer.tracing.TraceContext
+import io.micrometer.tracing.Tracer
 import jakarta.servlet.FilterChain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.slf4j.MDC
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
@@ -137,9 +143,69 @@ class BaseMdcLoggingFilterTest {
         assertMdcCleared()
     }
 
-    private fun testFilter(userId: String?): BaseMdcLoggingFilter = object : BaseMdcLoggingFilter() {
-        override fun resolveUserId(): String? = userId
+    @Test
+    fun `uses OTel traceId and spanId when active span is available`() {
+        val otelTraceId = "abcdef0123456789abcdef0123456789"
+        val otelSpanId = "fedcba9876543210"
+        val tracer = mockTracer(otelTraceId, otelSpanId)
+        val filter = testFilter(null, tracer)
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request(), response) { _, _ ->
+            assertEquals(otelTraceId, MDC.get(BaseMdcLoggingFilter.TRACE_ID_KEY))
+            assertEquals(otelSpanId, MDC.get(BaseMdcLoggingFilter.SPAN_ID_KEY))
+        }
+
+        assertEquals(otelTraceId, response.getHeader(BaseMdcLoggingFilter.TRACE_ID_HEADER))
+        assertMdcCleared()
     }
+
+    @Test
+    fun `falls back to UUID traceId and omits spanId when no active span`() {
+        val tracer = mock(Tracer::class.java)
+        `when`(tracer.currentSpan()).thenReturn(null)
+        val filter = testFilter(null, tracer)
+
+        filter.doFilter(request(), MockHttpServletResponse()) { _, _ ->
+            val traceId = MDC.get(BaseMdcLoggingFilter.TRACE_ID_KEY)
+            assertNotNull(traceId)
+            assertEquals(32, traceId.length)
+            assertNull(MDC.get(BaseMdcLoggingFilter.SPAN_ID_KEY))
+        }
+
+        assertMdcCleared()
+    }
+
+    @Test
+    fun `falls back to UUID when active span reports noop traceId`() {
+        val tracer = mockTracer("00000000000000000000000000000000", "0000000000000000")
+        val filter = testFilter(null, tracer)
+
+        filter.doFilter(request(), MockHttpServletResponse()) { _, _ ->
+            val traceId = MDC.get(BaseMdcLoggingFilter.TRACE_ID_KEY)
+            assertNotNull(traceId)
+            assertEquals(32, traceId.length)
+            assertNull(MDC.get(BaseMdcLoggingFilter.SPAN_ID_KEY))
+        }
+
+        assertMdcCleared()
+    }
+
+    private fun mockTracer(traceId: String, spanId: String): Tracer {
+        val context = mock(TraceContext::class.java)
+        `when`(context.traceId()).thenReturn(traceId)
+        `when`(context.spanId()).thenReturn(spanId)
+        val span = mock(Span::class.java)
+        `when`(span.context()).thenReturn(context)
+        val tracer = mock(Tracer::class.java)
+        `when`(tracer.currentSpan()).thenReturn(span)
+        return tracer
+    }
+
+    private fun testFilter(userId: String?, tracer: Tracer? = null): BaseMdcLoggingFilter =
+        object : BaseMdcLoggingFilter(tracer) {
+            override fun resolveUserId(): String? = userId
+        }
 
     private fun request(method: String = "GET", uri: String = "/api/main"): MockHttpServletRequest =
         MockHttpServletRequest(method, uri)

--- a/observability/src/test/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilterTest.kt
+++ b/observability/src/test/kotlin/com/beat/observability/logging/filter/BaseMdcLoggingFilterTest.kt
@@ -1,8 +1,8 @@
 package com.beat.observability.logging.filter
 
-import io.micrometer.tracing.Span
-import io.micrometer.tracing.TraceContext
-import io.micrometer.tracing.Tracer
+import com.beat.observability.tracing.NoOpTraceContextResolver
+import com.beat.observability.tracing.TraceContextResolver
+import com.beat.observability.tracing.TraceContextResolver.ResolvedTraceContext
 import jakarta.servlet.FilterChain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import org.slf4j.MDC
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
@@ -144,11 +142,10 @@ class BaseMdcLoggingFilterTest {
     }
 
     @Test
-    fun `uses OTel traceId and spanId when active span is available`() {
+    fun `uses resolved traceId and spanId when active span is available`() {
         val otelTraceId = "abcdef0123456789abcdef0123456789"
         val otelSpanId = "fedcba9876543210"
-        val tracer = mockTracer(otelTraceId, otelSpanId)
-        val filter = testFilter(null, tracer)
+        val filter = testFilter(null, stubResolver(otelTraceId, otelSpanId))
         val response = MockHttpServletResponse()
 
         filter.doFilter(request(), response) { _, _ ->
@@ -161,10 +158,8 @@ class BaseMdcLoggingFilterTest {
     }
 
     @Test
-    fun `falls back to UUID traceId and omits spanId when no active span`() {
-        val tracer = mock(Tracer::class.java)
-        `when`(tracer.currentSpan()).thenReturn(null)
-        val filter = testFilter(null, tracer)
+    fun `falls back to UUID traceId and omits spanId when resolver returns null`() {
+        val filter = testFilter(null, NoOpTraceContextResolver)
 
         filter.doFilter(request(), MockHttpServletResponse()) { _, _ ->
             val traceId = MDC.get(BaseMdcLoggingFilter.TRACE_ID_KEY)
@@ -176,34 +171,14 @@ class BaseMdcLoggingFilterTest {
         assertMdcCleared()
     }
 
-    @Test
-    fun `falls back to UUID when active span reports noop traceId`() {
-        val tracer = mockTracer("00000000000000000000000000000000", "0000000000000000")
-        val filter = testFilter(null, tracer)
+    private fun stubResolver(traceId: String, spanId: String): TraceContextResolver =
+        TraceContextResolver { ResolvedTraceContext(traceId, spanId) }
 
-        filter.doFilter(request(), MockHttpServletResponse()) { _, _ ->
-            val traceId = MDC.get(BaseMdcLoggingFilter.TRACE_ID_KEY)
-            assertNotNull(traceId)
-            assertEquals(32, traceId.length)
-            assertNull(MDC.get(BaseMdcLoggingFilter.SPAN_ID_KEY))
-        }
-
-        assertMdcCleared()
-    }
-
-    private fun mockTracer(traceId: String, spanId: String): Tracer {
-        val context = mock(TraceContext::class.java)
-        `when`(context.traceId()).thenReturn(traceId)
-        `when`(context.spanId()).thenReturn(spanId)
-        val span = mock(Span::class.java)
-        `when`(span.context()).thenReturn(context)
-        val tracer = mock(Tracer::class.java)
-        `when`(tracer.currentSpan()).thenReturn(span)
-        return tracer
-    }
-
-    private fun testFilter(userId: String?, tracer: Tracer? = null): BaseMdcLoggingFilter =
-        object : BaseMdcLoggingFilter(tracer) {
+    private fun testFilter(
+        userId: String?,
+        resolver: TraceContextResolver = NoOpTraceContextResolver,
+    ): BaseMdcLoggingFilter =
+        object : BaseMdcLoggingFilter(resolver) {
             override fun resolveUserId(): String? = userId
         }
 

--- a/observability/src/test/kotlin/com/beat/observability/tracing/MicrometerTraceContextResolverTest.kt
+++ b/observability/src/test/kotlin/com/beat/observability/tracing/MicrometerTraceContextResolverTest.kt
@@ -1,0 +1,68 @@
+package com.beat.observability.tracing
+
+import io.micrometer.tracing.Span
+import io.micrometer.tracing.TraceContext
+import io.micrometer.tracing.Tracer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class MicrometerTraceContextResolverTest {
+
+    @Test
+    fun `returns null when tracer has no active span`() {
+        val tracer = mock(Tracer::class.java)
+        `when`(tracer.currentSpan()).thenReturn(null)
+
+        val resolved = MicrometerTraceContextResolver(tracer).resolve()
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun `returns null when traceId is blank`() {
+        val tracer = mockTracer(traceId = "   ", spanId = "abc")
+
+        val resolved = MicrometerTraceContextResolver(tracer).resolve()
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun `returns null when traceId is the OTel noop id`() {
+        val tracer = mockTracer(
+            traceId = "00000000000000000000000000000000",
+            spanId = "0000000000000000",
+        )
+
+        val resolved = MicrometerTraceContextResolver(tracer).resolve()
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun `returns resolved context for a real active span`() {
+        val tracer = mockTracer(
+            traceId = "abcdef0123456789abcdef0123456789",
+            spanId = "fedcba9876543210",
+        )
+
+        val resolved = MicrometerTraceContextResolver(tracer).resolve()
+
+        assertEquals("abcdef0123456789abcdef0123456789", resolved?.traceId)
+        assertEquals("fedcba9876543210", resolved?.spanId)
+    }
+
+    private fun mockTracer(traceId: String, spanId: String): Tracer {
+        val context = mock(TraceContext::class.java)
+        `when`(context.traceId()).thenReturn(traceId)
+        `when`(context.spanId()).thenReturn(spanId)
+        val span = mock(Span::class.java)
+        `when`(span.context()).thenReturn(context)
+        val tracer = mock(Tracer::class.java)
+        `when`(tracer.currentSpan()).thenReturn(span)
+        return tracer
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closes #484

## Work Description ✏️

## 작업 목적

prod 로그에 `spanId=NO_SPAN` 으로 떨어지고 `traceId` 도 OTel 가 만든 값이 아니라 `BaseMdcLoggingFilter` 가 직접 생성한 UUID였다. 결과적으로 **로그 ↔ Tempo trace correlation 이 끊겨있는 상태**여서 Grafana Cloud Logs 에서 trace 점프가 불가능했다.

## 주요 변경 사항

### 1. `TraceContextResolver` 추상화 도입 (`observability/tracing`)

- `interface TraceContextResolver` — `resolve(): ResolvedTraceContext?` (SAM)
- `object NoOpTraceContextResolver` — tracing 비활성 환경 기본값
- `class MicrometerTraceContextResolver(tracer: Tracer)` — 활성 span 추출, `traceId` blank / NoOp(`00…00`) 가드
- 필터가 `io.micrometer.tracing.Tracer` 를 직접 import 하지 않도록 책임 분리

### 2. `BaseMdcLoggingFilter` 단순화

- 생성자: `Tracer?` → `TraceContextResolver` (기본 `NoOpTraceContextResolver`)
- `populateMdc()` 가 5줄로 축약, OTel context resolution / blank / NoOp 3중 분기는 resolver 안으로 캡슐화
- 활성 span 있으면 `SPAN_ID_KEY` MDC put, 없으면 키 자체를 두지 않음 (log4j2 패턴 `%equals{%X{spanId}}{}{NO_SPAN}` 가 출력 시 자동 치환)
- `SPAN_ID_KEY = "spanId"` 상수 추가

### 3. 하위 필터 / 빈 와이어링

- `SimpleMdcLoggingFilter(resolver: TraceContextResolver = NoOpTraceContextResolver)` — 무인자 호환
- `SecurityMdcLoggingFilter(TraceContextResolver)` — 단일 생성자, `null` 제거
- `GatewaySecurityServletConfig` 가 `TraceContextResolver` 빈을 직접 주입 (`ObjectProvider<Tracer>` 책임은 `TracingConfig` 로 이관)
- `TracingConfig` 가 `ObjectProvider<Tracer>` 보고 `MicrometerTraceContextResolver` 또는 `NoOpTraceContextResolver` 등록

### 4. observability 모듈 의존성 노출

- `micrometer-tracing-bridge-otel` 을 `implementation` → `api` 로 변경하여 resolver 구현체에서 Tracer 타입 참조 가능

### 5. 테스트 보강

- `MicrometerTraceContextResolverTest` 신규: null span / blank traceId / NoOp traceId / 정상 active span 4 케이스
- `BaseMdcLoggingFilterTest`: Mockito 3단 stub 제거, `TraceContextResolver { ResolvedTraceContext(...) }` SAM 람다로 단순화. OTel 활성 / 무스팬 fallback 시나리오 보존
- `SecurityMdcLoggingFilterTest`: `NoOpTraceContextResolver.INSTANCE` 명시

## 동작 매트릭스

| 환경 | resolver | `traceId` | `spanId` MDC | 로그 출력 |
|------|---------|-----------|-------------|---------|
| dev (tracing OFF) | `NoOp` | UUID fallback | 키 없음 | `spanId=NO_SPAN` (log4j2 default) |
| prod (활성 span) | `Micrometer` | OTel traceId | OTel spanId | `spanId=<hex>` |
| prod (no current span) | `Micrometer` | UUID fallback | 키 없음 | `spanId=NO_SPAN` (log4j2 default) |

> `NO_SPAN` 문자열은 MDC value 가 아니라 `log4j2-spring.xml` 의 `%equals{%X{spanId}}{}{NO_SPAN}` 가 출력 시점에 채우는 substitute 값. `Log4j2PatternContractTest` 가 이 contract 를 강제.

## Test plan

- [ ] dev: 기존 로그 패턴(`traceId=<32hex>, spanId=NO_SPAN`) 유지 확인
- [ ] prod: `traceId` 값이 Tempo 의 `trace_id` 와 일치하는지 검증
- [ ] prod: `spanId` 값이 채워지는지 확인 (`NO_SPAN` 사라짐)
- [ ] Grafana Cloud Logs → Tempo trace 점프(derived field) 정상 동작
- [ ] Sentry breadcrumb 의 `traceId` 가 로그와 일치