### PR TITLE
fix: Tempo OTLP ingest 를 gRPC + scheme 없는 endpoint 로 정정

### DIFF
--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -18,7 +18,7 @@ gc_prom_url: ENC[AES256_GCM,data:yyZGtCz9Oqm+QdtvXVj2Gs1TtMz5VmaHFSroveLvx66/HQ/
 gc_prom_user: ENC[AES256_GCM,data:2OfoWdnEGg==,iv:9FqMdViPbcA/ZWEnVKxvDm7+NhuCIFhJ1/3e8buUCws=,tag:i6/DhO+SbFAFhef2nulH9A==,type:str]
 gc_loki_url: ENC[AES256_GCM,data:i5X6xRWXzoLBI3ICg4zfN/6U/kD3eRoxl+3CWIE250TTrMLkFc+slYVV2A35ZI3yLE8=,iv:TCiUkq5cRFhiJpDE2Q5bodcolfWjvvVLd8jTIx3Qqog=,tag:D/IFIKMhw0UBv7M+BnSmRg==,type:str]
 gc_loki_user: ENC[AES256_GCM,data:lgyX9ipumg==,iv:wPprqqwjN/CWCpdK8FLrdjNewWzSmJOkznochrxWOjU=,tag:BGHKvRmG7Fe9jz8xVGEtoQ==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:PsoQ1Go5se96NiuvqGghSBBbtPWzqrPoaG6VEjl2QB0733V6NeqJHnRtzA8+ST6vZmVuavaD5OgMoCgKe+pi,iv:cOaxeJAxQiJMGyFWhexOF1BdQqsBmd0ozlWjHLHJY9c=,tag:iXSH9zGjClJgZsmVYvr5qA==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:rywCJsKUY9t11P3qdqh23sOQj0QyRen1cymQmSORpNC0zdriaahzoGfl1PuUGA/Zjg==,iv:VWDGXW9j7mXRNm4aIOx+DLAH80mlPcME528TKyUHW9s=,tag:zq1YQtxpEK1ZoOx93DaMXg==,type:str]
 gc_tempo_user: ENC[AES256_GCM,data:B2ylR7xOVw==,iv:k8+pJnzdBp+PCIJtK+KJ6HgW//niqqoP5BgVVdFSYjc=,tag:yDjdWDrmTQx9yKXZAM+i7Q==,type:str]
 sops:
     age:
@@ -49,7 +49,7 @@ sops:
             aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
             FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-22T17:50:57Z"
-    mac: ENC[AES256_GCM,data:3oU0iwASZTUpauSqYUn2Tp0poWQMW8dsLswHhKn8qqF75IhniT4czWY2C4O6TWkfc68mBjNM3kHHZqUR3BgKduuZaB9JKlfqPzJ4uTI1/KW2bCYLz87BOHRWnLCeEid1L269MDyVAOg3yi7iVq+jucjAZHYb7Gy9YioHC97nuag=,iv:NtXTo8CO8QxBdAvpJyqajbZago5EwxueXEsepzcy1zQ=,tag:qa3Hpa4mEtTA8xI8ZdXdrQ==,type:str]
+    lastmodified: "2026-05-22T18:27:57Z"
+    mac: ENC[AES256_GCM,data:xmo5V7POeNTPUODPWGJHp2qtX58E1I/JGzdaB60j8olCu6i3/j5leKm7OXioLLDtb8bh0T77wNUc/u2HsFoHZ3fWK4qYzhr4bgfrRglVTPhcwn/3Nb/qTDECxRaiQjNgfBzKETawu9XYwEmcuT3gxxU6UjcSywYTmFTRoLokC8k=,iv:o4i20JbeDi2+FX9ueRO92jRClZMUY9TYPqf0v6hkMJ4=,tag:bz99j/CUOBbpUy5yGSwM7g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -269,15 +269,15 @@ otelcol.processor.tail_sampling "policy" {
   }
 
   output {
-    traces = [otelcol.exporter.otlphttp.gc.input]
+    traces = [otelcol.exporter.otlp.gc.input]
   }
 }
 
-// Grafana Cloud Tempo 는 OTLP HTTP gateway 만 제공 (gRPC 미지원).
-// otelcol.exporter.otlp (gRPC) 로 보내면 connection 단계에서 silent fail.
-// endpoint 는 https://otlp-gateway-...grafana.net/otlp 또는 https://tempo-...grafana.net/tempo 형식 (https scheme 필수).
-// otlphttp 가 endpoint 뒤에 /v1/traces 를 자동 append.
-otelcol.exporter.otlphttp "gc" {
+// Grafana Cloud Tempo OTLP ingest — 콘솔의 공식 Alloy example 기준.
+//   exporter: otelcol.exporter.otlp (gRPC, port 443/TLS)
+//   endpoint: tempo-prod-XX-<region>.grafana.net:443  (scheme/path 없음)
+// tempo-...grafana.net/tempo 는 Grafana datasource 가 query 할 때 쓰는 URL 이지 OTLP ingest 와 다름.
+otelcol.exporter.otlp "gc" {
   client {
     endpoint = "{{ gc_tempo_endpoint }}"
     auth     = otelcol.auth.basic.gc.handler


### PR DESCRIPTION
## Related issue 🛠

- closes #506

## Root cause 재정리

PR #495 / #503 의 가설(`Tempo 는 HTTP gateway 만 제공` / `/tempo path 필요`) 이 **모두 틀렸음**. Grafana Cloud 콘솔의 공식 Alloy example 은 **gRPC + scheme 없는 endpoint** 를 명시.

### Grafana Cloud 공식 예시

```alloy
otelcol.exporter.otlp "grafanacloud" {
  client {
    endpoint = "tempo-prod-20-prod-ap-northeast-0.grafana.net:443"
    auth     = otelcol.auth.basic.grafanacloud.handler
  }
}
```

### 시도 매트릭스

| 시도 | exporter | endpoint | 결과 |
|------|----------|----------|------|
| 초기 | `otelcol.exporter.otlp` (gRPC) | `…grafana.net:443` | App OTLP 미작동 (PR #499 전) — 진단 불가 |
| PR #495 | `otlphttp` 로 전환 | `https://…grafana.net:443` | 404 |
| PR #503 | `otlphttp` (그대로) | `https://…grafana.net:443/tempo` | 404 |
| ✅ Fix | `otelcol.exporter.otlp` (**gRPC**) | `tempo-…grafana.net:443` | 200 (기대) |

`https://…grafana.net/tempo` 는 **Grafana datasource 가 query 할 때 쓰는 URL** 이지 OTLP **ingest** 가 아님. 우리가 docs 의 datasource URL 을 ingest 로 오해해서 두 번 잘못 fix.

초기 gRPC 시점의 trace 0 건은 사실 Spring Boot 4.0 OTLP autoconfig 미적용 (PR #499 가 fix) 때문 — 그땐 app 이 아예 OTLP 발신 안 했으니 gRPC 도 도착 못함 → 우리가 gRPC 문제로 오진단.

## Fix

1. `config.alloy.j2`: `otelcol.exporter.otlphttp "gc"` → `otelcol.exporter.otlp "gc"` (gRPC) + 주석 정정
2. prod SOPS `gc_tempo_endpoint`: `https://tempo-…grafana.net:443/tempo` → `tempo-…grafana.net:443`

## 배포 / 검증

PR 머지 + v1.3.8 release 후:

```bash
gh workflow run deploy-observability-prod.yml -f deploy_ref=main
```

검증:

```bash
docker logs alloy --since 5m 2>&1 | grep "Exporting failed"
# 기대: 0건
```

Grafana Cloud Tempo Explore 에서 trace 출현 + Loki trace_id → Tempo 링크 정상 동작 확인.