### PR TITLE
fix: Spring Boot 4.0 OTLP autoconfig 적용 + env var cleanup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,7 @@ testcontainers = "1.21.3"
 redis-testcontainers = "2.2.2"
 sentry = "8.41.0"
 sentry-gradle-plugin = "6.6.0"
-micrometer-tracing = "1.4.2"
-opentelemetry = "1.55.0"
+# Micrometer Tracing / OpenTelemetry 버전은 Spring Boot 4.0 BOM 이 관리 (spring-boot-starter-opentelemetry 가 정렬된 transitive 제공)
 # JUnit Platform/Jupiter is the baseline for existing Java tests and Spring Boot starter-test.
 # Kotlin migration may add Kotest/MockK as an optional Kotlin test layer on top of this baseline,
 # not as a replacement for the shared JUnit Platform execution contract.
@@ -79,8 +78,8 @@ aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3" }
 nurigo-java-sdk = { module = "net.nurigo:javaSDK", version = "2.2" }
 
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
-micrometer-tracing-bridge-otel = { module = "io.micrometer:micrometer-tracing-bridge-otel", version.ref = "micrometer-tracing" }
-opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
+# Spring Boot 4.0 OTLP tracing starter — micrometer-tracing-bridge-otel + opentelemetry-sdk + opentelemetry-exporter-otlp + opentelemetry-api 를 BOM 정렬된 버전으로 transitive 제공
+spring-boot-starter-opentelemetry = { module = "org.springframework.boot:spring-boot-starter-opentelemetry", version.ref = "spring-boot" }
 testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 testcontainers-redis = { module = "com.redis:testcontainers-redis", version.ref = "redis-testcontainers" }

--- a/infra/ansible/inventories/dev/group_vars/all/main.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/main.yml
@@ -89,7 +89,3 @@ observability_alloy_enable_traces: false
 observability_alloy_enable_cadvisor: false
 observability_alloy_published_ports:
   - "127.0.0.1:12345:12345"
-
-# Spring Boot OTel exporter endpoint (app 컨테이너에 환경변수로 주입)
-# dev는 tracing.enabled=false라 실제 송신 안 되지만, 일관성 위해 정의
-otel_otlp_tracing_endpoint: "http://alloy:4318/v1/traces"

--- a/infra/ansible/inventories/prod/group_vars/all/main.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/main.yml
@@ -95,6 +95,3 @@ observability_alloy_published_ports:
   - "127.0.0.1:4318:4318"
 
 letsencrypt_cron_enabled: true
-
-# Spring Boot OTel exporter endpoint (app 컨테이너에 환경변수로 주입)
-otel_otlp_tracing_endpoint: "http://alloy:4318/v1/traces"

--- a/infra/ansible/roles/app_container_runtime/tasks/env.yml
+++ b/infra/ansible/roles/app_container_runtime/tasks/env.yml
@@ -8,8 +8,7 @@
           'SENTRY_RELEASE': 'beat-server@' ~ (
             app_container_runtime_release_ref
             | default(commit_sha | default(image_tag | default('unknown', true), true), true)
-          ),
-          'OTLP_TRACING_ENDPOINT': otel_otlp_tracing_endpoint
+          )
         }
         | combine({
           (app_container_runtime_module_cfg.spring_profile | upper ~ '_ACTUATOR_PORT'): actuator_port | string,

--- a/observability/build.gradle.kts
+++ b/observability/build.gradle.kts
@@ -11,8 +11,7 @@ dependencies {
     runtimeOnly(libs.sentry.log4j2)
     runtimeOnly(libs.log4j.layout.template.json)
 
-    api(libs.micrometer.tracing.bridge.otel)
-    implementation(libs.opentelemetry.exporter.otlp)
+    api(libs.spring.boot.starter.opentelemetry)
 
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.spring.boot.starter.web)

--- a/observability/src/main/resources/application-observability.yml
+++ b/observability/src/main/resources/application-observability.yml
@@ -34,16 +34,18 @@ management:
         http.server.requests: 0.95, 0.99
 
   tracing:
-    enabled: ${MANAGEMENT_TRACING_ENABLED:false}
+    enabled: false
     sampling:
-      probability: ${MANAGEMENT_TRACING_SAMPLING:1.0}
+      probability: 1.0
     propagation:
       type: W3C
-  otlp:
+  opentelemetry:
     tracing:
-      endpoint: ${OTLP_TRACING_ENDPOINT:http://localhost:4318/v1/traces}
-      transport: http
-      timeout: 10s
+      export:
+        otlp:
+          endpoint: http://alloy:4318/v1/traces
+          transport: http
+          timeout: 10s
 
 logging:
   level:


### PR DESCRIPTION
## Related issue 🛠

- closes #498

## Root cause

- Spring Boot 4.0 부터 OTLP tracing 은 `spring-boot-starter-opentelemetry` 의존성 필요 (공식 가이드 `actuator/tracing.adoc`)
- `OtlpTracingAutoConfiguration` 패키지 이동: `org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.otlp`
- `@ConditionalOnClass({OtelTracer, SdkTracerProvider, OpenTelemetry})` — starter 없이는 통과 불가 → OTLP exporter Bean 미생성 → **prod Tempo 0 traces (silent fail)**
- 진단 결정타: `sudo ss -tnp | grep ":4318"` 30초 모니터링 결과 **apis-blue → alloy:4318 TCP connection 0건**
- property prefix 변경: `management.otlp.tracing.*` → `management.opentelemetry.tracing.export.otlp.*`

## Major Changes

### Fix (root cause 해결)
- `gradle/libs.versions.toml`: `micrometer-tracing` / `opentelemetry` version pin 제거, `spring-boot-starter-opentelemetry` 추가 (`version.ref = "spring-boot"`)
- `observability/build.gradle.kts`: starter 단일 의존으로 교체 (transitive 로 bridge-otel + sdk + api + exporter-otlp 정렬)
- `application-observability.yml`: 새 property prefix 적용

### Cleanup (이번 PR에 함께 묶음)
- `OTLP_TRACING_ENDPOINT` env var 체인 제거 — alloy host (`http://alloy:4318/v1/traces`) 가 Docker network 내 고정값이라 Spring property 에 직접 하드코딩
- `MANAGEMENT_TRACING_ENABLED` / `MANAGEMENT_TRACING_SAMPLING` fallback 표현식 제거 — 어디서도 주입되지 않는 dead env var
- `app_container_runtime/tasks/env.yml` + dev/prod `group_vars/all/main.yml` 정리

## Validation Plan

1. **dev 배포 검증** (1차)
   - dev tracing 비활성이라 export 무관, 하지만 startup 정상성 확인
   - `docker logs apis | grep -iE "started|error"` → 정상 부팅

2. **prod 배포 후 핵심 검증**
   ```bash
   # apis-blue → alloy:4318 connection 발생 확인 (이번 fix 의 결정적 증거)
   sudo ss -tnp 2>/dev/null | grep ":4318"
   ```
   기대: connection 출현 (Before: 0건 → After: 출현)

3. **Tempo 최종 검증**
   - Loki Explore → `{env="prod", module="apis"} | json | trace_id!=""` → 로그 한 줄 클릭 → 🔗 Tempo 링크
   - Tempo trace view 정상 출력되면 완전 성공