### PR TITLE
release: v1.3.7 릴리즈

### DIFF
--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -18,7 +18,7 @@ gc_prom_url: ENC[AES256_GCM,data:yyZGtCz9Oqm+QdtvXVj2Gs1TtMz5VmaHFSroveLvx66/HQ/
 gc_prom_user: ENC[AES256_GCM,data:2OfoWdnEGg==,iv:9FqMdViPbcA/ZWEnVKxvDm7+NhuCIFhJ1/3e8buUCws=,tag:i6/DhO+SbFAFhef2nulH9A==,type:str]
 gc_loki_url: ENC[AES256_GCM,data:i5X6xRWXzoLBI3ICg4zfN/6U/kD3eRoxl+3CWIE250TTrMLkFc+slYVV2A35ZI3yLE8=,iv:TCiUkq5cRFhiJpDE2Q5bodcolfWjvvVLd8jTIx3Qqog=,tag:D/IFIKMhw0UBv7M+BnSmRg==,type:str]
 gc_loki_user: ENC[AES256_GCM,data:lgyX9ipumg==,iv:wPprqqwjN/CWCpdK8FLrdjNewWzSmJOkznochrxWOjU=,tag:BGHKvRmG7Fe9jz8xVGEtoQ==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:sntb0kPzTSjdosykGkSp/5sSH5JI63tIwXSy4aD8YyoI2f8HCW3/ev1qXMLzmZG2P2fHPDYSDfoL,iv:eEcAZrod1MBzF+X03uLyL8o2HopiN2uIvA26/CYv7Eg=,tag:i0hZ955k+aqXA9Kh0s7ftA==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:PsoQ1Go5se96NiuvqGghSBBbtPWzqrPoaG6VEjl2QB0733V6NeqJHnRtzA8+ST6vZmVuavaD5OgMoCgKe+pi,iv:cOaxeJAxQiJMGyFWhexOF1BdQqsBmd0ozlWjHLHJY9c=,tag:iXSH9zGjClJgZsmVYvr5qA==,type:str]
 gc_tempo_user: ENC[AES256_GCM,data:B2ylR7xOVw==,iv:k8+pJnzdBp+PCIJtK+KJ6HgW//niqqoP5BgVVdFSYjc=,tag:yDjdWDrmTQx9yKXZAM+i7Q==,type:str]
 sops:
     age:
@@ -49,7 +49,7 @@ sops:
             aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
             FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-22T15:59:54Z"
-    mac: ENC[AES256_GCM,data:XXDXVPEu14uuWjPXbsg2GEhhwXEDjcm8IHA4ihwoEeTKfv+yVyNIUoVhQlyJtV55/SjkxUx9bfi/bB+zkhMtYB93iykCU7HB984u9N3c7kLETcd6MUW/MsEkltjdAHitejgeGyV1mPibZR57auohhArEoB8eDHdNgU17B1XVjR4=,iv:M9a5wjMe1WZ9jmJpcll8BpvGSY/WpNTXkFtDPNcIIHg=,tag:AP97BlYEQs9L3qhaH0SSsA==,type:str]
+    lastmodified: "2026-05-22T17:50:57Z"
+    mac: ENC[AES256_GCM,data:3oU0iwASZTUpauSqYUn2Tp0poWQMW8dsLswHhKn8qqF75IhniT4czWY2C4O6TWkfc68mBjNM3kHHZqUR3BgKduuZaB9JKlfqPzJ4uTI1/KW2bCYLz87BOHRWnLCeEid1L269MDyVAOg3yi7iVq+jucjAZHYb7Gy9YioHC97nuag=,iv:NtXTo8CO8QxBdAvpJyqajbZago5EwxueXEsepzcy1zQ=,tag:qa3Hpa4mEtTA8xI8ZdXdrQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #504

## Release Version

- v1.3.7

## Major Changes

- prod Tempo OTLP endpoint 에 `/tempo` base path 추가하여 Grafana Cloud Tempo gateway 404 (`code = Unimplemented`) 해소 (#503)