### PR TITLE
release: v1.3.8 릴리즈

### DIFF
--- a/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -18,7 +18,7 @@ gc_prom_url: ENC[AES256_GCM,data:yyZGtCz9Oqm+QdtvXVj2Gs1TtMz5VmaHFSroveLvx66/HQ/
 gc_prom_user: ENC[AES256_GCM,data:2OfoWdnEGg==,iv:9FqMdViPbcA/ZWEnVKxvDm7+NhuCIFhJ1/3e8buUCws=,tag:i6/DhO+SbFAFhef2nulH9A==,type:str]
 gc_loki_url: ENC[AES256_GCM,data:i5X6xRWXzoLBI3ICg4zfN/6U/kD3eRoxl+3CWIE250TTrMLkFc+slYVV2A35ZI3yLE8=,iv:TCiUkq5cRFhiJpDE2Q5bodcolfWjvvVLd8jTIx3Qqog=,tag:D/IFIKMhw0UBv7M+BnSmRg==,type:str]
 gc_loki_user: ENC[AES256_GCM,data:lgyX9ipumg==,iv:wPprqqwjN/CWCpdK8FLrdjNewWzSmJOkznochrxWOjU=,tag:BGHKvRmG7Fe9jz8xVGEtoQ==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:PsoQ1Go5se96NiuvqGghSBBbtPWzqrPoaG6VEjl2QB0733V6NeqJHnRtzA8+ST6vZmVuavaD5OgMoCgKe+pi,iv:cOaxeJAxQiJMGyFWhexOF1BdQqsBmd0ozlWjHLHJY9c=,tag:iXSH9zGjClJgZsmVYvr5qA==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:rywCJsKUY9t11P3qdqh23sOQj0QyRen1cymQmSORpNC0zdriaahzoGfl1PuUGA/Zjg==,iv:VWDGXW9j7mXRNm4aIOx+DLAH80mlPcME528TKyUHW9s=,tag:zq1YQtxpEK1ZoOx93DaMXg==,type:str]
 gc_tempo_user: ENC[AES256_GCM,data:B2ylR7xOVw==,iv:k8+pJnzdBp+PCIJtK+KJ6HgW//niqqoP5BgVVdFSYjc=,tag:yDjdWDrmTQx9yKXZAM+i7Q==,type:str]
 sops:
     age:
@@ -49,7 +49,7 @@ sops:
             aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
             FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-22T17:50:57Z"
-    mac: ENC[AES256_GCM,data:3oU0iwASZTUpauSqYUn2Tp0poWQMW8dsLswHhKn8qqF75IhniT4czWY2C4O6TWkfc68mBjNM3kHHZqUR3BgKduuZaB9JKlfqPzJ4uTI1/KW2bCYLz87BOHRWnLCeEid1L269MDyVAOg3yi7iVq+jucjAZHYb7Gy9YioHC97nuag=,iv:NtXTo8CO8QxBdAvpJyqajbZago5EwxueXEsepzcy1zQ=,tag:qa3Hpa4mEtTA8xI8ZdXdrQ==,type:str]
+    lastmodified: "2026-05-22T18:27:57Z"
+    mac: ENC[AES256_GCM,data:xmo5V7POeNTPUODPWGJHp2qtX58E1I/JGzdaB60j8olCu6i3/j5leKm7OXioLLDtb8bh0T77wNUc/u2HsFoHZ3fWK4qYzhr4bgfrRglVTPhcwn/3Nb/qTDECxRaiQjNgfBzKETawu9XYwEmcuT3gxxU6UjcSywYTmFTRoLokC8k=,iv:o4i20JbeDi2+FX9ueRO92jRClZMUY9TYPqf0v6hkMJ4=,tag:bz99j/CUOBbpUy5yGSwM7g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -269,15 +269,15 @@ otelcol.processor.tail_sampling "policy" {
   }
 
   output {
-    traces = [otelcol.exporter.otlphttp.gc.input]
+    traces = [otelcol.exporter.otlp.gc.input]
   }
 }
 
-// Grafana Cloud Tempo 는 OTLP HTTP gateway 만 제공 (gRPC 미지원).
-// otelcol.exporter.otlp (gRPC) 로 보내면 connection 단계에서 silent fail.
-// endpoint 는 https://otlp-gateway-...grafana.net/otlp 또는 https://tempo-...grafana.net/tempo 형식 (https scheme 필수).
-// otlphttp 가 endpoint 뒤에 /v1/traces 를 자동 append.
-otelcol.exporter.otlphttp "gc" {
+// Grafana Cloud Tempo OTLP ingest — 콘솔의 공식 Alloy example 기준.
+//   exporter: otelcol.exporter.otlp (gRPC, port 443/TLS)
+//   endpoint: tempo-prod-XX-<region>.grafana.net:443  (scheme/path 없음)
+// tempo-...grafana.net/tempo 는 Grafana datasource 가 query 할 때 쓰는 URL 이지 OTLP ingest 와 다름.
+otelcol.exporter.otlp "gc" {
   client {
     endpoint = "{{ gc_tempo_endpoint }}"
     auth     = otelcol.auth.basic.gc.handler


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #508

## Release Version

- v1.3.8

## Major Changes

- Tempo OTLP ingest 를 gRPC + scheme 없는 endpoint 로 정정 — PR #495 / #503 의 datasource URL ↔ ingest URL 혼동 해소 (#507)