### PR TITLE
fix: Tempo OTLP exporter gRPC → HTTP 전환

### DIFF
--- a/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
@@ -18,7 +18,7 @@ gc_prom_url: ENC[AES256_GCM,data:gK+hbMcfcIaOnPl8l+zABJzEfTe8oC7HQiL+368fC/D/MKG
 gc_prom_user: ENC[AES256_GCM,data:3muQp50jWg==,iv:lH8d++JukUYzWrX895t/kYue/TKyfFcgTxunBLhs3LQ=,tag:nkPDSL5NfkaGgMRew+7tbw==,type:str]
 gc_loki_url: ENC[AES256_GCM,data://Hnf53RscDb/X4Vm7cqQERgVT++BZ39eflLoZmVqj1gUK2Z9iIL11ouCxkeyyo5Jxs=,iv:h4WiP1yw0JlHLamB0w7cl7Z7VgkFMiKlWCSIqND+ZMs=,tag:q6kDIKDwa3OJcu/Rp7WDYw==,type:str]
 gc_loki_user: ENC[AES256_GCM,data:h7Kl7Azk8Q==,iv:3jPAzUtzBZLjWOo1sh8LAlpdrZ7Cucnx4eCc5s3zEfg=,tag:KJI7P8BkGLnytDaAbW/jSw==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:ZqBDCX17PE7eG74xCn0CuhIAEmGEqpLuCbfNp42RSWzET1bMtvWVA60jR5ZDednugQ==,iv:WU2imMJYD/hE2Su2F2rinfWzx3z8z5vYkn27/ch5L84=,tag:n85LGXawR2tYTArmLpyZoQ==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:TSJdNVlRTnVYcre75oOA8c0jOtW5erfxlm8rFh62rYyo4VI/c4kp9XMyugZqln+Ol7YUBPTKO2O6,iv:cfyY67qSDj6sjNIwr+XOpYoCjp8Hi52+vhdn4DHR6UU=,tag:jOtRhAX3bvhPfRf3Qnvzaw==,type:str]
 gc_tempo_user: ENC[AES256_GCM,data:AEbok3tftA==,iv:2Kd0+FZ5ihh4Qs1/FwhH9W0m0apgItdoCgPbVkAakwc=,tag:X1fY1bFdk5UaQpkWWo0Sag==,type:str]
 sops:
     age:
@@ -49,7 +49,7 @@ sops:
             aThPTEVkZ3k1TFZhWFdWaGF1Q3F0TU0K5bpZQewMIh8Fa/l2wMhMpeQpakm/OPZP
             d9ev5czGQm28TquHDAQEPyFS1l3mUrEdA8rmw6Eui9BxfctrLfCe2w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T18:58:29Z"
-    mac: ENC[AES256_GCM,data:77v+u0BlmZjnUwCwKc2d037Pb27XEIDu4pd5RSoEeNBu1zg4TIkjZj6S5z+UqshLMgOvKxzMsO70s9OQocZHCZgAhvht5d+YS/cjfV2onsr2Rhb4HEb+o79KAAcAPZkFK/Z0IJZf3W9Ili9BdoCaX6suos1OH9Sv0OdOXgU8d6g=,iv:0MH/mEBgCx4eBZzlJmHjLPeRD++H3Ust56uuiLtIl4I=,tag:fH87VAkO81Lkm2lGlIh6cA==,type:str]
+    lastmodified: "2026-05-22T15:59:56Z"
+    mac: ENC[AES256_GCM,data:LhsNbdy8jHfSXHCLhEXgm8a8sazmrxNDyPrVO6s72ChjnQf2LlFcVq1uV8shPL4huZKf8qWlTpwa6lH3N67J9EmRZXhOUQjlvTSRST6f2nTW6cgkQUIPaB4a+QlBNcn7wzVY2ALYZOpkXN0N5H9Rbpu0AMzAwG7vkmcC/hfueqY=,iv:suDd3X75LMw+dsxReweel7kdC14v7JzrWf4eL5TwYtw=,tag:rEd7K3DktIbzdQp3wiOCyA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -18,7 +18,7 @@ gc_prom_url: ENC[AES256_GCM,data:yyZGtCz9Oqm+QdtvXVj2Gs1TtMz5VmaHFSroveLvx66/HQ/
 gc_prom_user: ENC[AES256_GCM,data:2OfoWdnEGg==,iv:9FqMdViPbcA/ZWEnVKxvDm7+NhuCIFhJ1/3e8buUCws=,tag:i6/DhO+SbFAFhef2nulH9A==,type:str]
 gc_loki_url: ENC[AES256_GCM,data:i5X6xRWXzoLBI3ICg4zfN/6U/kD3eRoxl+3CWIE250TTrMLkFc+slYVV2A35ZI3yLE8=,iv:TCiUkq5cRFhiJpDE2Q5bodcolfWjvvVLd8jTIx3Qqog=,tag:D/IFIKMhw0UBv7M+BnSmRg==,type:str]
 gc_loki_user: ENC[AES256_GCM,data:lgyX9ipumg==,iv:wPprqqwjN/CWCpdK8FLrdjNewWzSmJOkznochrxWOjU=,tag:BGHKvRmG7Fe9jz8xVGEtoQ==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:fXx85m6a3qS0OvEIAMFSTprY//PsGCihyFcsATu6jqOu+P3BjHAkwI215J/IJ0jH7Q==,iv:r6fhFJn+E44/t7SyCuuY5WvmcMskgqv2DI710t/DNzk=,tag:LLHk95Wa3j/TvlG9Fg++fg==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:sntb0kPzTSjdosykGkSp/5sSH5JI63tIwXSy4aD8YyoI2f8HCW3/ev1qXMLzmZG2P2fHPDYSDfoL,iv:eEcAZrod1MBzF+X03uLyL8o2HopiN2uIvA26/CYv7Eg=,tag:i0hZ955k+aqXA9Kh0s7ftA==,type:str]
 gc_tempo_user: ENC[AES256_GCM,data:B2ylR7xOVw==,iv:k8+pJnzdBp+PCIJtK+KJ6HgW//niqqoP5BgVVdFSYjc=,tag:yDjdWDrmTQx9yKXZAM+i7Q==,type:str]
 sops:
     age:
@@ -49,7 +49,7 @@ sops:
             aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
             FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-17T12:12:32Z"
-    mac: ENC[AES256_GCM,data:j25UlCbh1LRkPA415pGVlzjYu7Yq4AuG29Sx55V9Pq26A9zjG6VAkbY+3X1WFtbE+hvST+77uJNGcbYyiHgq+pQqLQgH9MBy08hfklbUceuZ8wdau6PQ+LM7G4uFOXkFecjPLnOUCgF/t1CIeMX/QzWSzbne61vRADeya2hdw5Y=,iv:MpDk4CNC3IYGOJNbPy5Z5he9Dbuq7E3TwW6MvGaHDIA=,tag:lW7jDEJLS5cb7hTtGkOKDA==,type:str]
+    lastmodified: "2026-05-22T15:59:54Z"
+    mac: ENC[AES256_GCM,data:XXDXVPEu14uuWjPXbsg2GEhhwXEDjcm8IHA4ihwoEeTKfv+yVyNIUoVhQlyJtV55/SjkxUx9bfi/bB+zkhMtYB93iykCU7HB984u9N3c7kLETcd6MUW/MsEkltjdAHitejgeGyV1mPibZR57auohhArEoB8eDHdNgU17B1XVjR4=,iv:M9a5wjMe1WZ9jmJpcll8BpvGSY/WpNTXkFtDPNcIIHg=,tag:AP97BlYEQs9L3qhaH0SSsA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -269,11 +269,15 @@ otelcol.processor.tail_sampling "policy" {
   }
 
   output {
-    traces = [otelcol.exporter.otlp.gc.input]
+    traces = [otelcol.exporter.otlphttp.gc.input]
   }
 }
 
-otelcol.exporter.otlp "gc" {
+// Grafana Cloud Tempo 는 OTLP HTTP gateway 만 제공 (gRPC 미지원).
+// otelcol.exporter.otlp (gRPC) 로 보내면 connection 단계에서 silent fail.
+// endpoint 는 https://otlp-gateway-...grafana.net/otlp 또는 https://tempo-...grafana.net/tempo 형식 (https scheme 필수).
+// otlphttp 가 endpoint 뒤에 /v1/traces 를 자동 append.
+otelcol.exporter.otlphttp "gc" {
   client {
     endpoint = "{{ gc_tempo_endpoint }}"
     auth     = otelcol.auth.basic.gc.handler


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #494

## Major Changes

- prod Tempo 0 traces 원인 해결: Grafana Cloud Tempo 가 OTLP HTTP gateway 만 제공 (gRPC 미지원) → `otelcol.exporter.otlp` (gRPC) 사용 중에는 connection silent fail
- `otelcol.exporter.otlp` → `otelcol.exporter.otlphttp` 전환 (공식 Alloy 가이드 `collect/opentelemetry-to-lgtm-stack` 권장)
- tail_sampling output traces reference 도 동기 변경 (`otlphttp.gc.input`)
- SOPS `gc_tempo_endpoint`: `https://` scheme 추가 (prod + dev 양쪽). otlphttp 가 endpoint 뒤 `/v1/traces` 를 자동 append 하므로 path 명시 불필요

## Validation Plan

머지 + prod 배포 (workflow_dispatch deploy-observability-prod) 후:
1. Loki Explore → `{env="prod", module="apis"} | json | trace_id!=""` 로 trace_id 픽업
2. 해당 로그 라인에서 Tempo correlation 링크 클릭 → Tempo trace view 가 열리면 성공
3. Tempo Search → `{resource.service.name=~".*beat.*"}` 직접 검색으로도 검증