### PR TITLE
refactor: image CDN 처리 스파게티 정리 + Jackson 3 정합 + 운영 안정성 보강

### DIFF
--- a/admin/src/main/java/com/beat/admin/handler/AdminGlobalExceptionHandler.java
+++ b/admin/src/main/java/com/beat/admin/handler/AdminGlobalExceptionHandler.java
@@ -32,6 +32,12 @@ public class AdminGlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(exception.getBaseErrorCode()));
 	}
 
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(final IllegalArgumentException exception) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), exception.getMessage()));
+	}
+
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
 		MethodArgumentNotValidException exception) {

--- a/admin/src/main/java/com/beat/admin/promotion/application/dto/result/AdminPromotionResults.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/dto/result/AdminPromotionResults.java
@@ -2,6 +2,8 @@ package com.beat.admin.promotion.application.dto.result;
 
 import java.util.List;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record AdminPromotionResults(
 	List<AdminPromotionResult> promotionResults
 ) {
@@ -17,7 +19,7 @@ public record AdminPromotionResults(
 	public record AdminPromotionResult(
 		Long promotionId,
 		String carouselNumber,
-		String newImageUrl,
+		@CdnImageUrl String newImageUrl,
 		boolean isExternal,
 		String redirectUrl,
 		Long performanceId

--- a/admin/src/main/java/com/beat/admin/promotion/application/service/command/AdminPromotionCommandService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/service/command/AdminPromotionCommandService.java
@@ -10,8 +10,8 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.beat.admin.application.exception.AdminApplicationErrorCode;
 import com.beat.admin.common.application.converter.AdminCarouselNumberEnumConverter;
-
 import com.beat.admin.promotion.application.dto.request.AdminCarouselNumber;
 import com.beat.admin.promotion.application.dto.request.CarouselHandleRequest;
 import com.beat.admin.promotion.application.dto.request.CarouselHandleRequest.PromotionGenerateRequest;
@@ -20,7 +20,6 @@ import com.beat.admin.promotion.application.dto.request.PromotionHandleRequest;
 import com.beat.admin.promotion.application.dto.response.CarouselHandleAllResponse;
 import com.beat.admin.promotion.application.dto.result.AdminPromotionResults;
 import com.beat.admin.promotion.application.dto.result.AdminPromotionResults.AdminPromotionResult;
-import com.beat.admin.application.exception.AdminApplicationErrorCode;
 import com.beat.domain.member.repository.MemberRepository;
 import com.beat.domain.performance.repository.PerformanceRepository;
 import com.beat.domain.promotion.domain.CarouselNumber;
@@ -28,6 +27,7 @@ import com.beat.domain.promotion.domain.Promotion;
 import com.beat.domain.promotion.repository.PromotionRepository;
 import com.beat.global.support.exception.BadRequestException;
 import com.beat.global.support.exception.NotFoundException;
+import com.beat.global.support.utils.ImageKeyExtractor;
 
 import lombok.RequiredArgsConstructor;
 
@@ -148,7 +148,8 @@ public class AdminPromotionCommandService {
 
 				Promotion updatedPromotion = promotion.updatePromotionDetails(
 					toCarouselNumber(modifyRequest.carouselNumber()),
-					modifyRequest.newImageUrl(), modifyRequest.isExternal(), modifyRequest.redirectUrl(),
+					ImageKeyExtractor.extract(modifyRequest.newImageUrl()), modifyRequest.isExternal(),
+					modifyRequest.redirectUrl(),
 					performanceId);
 				return promotionRepository.save(updatedPromotion);
 			})
@@ -160,7 +161,8 @@ public class AdminPromotionCommandService {
 			.map(generateRequest -> {
 				Long performanceId = validatePerformanceId(generateRequest.performanceId());
 
-				Promotion newPromotion = Promotion.create(generateRequest.newImageUrl(), performanceId,
+				Promotion newPromotion = Promotion.create(ImageKeyExtractor.extract(generateRequest.newImageUrl()),
+					performanceId,
 					generateRequest.redirectUrl(), generateRequest.isExternal(),
 					toCarouselNumber(generateRequest.carouselNumber()));
 				return promotionRepository.save(newPromotion);

--- a/admin/src/main/java/com/beat/admin/promotion/application/service/query/AdminPromotionQueryService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/service/query/AdminPromotionQueryService.java
@@ -6,9 +6,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.beat.admin.common.application.converter.AdminCarouselNumberEnumConverter;
-
 import com.beat.admin.application.exception.AdminApplicationErrorCode;
+import com.beat.admin.common.application.converter.AdminCarouselNumberEnumConverter;
 import com.beat.admin.promotion.application.dto.response.BannerPresignedUrlFindResponse;
 import com.beat.admin.promotion.application.dto.response.CarouselFindAllResponse;
 import com.beat.admin.promotion.application.dto.response.CarouselPresignedUrlFindAllResponse;

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
@@ -93,9 +93,9 @@ class AdminPromotionCommandServiceTest {
 		});
 
 		CarouselHandleRequest request = new CarouselHandleRequest(List.of(
-			new PromotionModifyRequest(1L, AdminCarouselNumber.THREE, "modified-image", true, "modified-url",
+			new PromotionModifyRequest(1L, AdminCarouselNumber.THREE, "carousel/modified-image", true, "modified-url",
 				PERFORMANCE_ID),
-			new PromotionGenerateRequest(AdminCarouselNumber.ONE, "created-image", false, "created-url", null)
+			new PromotionGenerateRequest(AdminCarouselNumber.ONE, "carousel/created-image", false, "created-url", null)
 		));
 
 		CarouselHandleAllResponse response =
@@ -109,10 +109,10 @@ class AdminPromotionCommandServiceTest {
 
 		assertEquals(2, response.modifiedPromotionResponses().size());
 		assertEquals(3L, response.modifiedPromotionResponses().get(0).promotionId());
-		assertEquals("created-image", response.modifiedPromotionResponses().get(0).newImageUrl());
+		assertEquals("carousel/created-image", response.modifiedPromotionResponses().get(0).newImageUrl());
 		assertEquals("ONE", response.modifiedPromotionResponses().get(0).carouselNumber());
 		assertEquals(1L, response.modifiedPromotionResponses().get(1).promotionId());
-		assertEquals("modified-image", response.modifiedPromotionResponses().get(1).newImageUrl());
+		assertEquals("carousel/modified-image", response.modifiedPromotionResponses().get(1).newImageUrl());
 		assertEquals("THREE", response.modifiedPromotionResponses().get(1).carouselNumber());
 	}
 

--- a/apis/src/main/java/com/beat/apis/booking/application/MemberBookingRetrieveService.java
+++ b/apis/src/main/java/com/beat/apis/booking/application/MemberBookingRetrieveService.java
@@ -1,8 +1,5 @@
 package com.beat.apis.booking.application;
 
-import com.beat.apis.common.application.converter.BookingStatusEnumConverter;
-import com.beat.apis.common.application.converter.BankNameEnumConverter;
-import com.beat.apis.common.application.converter.ScheduleNumberEnumConverter;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
@@ -13,8 +10,15 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import com.beat.apis.booking.application.dto.MemberBookingRetrieveResponse;
-import com.beat.domain.booking.repository.BookingRepository;
+import com.beat.apis.common.application.converter.BankNameEnumConverter;
+import com.beat.apis.common.application.converter.BookingStatusEnumConverter;
+import com.beat.apis.common.application.converter.ScheduleNumberEnumConverter;
+import com.beat.apis.member.application.exception.MemberApplicationErrorCode;
+import com.beat.apis.performance.application.exception.PerformanceApplicationErrorCode;
+import com.beat.apis.schedule.application.exception.ScheduleApplicationErrorCode;
+import com.beat.apis.user.application.exception.UserApplicationErrorCode;
 import com.beat.domain.booking.domain.Booking;
+import com.beat.domain.booking.repository.BookingRepository;
 import com.beat.domain.member.domain.Member;
 import com.beat.domain.member.repository.MemberRepository;
 import com.beat.domain.performance.domain.Performance;
@@ -27,10 +31,6 @@ import com.beat.domain.user.repository.UserRepository;
 import com.beat.global.support.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
-import com.beat.apis.member.application.exception.MemberApplicationErrorCode;
-import com.beat.apis.performance.application.exception.PerformanceApplicationErrorCode;
-import com.beat.apis.schedule.application.exception.ScheduleApplicationErrorCode;
-import com.beat.apis.user.application.exception.UserApplicationErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -81,7 +81,8 @@ public class MemberBookingRetrieveService {
 			.collect(Collectors.toMap(Performance::getId, Function.identity()));
 	}
 
-	private MemberBookingRetrieveResponse toMemberBookingResponse(LocalDate today, Booking booking, Map<Long, Schedule> scheduleMap,
+	private MemberBookingRetrieveResponse toMemberBookingResponse(LocalDate today, Booking booking,
+		Map<Long, Schedule> scheduleMap,
 		Map<Long, Performance> performanceMap) {
 		Schedule schedule = findScheduleForBooking(scheduleMap, booking);
 		Performance performance = findPerformanceForSchedule(performanceMap, schedule);

--- a/apis/src/main/java/com/beat/apis/booking/application/dto/GuestBookingRetrieveResponse.java
+++ b/apis/src/main/java/com/beat/apis/booking/application/dto/GuestBookingRetrieveResponse.java
@@ -1,10 +1,10 @@
 package com.beat.apis.booking.application.dto;
 
-import com.beat.apis.booking.application.dto.BookingStatusType;
+import java.time.LocalDateTime;
+
 import com.beat.apis.performance.application.dto.BankNameType;
 import com.beat.apis.schedule.application.dto.ScheduleNumberType;
-
-import java.time.LocalDateTime;
+import com.beat.global.support.jackson.CdnImageUrl;
 
 public record GuestBookingRetrieveResponse(
 	Long bookingId,
@@ -23,7 +23,7 @@ public record GuestBookingRetrieveResponse(
 	int dueDate,
 	BookingStatusType bookingStatus,
 	LocalDateTime createdAt,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	int totalPaymentAmount
 ) {
 	public static GuestBookingRetrieveResponse of(

--- a/apis/src/main/java/com/beat/apis/booking/application/dto/MemberBookingRetrieveResponse.java
+++ b/apis/src/main/java/com/beat/apis/booking/application/dto/MemberBookingRetrieveResponse.java
@@ -1,10 +1,10 @@
 package com.beat.apis.booking.application.dto;
 
-import com.beat.apis.booking.application.dto.BookingStatusType;
+import java.time.LocalDateTime;
+
 import com.beat.apis.performance.application.dto.BankNameType;
 import com.beat.apis.schedule.application.dto.ScheduleNumberType;
-
-import java.time.LocalDateTime;
+import com.beat.global.support.jackson.CdnImageUrl;
 
 public record MemberBookingRetrieveResponse(
 	Long userId,
@@ -24,7 +24,7 @@ public record MemberBookingRetrieveResponse(
 	int dueDate,
 	BookingStatusType bookingStatus,
 	LocalDateTime createdAt,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	int totalPaymentAmount
 ) {
 	public static MemberBookingRetrieveResponse of(

--- a/apis/src/main/java/com/beat/apis/common/handler/GlobalExceptionHandler.java
+++ b/apis/src/main/java/com/beat/apis/common/handler/GlobalExceptionHandler.java
@@ -33,6 +33,13 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(exception.getBaseErrorCode()));
 	}
 
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(final IllegalArgumentException exception) {
+		log.warn("IllegalArgumentException: {}", exception.getMessage());
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), exception.getMessage()));
+	}
+
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
 		MethodArgumentNotValidException exception) {

--- a/apis/src/main/java/com/beat/apis/home/application/HomeService.java
+++ b/apis/src/main/java/com/beat/apis/home/application/HomeService.java
@@ -1,6 +1,5 @@
 package com.beat.apis.home.application;
 
-import com.beat.apis.common.application.converter.GenreEnumConverter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -10,6 +9,7 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.beat.apis.common.application.converter.GenreEnumConverter;
 import com.beat.apis.home.application.dto.HomeFindAllResponse;
 import com.beat.apis.home.application.dto.HomeFindRequest;
 import com.beat.apis.home.application.dto.HomeGenreType;

--- a/apis/src/main/java/com/beat/apis/home/application/dto/HomePerformanceDetail.java
+++ b/apis/src/main/java/com/beat/apis/home/application/dto/HomePerformanceDetail.java
@@ -1,5 +1,7 @@
 package com.beat.apis.home.application.dto;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record HomePerformanceDetail(
 	Long performanceId,
 	String performanceTitle,
@@ -7,7 +9,7 @@ public record HomePerformanceDetail(
 	int ticketPrice,
 	int dueDate,
 	String genre,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	String performanceVenue
 ) {
 

--- a/apis/src/main/java/com/beat/apis/home/application/dto/HomePromotionDetail.java
+++ b/apis/src/main/java/com/beat/apis/home/application/dto/HomePromotionDetail.java
@@ -1,16 +1,20 @@
 package com.beat.apis.home.application.dto;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record HomePromotionDetail(
 	Long promotionId,
-	String promotionPhoto,
+	@CdnImageUrl String promotionPhoto,
 	Long performanceId,
 	String redirectUrl,
 	boolean isExternal,
 	String carouselNumber
 ) {
 
-	public static HomePromotionDetail of(Long promotionId, String promotionPhoto, Long performanceId, String redirectUrl,
+	public static HomePromotionDetail of(Long promotionId, String promotionPhoto, Long performanceId,
+		String redirectUrl,
 		boolean isExternal, String carouselNumber) {
-		return new HomePromotionDetail(promotionId, promotionPhoto, performanceId, redirectUrl, isExternal, carouselNumber);
+		return new HomePromotionDetail(promotionId, promotionPhoto, performanceId, redirectUrl, isExternal,
+			carouselNumber);
 	}
 }

--- a/apis/src/main/java/com/beat/apis/performance/application/PerformanceManagementService.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/PerformanceManagementService.java
@@ -1,8 +1,5 @@
 package com.beat.apis.performance.application;
 
-import com.beat.apis.common.application.converter.GenreEnumConverter;
-import com.beat.apis.common.application.converter.BankNameEnumConverter;
-import com.beat.apis.common.application.converter.ScheduleNumberEnumConverter;
 import static java.util.Comparator.comparing;
 
 import java.time.LocalDate;
@@ -14,6 +11,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.beat.apis.common.application.converter.BankNameEnumConverter;
+import com.beat.apis.common.application.converter.GenreEnumConverter;
+import com.beat.apis.common.application.converter.ScheduleNumberEnumConverter;
 import com.beat.apis.member.application.exception.MemberApplicationErrorCode;
 import com.beat.apis.performance.application.dto.create.CastResponse;
 import com.beat.apis.performance.application.dto.create.PerformanceImageResponse;
@@ -22,6 +22,7 @@ import com.beat.apis.performance.application.dto.create.PerformanceResponse;
 import com.beat.apis.performance.application.dto.create.ScheduleResponse;
 import com.beat.apis.performance.application.dto.create.StaffResponse;
 import com.beat.apis.performance.application.exception.PerformanceApplicationErrorCode;
+import com.beat.contracts.cdn.ImageCachePort;
 import com.beat.contracts.schedule.ScheduleBookingCloseJobPort;
 import com.beat.contracts.schedule.ScheduleBookingCloseJobTarget;
 import com.beat.domain.booking.domain.BookingStatus;
@@ -44,6 +45,7 @@ import com.beat.domain.staff.repository.StaffRepository;
 import com.beat.global.support.exception.BadRequestException;
 import com.beat.global.support.exception.ForbiddenException;
 import com.beat.global.support.exception.NotFoundException;
+import com.beat.global.support.utils.ImageKeyExtractor;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,6 +64,7 @@ public class PerformanceManagementService {
 	private final PerformanceImageRepository performanceImageRepository;
 	private final PromotionRepository promotionRepository;
 	private final ScheduleBookingCloseJobPort scheduleBookingCloseJobPort;
+	private final ImageCachePort imageCachePort;
 	private final ScheduleDomainService scheduleDomainService = new ScheduleDomainService();
 
 	@Transactional
@@ -78,7 +81,7 @@ public class PerformanceManagementService {
 			BankNameEnumConverter.toDomain(request.bankName()),
 			request.accountNumber(),
 			request.accountHolder(),
-			request.posterImage(),
+			ImageKeyExtractor.extract(request.posterImage()),
 			request.performanceTeamName(),
 			request.performanceVenue(),
 			request.roadAddressName(),
@@ -128,7 +131,7 @@ public class PerformanceManagementService {
 			.map(castRequest -> Cast.create(
 				castRequest.castName(),
 				castRequest.castRole(),
-				castRequest.castPhoto(),
+				ImageKeyExtractor.extract(castRequest.castPhoto()),
 				savedPerformanceId
 			))
 			.toList());
@@ -137,7 +140,7 @@ public class PerformanceManagementService {
 			.map(staffRequest -> Staff.create(
 				staffRequest.staffName(),
 				staffRequest.staffRole(),
-				staffRequest.staffPhoto(),
+				ImageKeyExtractor.extract(staffRequest.staffPhoto()),
 				savedPerformanceId
 			))
 			.toList());
@@ -145,11 +148,13 @@ public class PerformanceManagementService {
 		List<PerformanceImage> performanceImageList = performanceImageRepository.saveAll(
 			request.performanceImageList().stream()
 				.map(performanceImageRequest -> PerformanceImage.create(
-					performanceImageRequest.performanceImage(),
+					ImageKeyExtractor.extract(performanceImageRequest.performanceImage()),
 					savedPerformanceId
 				))
 				.toList()
 		);
+
+		imageCachePort.preWarm(savedPerformance.getPosterImage());
 
 		return mapToPerformanceResponse(savedPerformance, schedules, casts, staffs, performanceImageList);
 	}

--- a/apis/src/main/java/com/beat/apis/performance/application/PerformanceModifyService.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/PerformanceModifyService.java
@@ -1,8 +1,5 @@
 package com.beat.apis.performance.application;
 
-import com.beat.apis.common.application.converter.GenreEnumConverter;
-import com.beat.apis.common.application.converter.BankNameEnumConverter;
-import com.beat.apis.common.application.converter.ScheduleNumberEnumConverter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +9,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.beat.apis.common.application.converter.BankNameEnumConverter;
+import com.beat.apis.common.application.converter.GenreEnumConverter;
+import com.beat.apis.common.application.converter.ScheduleNumberEnumConverter;
 import com.beat.apis.member.application.exception.MemberApplicationErrorCode;
 import com.beat.apis.performance.application.dto.modify.PerformanceModifyRequest;
 import com.beat.apis.performance.application.dto.modify.PerformanceModifyResponse;
@@ -28,6 +28,7 @@ import com.beat.apis.performance.application.exception.PerformanceApplicationErr
 import com.beat.apis.performance.application.exception.PerformanceImageApplicationErrorCode;
 import com.beat.apis.performance.application.exception.StaffApplicationErrorCode;
 import com.beat.apis.schedule.application.exception.ScheduleApplicationErrorCode;
+import com.beat.contracts.cdn.ImageCachePort;
 import com.beat.contracts.schedule.ScheduleBookingCloseJobPort;
 import com.beat.contracts.schedule.ScheduleBookingCloseJobTarget;
 import com.beat.domain.booking.domain.BookingStatus;
@@ -49,6 +50,7 @@ import com.beat.domain.staff.repository.StaffRepository;
 import com.beat.global.support.exception.BadRequestException;
 import com.beat.global.support.exception.ForbiddenException;
 import com.beat.global.support.exception.NotFoundException;
+import com.beat.global.support.utils.ImageKeyExtractor;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +68,7 @@ public class PerformanceModifyService {
 	private final BookingRepository bookingRepository;
 	private final PerformanceImageRepository performanceImageRepository;
 	private final ScheduleBookingCloseJobPort scheduleBookingCloseJobPort;
+	private final ImageCachePort imageCachePort;
 	private final ScheduleDomainService scheduleDomainService = new ScheduleDomainService();
 
 	@Transactional
@@ -99,6 +102,8 @@ public class PerformanceModifyService {
 
 		PerformanceModifyResponse response = completeModifyResponse(performance, modifiedSchedules, modifiedCasts,
 			modifiedStaffs, modifiedPerformanceImages);
+
+		imageCachePort.preWarm(performance.getPosterImage());
 
 		log.info("Successfully completed updatePerformance for performanceId: {}", request.performanceId());
 		return response;
@@ -146,7 +151,7 @@ public class PerformanceModifyService {
 			BankNameEnumConverter.toDomain(request.bankName()),
 			request.accountNumber(),
 			request.accountHolder(),
-			request.posterImage(),
+			ImageKeyExtractor.extract(request.posterImage()),
 			request.performanceTeamName(),
 			request.performanceVenue(),
 			request.roadAddressName(),
@@ -358,7 +363,7 @@ public class PerformanceModifyService {
 		Cast cast = Cast.create(
 			request.castName(),
 			request.castRole(),
-			request.castPhoto(),
+			ImageKeyExtractor.extract(request.castPhoto()),
 			performance.getId()
 		);
 		Cast savedCast = castRepository.save(cast);
@@ -387,7 +392,7 @@ public class PerformanceModifyService {
 		cast = castRepository.save(cast.update(
 			request.castName(),
 			request.castRole(),
-			request.castPhoto()
+			ImageKeyExtractor.extract(request.castPhoto())
 		));
 		log.debug("Updated cast with castId: {}", cast.getId());
 		return CastModifyResponse.of(
@@ -442,7 +447,7 @@ public class PerformanceModifyService {
 		Staff staff = Staff.create(
 			request.staffName(),
 			request.staffRole(),
-			request.staffPhoto(),
+			ImageKeyExtractor.extract(request.staffPhoto()),
 			performance.getId()
 		);
 		Staff savedStaff = staffRepository.save(staff);
@@ -471,7 +476,7 @@ public class PerformanceModifyService {
 		staff = staffRepository.save(staff.update(
 			request.staffName(),
 			request.staffRole(),
-			request.staffPhoto()
+			ImageKeyExtractor.extract(request.staffPhoto())
 		));
 		log.debug("Updated staff with staffId: {}", staff.getId());
 		return StaffModifyResponse.of(
@@ -526,7 +531,7 @@ public class PerformanceModifyService {
 		log.debug("Adding performanceImages for performanceId: {}", performance.getId());
 
 		PerformanceImage performanceImage = PerformanceImage.create(
-			request.performanceImage(),
+			ImageKeyExtractor.extract(request.performanceImage()),
 			performance.getId()
 		);
 		PerformanceImage savedPerformanceImage = performanceImageRepository.save(performanceImage);
@@ -552,7 +557,8 @@ public class PerformanceModifyService {
 				PerformanceImageApplicationErrorCode.PERFORMANCE_IMAGE_NOT_BELONG_TO_PERFORMANCE);
 		}
 
-		performanceImage = performanceImageRepository.save(performanceImage.update(request.performanceImage()));
+		performanceImage = performanceImageRepository.save(
+			performanceImage.update(ImageKeyExtractor.extract(request.performanceImage())));
 		log.debug("Updated performanceImage: {}", performanceImage.getId());
 		return PerformanceImageModifyResponse.of(
 			performanceImage.getId(),

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/bookingPerformanceDetail/BookingPerformanceDetailResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/bookingPerformanceDetail/BookingPerformanceDetailResponse.java
@@ -2,6 +2,8 @@ package com.beat.apis.performance.application.dto.bookingPerformanceDetail;
 
 import java.util.List;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record BookingPerformanceDetailResponse(
 	Long performanceId,
 	String performanceTitle,
@@ -9,7 +11,7 @@ public record BookingPerformanceDetailResponse(
 	List<BookingPerformanceDetailScheduleResponse> scheduleList,
 	int ticketPrice,
 	String genre,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	String performanceVenue,
 	String performanceTeamName,
 	String bankName,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/create/CastResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/create/CastResponse.java
@@ -1,10 +1,12 @@
 package com.beat.apis.performance.application.dto.create;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record CastResponse(
 	Long castId,
 	String castName,
 	String castRole,
-	String castPhoto
+	@CdnImageUrl String castPhoto
 ) {
 	public static CastResponse of(
 		Long castId,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/create/PerformanceImageResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/create/PerformanceImageResponse.java
@@ -1,8 +1,10 @@
 package com.beat.apis.performance.application.dto.create;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record PerformanceImageResponse(
 	Long imageId,
-	String imageUrl
+	@CdnImageUrl String imageUrl
 ) {
 	public static PerformanceImageResponse of(
 		Long imageId,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/create/PerformanceResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/create/PerformanceResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.beat.apis.performance.application.dto.BankNameType;
 import com.beat.apis.performance.application.dto.GenreType;
+import com.beat.global.support.jackson.CdnImageUrl;
 
 public record PerformanceResponse(
 	Long userId,
@@ -16,7 +17,7 @@ public record PerformanceResponse(
 	BankNameType bankName,
 	String accountNumber,
 	String accountHolder,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	String performanceTeamName,
 	String performanceVenue,
 	String roadAddressName,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/create/StaffResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/create/StaffResponse.java
@@ -1,10 +1,12 @@
 package com.beat.apis.performance.application.dto.create;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record StaffResponse(
 	Long staffId,
 	String staffName,
 	String staffRole,
-	String staffPhoto
+	@CdnImageUrl String staffPhoto
 ) {
 	public static StaffResponse of(
 		Long staffId,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/makerPerformance/MakerPerformanceDetailResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/makerPerformance/MakerPerformanceDetailResponse.java
@@ -1,10 +1,12 @@
 package com.beat.apis.performance.application.dto.makerPerformance;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record MakerPerformanceDetailResponse(
 	Long performanceId,
 	String genre,
 	String performanceTitle,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	String performancePeriod,
 	int minDueDate
 ) {

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/modify/PerformanceModifyDetailResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/modify/PerformanceModifyDetailResponse.java
@@ -2,12 +2,13 @@ package com.beat.apis.performance.application.dto.modify;
 
 import java.util.List;
 
+import com.beat.apis.performance.application.dto.BankNameType;
+import com.beat.apis.performance.application.dto.GenreType;
 import com.beat.apis.performance.application.dto.create.CastResponse;
 import com.beat.apis.performance.application.dto.create.PerformanceImageResponse;
 import com.beat.apis.performance.application.dto.create.ScheduleResponse;
 import com.beat.apis.performance.application.dto.create.StaffResponse;
-import com.beat.apis.performance.application.dto.BankNameType;
-import com.beat.apis.performance.application.dto.GenreType;
+import com.beat.global.support.jackson.CdnImageUrl;
 
 public record PerformanceModifyDetailResponse(
 	Long userId,
@@ -20,7 +21,7 @@ public record PerformanceModifyDetailResponse(
 	BankNameType bankName,
 	String accountNumber,
 	String accountHolder,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	String performanceTeamName,
 	String performanceVenue,
 	String roadAddressName,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/modify/PerformanceModifyResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/modify/PerformanceModifyResponse.java
@@ -2,12 +2,13 @@ package com.beat.apis.performance.application.dto.modify;
 
 import java.util.List;
 
+import com.beat.apis.performance.application.dto.BankNameType;
+import com.beat.apis.performance.application.dto.GenreType;
 import com.beat.apis.performance.application.dto.modify.cast.CastModifyResponse;
 import com.beat.apis.performance.application.dto.modify.performanceImage.PerformanceImageModifyResponse;
 import com.beat.apis.performance.application.dto.modify.schedule.ScheduleModifyResponse;
 import com.beat.apis.performance.application.dto.modify.staff.StaffModifyResponse;
-import com.beat.apis.performance.application.dto.BankNameType;
-import com.beat.apis.performance.application.dto.GenreType;
+import com.beat.global.support.jackson.CdnImageUrl;
 
 public record PerformanceModifyResponse(
 	Long userId,
@@ -20,7 +21,7 @@ public record PerformanceModifyResponse(
 	BankNameType bankName,
 	String accountNumber,
 	String accountHolder,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	String performanceTeamName,
 	String performanceVenue,
 	String roadAddressName,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/modify/cast/CastModifyResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/modify/cast/CastModifyResponse.java
@@ -1,9 +1,11 @@
 package com.beat.apis.performance.application.dto.modify.cast;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record CastModifyResponse(Long castId,
 								 String castName,
 								 String castRole,
-								 String castPhoto) {
+								 @CdnImageUrl String castPhoto) {
 
 	public static CastModifyResponse of(Long castId, String castName, String castRole, String castPhoto) {
 		return new CastModifyResponse(castId, castName, castRole, castPhoto);

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/modify/performanceImage/PerformanceImageModifyResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/modify/performanceImage/PerformanceImageModifyResponse.java
@@ -1,8 +1,10 @@
 package com.beat.apis.performance.application.dto.modify.performanceImage;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record PerformanceImageModifyResponse(
 	Long performanceImageId,
-	String performanceImage
+	@CdnImageUrl String performanceImage
 ) {
 
 	public static PerformanceImageModifyResponse of(Long performanceImageId, String performanceImage) {

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/modify/staff/StaffModifyResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/modify/staff/StaffModifyResponse.java
@@ -1,10 +1,12 @@
 package com.beat.apis.performance.application.dto.modify.staff;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record StaffModifyResponse(
 	Long staffId,
 	String staffName,
 	String staffRole,
-	String staffPhoto) {
+	@CdnImageUrl String staffPhoto) {
 	public static StaffModifyResponse of(Long staffId, String staffName, String staffRole, String staffPhoto) {
 		return new StaffModifyResponse(staffId, staffName, staffRole, staffPhoto);
 	}

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailCastResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailCastResponse.java
@@ -1,10 +1,12 @@
 package com.beat.apis.performance.application.dto.performanceDetail;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record PerformanceDetailCastResponse(
 	Long castId,
 	String castName,
 	String castRole,
-	String castPhoto
+	@CdnImageUrl String castPhoto
 ) {
 	public static PerformanceDetailCastResponse of(Long castId, String castName, String castRole, String castPhoto) {
 		return new PerformanceDetailCastResponse(castId, castName, castRole, castPhoto);

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailImageResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailImageResponse.java
@@ -1,8 +1,10 @@
 package com.beat.apis.performance.application.dto.performanceDetail;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record PerformanceDetailImageResponse(
 	Long performanceImageId,
-	String performanceImage
+	@CdnImageUrl String performanceImage
 ) {
 	public static PerformanceDetailImageResponse of(Long performanceImageId, String performanceImage) {
 		return new PerformanceDetailImageResponse(performanceImageId, performanceImage);

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailResponse.java
@@ -2,6 +2,8 @@ package com.beat.apis.performance.application.dto.performanceDetail;
 
 import java.util.List;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record PerformanceDetailResponse(
 	Long performanceId,
 	String performanceTitle,
@@ -9,7 +11,7 @@ public record PerformanceDetailResponse(
 	List<PerformanceDetailScheduleResponse> scheduleList,
 	int ticketPrice,
 	String genre,
-	String posterImage,
+	@CdnImageUrl String posterImage,
 	int runningTime,
 	String performanceVenue,
 	String roadAddressName,

--- a/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailStaffResponse.java
+++ b/apis/src/main/java/com/beat/apis/performance/application/dto/performanceDetail/PerformanceDetailStaffResponse.java
@@ -1,10 +1,12 @@
 package com.beat.apis.performance.application.dto.performanceDetail;
 
+import com.beat.global.support.jackson.CdnImageUrl;
+
 public record PerformanceDetailStaffResponse(
 	Long staffId,
 	String staffName,
 	String staffRole,
-	String staffPhoto
+	@CdnImageUrl String staffPhoto
 ) {
 	public static PerformanceDetailStaffResponse of(Long staffId, String staffName, String staffRole,
 		String staffPhoto) {

--- a/global-support/build.gradle.kts
+++ b/global-support/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.15.4")
-    compileOnly("com.fasterxml.jackson.core:jackson-databind:2.15.4")
+    // Jackson 3 (tools.jackson.*) — Spring Boot 4.0 default ObjectMapper.
+    // jackson-annotations remains under com.fasterxml.jackson.annotation per Jackson 3 migration rules.
+    compileOnly(libs.jackson3.databind)
 }

--- a/global-support/build.gradle.kts
+++ b/global-support/build.gradle.kts
@@ -2,3 +2,8 @@ plugins {
     id("beat.library")
     id("beat.sentry-source-context")
 }
+
+dependencies {
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.15.4")
+    compileOnly("com.fasterxml.jackson.core:jackson-databind:2.15.4")
+}

--- a/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrl.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrl.kt
@@ -1,0 +1,24 @@
+package com.beat.global.support.jackson
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+
+/**
+ * Marks a response DTO field that holds a storage key for an image. Jackson
+ * uses [CdnImageUrlSerializer] to prepend the configured CDN base when
+ * serializing, so application services can keep dealing with bare keys.
+ *
+ * Usage:
+ * ```kotlin
+ * data class HomePerformanceDetail(
+ *     val performanceId: Long,
+ *     @CdnImageUrl val posterImage: String?,
+ *     // ...
+ * )
+ * ```
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.VALUE_PARAMETER)
+@JacksonAnnotationsInside
+@JsonSerialize(using = CdnImageUrlSerializer::class)
+annotation class CdnImageUrl

--- a/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrl.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrl.kt
@@ -1,7 +1,7 @@
 package com.beat.global.support.jackson
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import tools.jackson.databind.annotation.JsonSerialize
 
 /**
  * Marks a response DTO field that holds a storage key for an image. Jackson

--- a/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrl.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrl.kt
@@ -3,20 +3,6 @@ package com.beat.global.support.jackson
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside
 import tools.jackson.databind.annotation.JsonSerialize
 
-/**
- * Marks a response DTO field that holds a storage key for an image. Jackson
- * uses [CdnImageUrlSerializer] to prepend the configured CDN base when
- * serializing, so application services can keep dealing with bare keys.
- *
- * Usage:
- * ```kotlin
- * data class HomePerformanceDetail(
- *     val performanceId: Long,
- *     @CdnImageUrl val posterImage: String?,
- *     // ...
- * )
- * ```
- */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.VALUE_PARAMETER)
 @JacksonAnnotationsInside

--- a/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
@@ -1,0 +1,41 @@
+package com.beat.global.support.jackson
+
+import com.beat.global.support.jackson.CdnImageUrlSerializer.Companion.initialize
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+
+/**
+ * Jackson serializer that prepends the configured CDN base to a bare image key.
+ * Jackson instantiates this class reflectively (no Spring DI), so the CDN base
+ * is supplied at boot time via [initialize] from infra.
+ */
+class CdnImageUrlSerializer : JsonSerializer<String>() {
+
+    override fun serialize(value: String?, gen: JsonGenerator, serializers: SerializerProvider) {
+        if (value == null) {
+            gen.writeNull()
+            return
+        }
+        if (value.isBlank() || value.startsWith("http") || cdnBase.isEmpty()) {
+            gen.writeString(value)
+            return
+        }
+        val normalized = if (value.startsWith("/")) value.substring(1) else value
+        gen.writeString("$cdnBase/$normalized")
+    }
+
+    companion object {
+        @Volatile
+        private var cdnBase: String = ""
+
+        @JvmStatic
+        fun initialize(domain: String?) {
+            cdnBase = when {
+                domain.isNullOrBlank() -> ""
+                domain.endsWith("/") -> domain.dropLast(1)
+                else -> domain
+            }
+        }
+    }
+}

--- a/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
@@ -1,18 +1,18 @@
 package com.beat.global.support.jackson
 
 import com.beat.global.support.jackson.CdnImageUrlSerializer.Companion.initialize
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.JsonSerializer
-import com.fasterxml.jackson.databind.SerializerProvider
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueSerializer
 
 /**
- * Jackson serializer that prepends the configured CDN base to a bare image key.
+ * Jackson 3 serializer that prepends the configured CDN base to a bare image key.
  * Jackson instantiates this class reflectively (no Spring DI), so the CDN base
  * is supplied at boot time via [initialize] from infra.
  */
-class CdnImageUrlSerializer : JsonSerializer<String>() {
+class CdnImageUrlSerializer : ValueSerializer<String>() {
 
-    override fun serialize(value: String?, gen: JsonGenerator, serializers: SerializerProvider) {
+    override fun serialize(value: String?, gen: JsonGenerator, ctxt: SerializationContext) {
         if (value == null) {
             gen.writeNull()
             return

--- a/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
@@ -17,7 +17,7 @@ class CdnImageUrlSerializer : ValueSerializer<String>() {
             gen.writeNull()
             return
         }
-        if (value.isBlank() || value.startsWith("http") || cdnBase.isEmpty()) {
+        if (value.isBlank() || isAbsoluteUrl(value) || cdnBase.isEmpty()) {
             gen.writeString(value)
             return
         }
@@ -28,6 +28,10 @@ class CdnImageUrlSerializer : ValueSerializer<String>() {
     companion object {
         @Volatile
         private var cdnBase: String = ""
+
+        private fun isAbsoluteUrl(value: String): Boolean =
+            value.startsWith("http://", ignoreCase = true) ||
+                value.startsWith("https://", ignoreCase = true)
 
         @JvmStatic
         fun initialize(domain: String?) {

--- a/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/jackson/CdnImageUrlSerializer.kt
@@ -1,15 +1,10 @@
 package com.beat.global.support.jackson
 
-import com.beat.global.support.jackson.CdnImageUrlSerializer.Companion.initialize
 import tools.jackson.core.JsonGenerator
 import tools.jackson.databind.SerializationContext
 import tools.jackson.databind.ValueSerializer
 
-/**
- * Jackson 3 serializer that prepends the configured CDN base to a bare image key.
- * Jackson instantiates this class reflectively (no Spring DI), so the CDN base
- * is supplied at boot time via [initialize] from infra.
- */
+// Jackson 이 reflective 로 생성하므로 Spring DI 를 못 받음 → 부트 시점에 initialize() 로 주입.
 class CdnImageUrlSerializer : ValueSerializer<String>() {
 
     override fun serialize(value: String?, gen: JsonGenerator, ctxt: SerializationContext) {
@@ -29,10 +24,6 @@ class CdnImageUrlSerializer : ValueSerializer<String>() {
         @Volatile
         private var cdnBase: String = ""
 
-        private fun isAbsoluteUrl(value: String): Boolean =
-            value.startsWith("http://", ignoreCase = true) ||
-                value.startsWith("https://", ignoreCase = true)
-
         @JvmStatic
         fun initialize(domain: String?) {
             cdnBase = when {
@@ -41,5 +32,9 @@ class CdnImageUrlSerializer : ValueSerializer<String>() {
                 else -> domain
             }
         }
+
+        private fun isAbsoluteUrl(value: String): Boolean =
+            value.startsWith("http://", ignoreCase = true) ||
+                value.startsWith("https://", ignoreCase = true)
     }
 }

--- a/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
@@ -2,17 +2,9 @@ package com.beat.global.support.utils
 
 import java.net.URI
 
-/**
- * Pure utility: extract the storage key (URI path without leading slash) from
- * a full S3/CDN URL and verify it lives under a known image prefix. Idempotent —
- * applying twice yields the same key. Returns the input unchanged when it is
- * null/blank. Throws [IllegalArgumentException] when the resulting key does not
- * start with one of the prefixes the S3 PresignedUrl flow can produce, blocking
- * arbitrary external URLs from being persisted (mirrors the CloudFront
- * viewer-request `ALLOWED_PREFIXES` whitelist).
- */
 object ImageKeyExtractor {
 
+    // CloudFront viewer-request ALLOWED_PREFIXES 와 정확히 일치해야 함.
     private val ALLOWED_PREFIXES: Set<String> =
         setOf("poster", "cast", "staff", "performance", "carousel", "banner")
 

--- a/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
@@ -1,0 +1,28 @@
+package com.beat.global.support.utils
+
+import java.net.URI
+
+/**
+ * Pure utility: extract the storage key (URI path without leading slash) from
+ * a full S3/CDN URL. Idempotent — applying twice yields the same key. Returns
+ * the input unchanged when it is null/blank or already a bare key.
+ */
+object ImageKeyExtractor {
+
+    @JvmStatic
+    fun extract(value: String?): String? {
+        if (value.isNullOrBlank() || !value.startsWith("http")) {
+            return value
+        }
+        return try {
+            val path = URI.create(value).path
+            when {
+                path.isNullOrEmpty() -> value
+                path.startsWith("/") -> path.drop(1)
+                else -> path
+            }
+        } catch (e: IllegalArgumentException) {
+            value
+        }
+    }
+}

--- a/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
@@ -4,25 +4,43 @@ import java.net.URI
 
 /**
  * Pure utility: extract the storage key (URI path without leading slash) from
- * a full S3/CDN URL. Idempotent — applying twice yields the same key. Returns
- * the input unchanged when it is null/blank or already a bare key.
+ * a full S3/CDN URL and verify it lives under a known image prefix. Idempotent —
+ * applying twice yields the same key. Returns the input unchanged when it is
+ * null/blank. Throws [IllegalArgumentException] when the resulting key does not
+ * start with one of the prefixes the S3 PresignedUrl flow can produce, blocking
+ * arbitrary external URLs from being persisted (mirrors the CloudFront
+ * viewer-request `ALLOWED_PREFIXES` whitelist).
  */
 object ImageKeyExtractor {
 
+    private val ALLOWED_PREFIXES: Set<String> =
+        setOf("poster", "cast", "staff", "performance", "carousel", "banner")
+
     @JvmStatic
     fun extract(value: String?): String? {
-        if (value.isNullOrBlank() || !isAbsoluteUrl(value)) {
+        if (value.isNullOrBlank()) {
             return value
         }
-        return try {
-            val path = URI.create(value).path
-            when {
-                path.isNullOrEmpty() -> value
-                path.startsWith("/") -> path.drop(1)
-                else -> path
-            }
-        } catch (e: IllegalArgumentException) {
-            value
+        val key = if (isAbsoluteUrl(value)) toKey(value) else value
+        requireAllowedPrefix(key)
+        return key
+    }
+
+    private fun toKey(absoluteUrl: String): String = try {
+        val path = URI.create(absoluteUrl).path
+        when {
+            path.isNullOrEmpty() -> absoluteUrl
+            path.startsWith("/") -> path.drop(1)
+            else -> path
+        }
+    } catch (e: IllegalArgumentException) {
+        absoluteUrl
+    }
+
+    private fun requireAllowedPrefix(key: String) {
+        val prefix = key.substringBefore('/', missingDelimiterValue = "")
+        require(prefix in ALLOWED_PREFIXES) {
+            "Invalid image key prefix: '$prefix' (allowed: $ALLOWED_PREFIXES)"
         }
     }
 

--- a/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
+++ b/global-support/src/main/kotlin/com/beat/global/support/utils/ImageKeyExtractor.kt
@@ -11,7 +11,7 @@ object ImageKeyExtractor {
 
     @JvmStatic
     fun extract(value: String?): String? {
-        if (value.isNullOrBlank() || !value.startsWith("http")) {
+        if (value.isNullOrBlank() || !isAbsoluteUrl(value)) {
             return value
         }
         return try {
@@ -25,4 +25,8 @@ object ImageKeyExtractor {
             value
         }
     }
+
+    private fun isAbsoluteUrl(value: String): Boolean =
+        value.startsWith("http://", ignoreCase = true) ||
+            value.startsWith("https://", ignoreCase = true)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,6 @@ sentry-log4j2 = { module = "io.sentry:sentry-log4j2", version.ref = "sentry" }
 log4j-layout-template-json = { module = "org.apache.logging.log4j:log4j-layout-template-json", version = "2.26.0" }
 
 mysql-connector-j = { module = "com.mysql:mysql-connector-j", version = "9.6.0" }
-spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 spring-boot-core = { module = "org.springframework.boot:spring-boot", version.ref = "spring-boot" }
 spring-boot-persistence = { module = "org.springframework.boot:spring-boot-persistence", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "spring-boot" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ sentry-log4j2 = { module = "io.sentry:sentry-log4j2", version.ref = "sentry" }
 log4j-layout-template-json = { module = "org.apache.logging.log4j:log4j-layout-template-json", version = "2.26.0" }
 
 mysql-connector-j = { module = "com.mysql:mysql-connector-j", version = "9.6.0" }
+spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 spring-boot-core = { module = "org.springframework.boot:spring-boot", version.ref = "spring-boot" }
 spring-boot-persistence = { module = "org.springframework.boot:spring-boot-persistence", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "spring-boot" }

--- a/infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java
+++ b/infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java
@@ -10,7 +10,6 @@ import com.beat.infra.InfraBaseConfig;
 import com.beat.infra.external.auth.social.kakao.KakaoSocialLoginAdapter;
 import com.beat.infra.external.auth.social.kakao.client.KakaoApiClient;
 import com.beat.infra.external.auth.social.kakao.client.KakaoAuthApiClient;
-import com.beat.infra.external.cdn.CdnImageUrlConfig;
 import com.beat.infra.external.cdn.ImageCacheAdapter;
 import com.beat.infra.external.notification.slack.SlackBookingNotificationAdapter;
 import com.beat.infra.external.notification.slack.SlackMemberNotificationAdapter;
@@ -21,7 +20,7 @@ import com.beat.infra.external.storage.s3.S3FileStorageAdapter;
 import com.beat.infra.external.storage.s3.S3InfraConfig;
 
 @Configuration(proxyBeanMethods = false)
-@Import({S3InfraConfig.class, CdnImageUrlConfig.class})
+@Import(S3InfraConfig.class)
 @EnableFeignClients(basePackageClasses = {
 	KakaoApiClient.class,
 	KakaoAuthApiClient.class,

--- a/infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java
+++ b/infra/src/main/java/com/beat/infra/config/ExternalClientConfig.java
@@ -1,9 +1,17 @@
 package com.beat.infra.config;
 
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+
 import com.beat.infra.InfraBaseConfig;
 import com.beat.infra.external.auth.social.kakao.KakaoSocialLoginAdapter;
 import com.beat.infra.external.auth.social.kakao.client.KakaoApiClient;
 import com.beat.infra.external.auth.social.kakao.client.KakaoAuthApiClient;
+import com.beat.infra.external.cdn.CdnImageUrlConfig;
+import com.beat.infra.external.cdn.ImageCacheAdapter;
 import com.beat.infra.external.notification.slack.SlackBookingNotificationAdapter;
 import com.beat.infra.external.notification.slack.SlackMemberNotificationAdapter;
 import com.beat.infra.external.notification.slack.client.BookingSlackClient;
@@ -11,14 +19,9 @@ import com.beat.infra.external.notification.slack.client.MemberSlackClient;
 import com.beat.infra.external.sms.CoolSmsAdapter;
 import com.beat.infra.external.storage.s3.S3FileStorageAdapter;
 import com.beat.infra.external.storage.s3.S3InfraConfig;
-import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
 
 @Configuration(proxyBeanMethods = false)
-@Import(S3InfraConfig.class)
+@Import({S3InfraConfig.class, CdnImageUrlConfig.class})
 @EnableFeignClients(basePackageClasses = {
 	KakaoApiClient.class,
 	KakaoAuthApiClient.class,
@@ -31,7 +34,8 @@ import org.springframework.context.annotation.Import;
 		SlackBookingNotificationAdapter.class,
 		SlackMemberNotificationAdapter.class,
 		S3FileStorageAdapter.class,
-		CoolSmsAdapter.class
+		CoolSmsAdapter.class,
+		ImageCacheAdapter.class
 	},
 	excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = S3InfraConfig.class)
 )

--- a/infra/src/main/java/com/beat/infra/external/cdn/CdnImageUrlConfig.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/CdnImageUrlConfig.java
@@ -1,16 +1,11 @@
 package com.beat.infra.external.cdn;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import com.beat.global.support.jackson.CdnImageUrlSerializer;
 
-import jakarta.annotation.PostConstruct;
-
-/**
- * Wires the configured CDN base into {@link CdnImageUrlSerializer} once at startup,
- * so {@code @CdnImageUrl}-annotated response fields are rendered with the CDN host.
- */
 @Configuration(proxyBeanMethods = false)
 public class CdnImageUrlConfig {
 

--- a/infra/src/main/java/com/beat/infra/external/cdn/CdnImageUrlConfig.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/CdnImageUrlConfig.java
@@ -1,0 +1,24 @@
+package com.beat.infra.external.cdn;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import com.beat.global.support.jackson.CdnImageUrlSerializer;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Wires the configured CDN base into {@link CdnImageUrlSerializer} once at startup,
+ * so {@code @CdnImageUrl}-annotated response fields are rendered with the CDN host.
+ */
+@Configuration(proxyBeanMethods = false)
+public class CdnImageUrlConfig {
+
+	@Value("${cloud.cdn.domain:}")
+	private String cdnDomain;
+
+	@PostConstruct
+	void initSerializer() {
+		CdnImageUrlSerializer.initialize(cdnDomain);
+	}
+}

--- a/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
@@ -1,0 +1,69 @@
+package com.beat.infra.external.cdn;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.beat.contracts.cdn.ImageCachePort;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Infrastructure adapter that pre-warms the CDN by issuing GETs for the
+ * common width variants of a freshly registered image key.
+ */
+@Slf4j
+@Component
+public class ImageCacheAdapter implements ImageCachePort {
+
+    private static final List<Integer> TARGET_WIDTHS = List.of(480, 960);
+
+    private final RestClient restClient;
+    private final String cdnBase;
+
+    public ImageCacheAdapter(RestClient.Builder restClientBuilder,
+                             @Value("${cloud.cdn.domain:}") String cdnDomain) {
+        this.restClient = restClientBuilder.build();
+        this.cdnBase = normalize(cdnDomain);
+    }
+
+    private static String normalize(String domain) {
+        if (domain == null || domain.isBlank()) {
+            return "";
+        }
+        return domain.endsWith("/") ? domain.substring(0, domain.length() - 1) : domain;
+    }
+
+    @Async
+    @Override
+    public void preWarm(String imageKey) {
+        if (imageKey == null || imageKey.isBlank() || cdnBase.isEmpty()) {
+            return;
+        }
+        String normalizedKey = imageKey.startsWith("/") ? imageKey.substring(1) : imageKey;
+        if (normalizedKey.startsWith("http")) {
+            log.debug("Skipping pre-warm for full URL value: {}", imageKey);
+            return;
+        }
+        String baseUrl = cdnBase + "/" + normalizedKey;
+        for (int width : TARGET_WIDTHS) {
+            warmSingleVariant(baseUrl, width);
+        }
+        log.info("CDN pre-warm completed for {}", baseUrl);
+    }
+
+    private void warmSingleVariant(String baseUrl, int width) {
+        String targetUrl = baseUrl + "?w=" + width;
+        try {
+            restClient.get()
+                    .uri(targetUrl)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("CDN pre-warm failed: {} — {}", targetUrl, e.getMessage());
+        }
+    }
+}

--- a/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
@@ -3,12 +3,16 @@ package com.beat.infra.external.cdn;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 import com.beat.contracts.cdn.ImageCachePort;
 
@@ -25,6 +29,7 @@ public class ImageCacheAdapter implements ImageCachePort {
     private static final List<Integer> TARGET_WIDTHS = List.of(480, 960);
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
+    private static final Executor VARIANT_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
 
     private final RestClient restClient;
     private final String cdnBase;
@@ -65,9 +70,11 @@ public class ImageCacheAdapter implements ImageCachePort {
             return;
         }
         String baseUrl = cdnBase + "/" + normalizedKey;
-        for (int width : TARGET_WIDTHS) {
-            warmSingleVariant(baseUrl, width);
-        }
+        CompletableFuture<?>[] variantTasks = TARGET_WIDTHS.stream()
+                .map(width -> CompletableFuture.runAsync(
+                        () -> warmSingleVariant(baseUrl, width), VARIANT_EXECUTOR))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(variantTasks).join();
         log.info("CDN pre-warm completed for {}", baseUrl);
     }
 
@@ -78,7 +85,7 @@ public class ImageCacheAdapter implements ImageCachePort {
                     .uri(targetUrl)
                     .retrieve()
                     .toBodilessEntity();
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.warn("CDN pre-warm failed: {} — {}", targetUrl, e.getMessage());
         }
     }

--- a/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
@@ -1,8 +1,11 @@
 package com.beat.infra.external.cdn;
 
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -20,14 +23,27 @@ import lombok.extern.slf4j.Slf4j;
 public class ImageCacheAdapter implements ImageCachePort {
 
     private static final List<Integer> TARGET_WIDTHS = List.of(480, 960);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
 
     private final RestClient restClient;
     private final String cdnBase;
 
     public ImageCacheAdapter(RestClient.Builder restClientBuilder,
                              @Value("${cloud.cdn.domain:}") String cdnDomain) {
-        this.restClient = restClientBuilder.build();
+        this.restClient = restClientBuilder
+                .requestFactory(buildRequestFactory())
+                .build();
         this.cdnBase = normalize(cdnDomain);
+    }
+
+    private static JdkClientHttpRequestFactory buildRequestFactory() {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .build();
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory.setReadTimeout(READ_TIMEOUT);
+        return factory;
     }
 
     private static String normalize(String domain) {

--- a/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
@@ -18,10 +18,6 @@ import com.beat.contracts.cdn.ImageCachePort;
 
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Infrastructure adapter that pre-warms the CDN by issuing GETs for the
- * common width variants of a freshly registered image key.
- */
 @Slf4j
 @Component
 public class ImageCacheAdapter implements ImageCachePort {

--- a/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
@@ -51,6 +51,11 @@ public class ImageCacheAdapter implements ImageCachePort {
         return factory;
     }
 
+    private static boolean isAbsoluteUrl(String value) {
+        String lower = value.toLowerCase(java.util.Locale.ROOT);
+        return lower.startsWith("http://") || lower.startsWith("https://");
+    }
+
     private static String normalize(String domain) {
         if (domain == null || domain.isBlank()) {
             return "";
@@ -65,7 +70,7 @@ public class ImageCacheAdapter implements ImageCachePort {
             return;
         }
         String normalizedKey = imageKey.startsWith("/") ? imageKey.substring(1) : imageKey;
-        if (normalizedKey.startsWith("http")) {
+        if (isAbsoluteUrl(normalizedKey)) {
             log.debug("Skipping pre-warm for full URL value: {}", imageKey);
             return;
         }

--- a/infra/src/main/resources/application-external.yml
+++ b/infra/src/main/resources/application-external.yml
@@ -45,6 +45,8 @@ cloud:
       secret-key: ${DEV_S3_SECRET_KEY}
   s3:
     bucket: beat-dev-bucket
+  cdn:
+    domain: "https://d3oubuynagl140.cloudfront.net"
 
 slack:
   webhook:
@@ -81,6 +83,8 @@ cloud:
       secret-key: ${PROD_S3_SECRET_KEY}
   s3:
     bucket: beat-prod-bucket
+  cdn:
+    domain: "https://cdn.beatlive.kr"
 
 slack:
   webhook:
@@ -129,6 +133,8 @@ cloud:
       secret-key: test-secret-key
   s3:
     bucket: beat-test-bucket
+  cdn:
+    domain: "https://test-cdn.beatlive.kr"
   stack:
     auto: false
 

--- a/module-contracts/src/main/java/com/beat/contracts/cdn/ImageCachePort.java
+++ b/module-contracts/src/main/java/com/beat/contracts/cdn/ImageCachePort.java
@@ -1,0 +1,19 @@
+package com.beat.contracts.cdn;
+
+/**
+ * Port for interacting with the image cache (CDN).
+ * Placed in module-contracts so both `apis` and `admin` modules can utilize it
+ * without cyclical dependencies.
+ */
+public interface ImageCachePort {
+
+	/**
+	 * Pre-warms the CDN cache for the given image storage key.
+	 * The adapter is responsible for converting the key into a CDN URL and
+	 * fetching common variants. Implementations should be best-effort and
+	 * non-blocking; failure must never break the calling transaction.
+	 *
+	 * @param imageKey storage key (e.g. {@code performance/abc123.jpg}).
+	 */
+	void preWarm(String imageKey);
+}

--- a/module-contracts/src/main/java/com/beat/contracts/cdn/ImageCachePort.java
+++ b/module-contracts/src/main/java/com/beat/contracts/cdn/ImageCachePort.java
@@ -1,19 +1,7 @@
 package com.beat.contracts.cdn;
 
-/**
- * Port for interacting with the image cache (CDN).
- * Placed in module-contracts so both `apis` and `admin` modules can utilize it
- * without cyclical dependencies.
- */
 public interface ImageCachePort {
 
-	/**
-	 * Pre-warms the CDN cache for the given image storage key.
-	 * The adapter is responsible for converting the key into a CDN URL and
-	 * fetching common variants. Implementations should be best-effort and
-	 * non-blocking; failure must never break the calling transaction.
-	 *
-	 * @param imageKey storage key (e.g. {@code performance/abc123.jpg}).
-	 */
+	// Best-effort, non-blocking. 실패해도 caller 트랜잭션에 전파되지 않아야 한다.
 	void preWarm(String imageKey);
 }


### PR DESCRIPTION
## Related issue 🛠
- closes #512
- parent: #510

## 🎯 Work Description

Phase 1 (#515) 로 CDN 인프라를 띄운 뒤 **백엔드 측 이미지 처리 코드가 스파게티**가 됐던 부분을 정리하고, 그 과정에서 발견된 Jackson 3 정합/운영 안정성 이슈까지 한꺼번에 처리.

기존 흐름은 9개 Service 가 매번 `ImageUrlMapper.toKey()` / `.toCdnUrl()` 를 손으로 호출하면서 도메인 prefix 조립을 비즈니스 로직 한가운데서 처리하던 구조. 이번 PR 에서 **저장은 1줄 추출 함수**, **응답은 Jackson 어노테이션 1개**, **pre-warm 은 key 만 던지면 끝** 인 형태로 책임을 응집.

### 핵심 흐름 (Before → After)

| 단계 | Before | After |
|------|--------|-------|
| 저장 | `imageUrlMapper.toKey(req.posterImage())` (Service 마다 mapper 주입 + 호출) | `ImageKeyExtractor.extract(req.posterImage())` (순수 static 함수) |
| 조회 | `imageUrlMapper.toCdnUrl(performance.getPosterImage())` (Service 마다 도메인 조립) | Service 는 raw key 만 리턴, DTO 필드의 `@CdnImageUrl` 가 직렬화 시 자동 prefix 부여 |
| Pre-warm | `imageCachePort.preWarm(imageUrlMapper.toCdnUrl(key))` + `ApplicationEvent` 우회 | `imageCachePort.preWarm(key)` 직접 호출, Adapter 가 base URL + width variant 조립 |

## 🏗️ Major Changes

### 1. Mapper port + ApplicationEvent 우회 제거 (1차 단순화)
- **삭제**: `ImageUrlMapper`(port), `CdnImageUrlMapper`(adapter), `ImageRegisteredEvent`, `ImagePrewarmListener`, `CdnImageUrlSerializerBootstrap`, `ImageUrlUtil.kt`
- **신규**: `CdnImageUrl`(annotation), `CdnImageUrlSerializer`(static cdnBase), `CdnImageUrlConfig`(@Value→initialize), `ImageKeyExtractor`(순수 함수)
- 1-2 줄짜리 conversion 에 비해 port + adapter + event + listener 4-layer 추상은 과해서, BEAT 의 `BookingCreatedEvent` 패턴 (apis 내부 event) 과의 일관성도 깨지던 부분 제거

### 2. Jackson 3 정합 (Spring Boot 4.0 default ObjectMapper)
| | Before (Jackson 2) | After (Jackson 3) |
|--|--------------------|-------------------|
| 패키지 | `com.fasterxml.jackson.core/databind.*` | `tools.jackson.core/databind.*` |
| Serializer base | `JsonSerializer<T>` | `ValueSerializer<T>` |
| Provider | `SerializerProvider` | `SerializationContext` |
| `@JsonSerialize` 위치 | `com.fasterxml.jackson.databind.annotation` | `tools.jackson.databind.annotation` |
| `@JacksonAnnotationsInside` | `com.fasterxml.jackson.annotation` | (그대로 — jackson-annotations 예외) |

- Spring Boot 4.0 의 기본 ObjectMapper 가 Jackson 3 이라 Jackson 2 시리얼라이저는 호환 레이어 없이는 인식 안 됨
- `global-support` 의 transitive Jackson 2.15.4 (CVE WS-2026-0003 영향 범위) 도 `libs.jackson3.databind` (3.1.1, build-logic CVE constraint 안전 범위) 로 교체

### 3. 운영 안정성 보강 (pre-warm Adapter)
- **RestClient timeout 명시** — connect 2s / read 5s 의 `JdkClientHttpRequestFactory + java.net.http.HttpClient`. 기존 무한 timeout 으로 인한 worker thread 장기 점유 / pool 고갈 / `CallerRunsPolicy` 의 컨트롤러 thread 잠식 위험 차단
- **variant 병렬화** — 480/960 GET 을 `CompletableFuture.allOf` + virtual thread per task executor 로 동시 실행. variant N 개로 늘어도 worker pool 압박 없이 scale (JDK 25 의 virtual thread 가 IO-bound 에 이상적)
- **catch 범위 명시화** — `Exception` → `RestClientException`. URL 빌드 실패 같은 비정상 경로는 `AsyncUncaughtExceptionHandler` 로 escalate
- BEAT 의 기존 `AsyncConfig` (`beatApplicationTaskExecutor`) 가 default executor 로 wired 되어 있어 별도 qualifier 불필요

### 4. ExternalClientConfig 정리
- `CdnImageUrlConfig` 는 `@PostConstruct` 1줄짜리 setup-only — bean factory 없음, 우선순위 없음 → ComponentScan 으로 자동 픽업되므로 `@Import` 중복 제거
- `S3InfraConfig` 는 `@Bean factory + @Primary` 가 있어 명시적 `@Import + excludeFilters` 패턴 유지 (부트 순서/충돌 제어 필요)

### 5. Garbage key Defense in Depth (`ImageKeyExtractor`)
- PresignedUrl 흐름이 발급하는 6개 prefix (`poster`, `cast`, `staff`, `performance`, `carousel`, `banner`) — **CloudFront viewer-request `ALLOWED_PREFIXES` 와 정확히 일치** — 화이트리스트로 추출 결과 검증
- 악의적/buggy 클라이언트가 외부 URL 직접 등록 시도하면 `IllegalArgumentException` 으로 DB 저장 전 즉시 reject (이전엔 CloudFront 가 400 으로 거부할 때까지 garbage 가 DB 에 남았음)
- 각 모듈 `GlobalExceptionHandler` 에 `IllegalArgumentException` → 400 매핑 추가 (BEAT 전체에 유용한 일반화)

## 📋 CodeRabbit Review 대응

| # | 지적 | 판정 | 조치 |
|---|------|------|------|
| 1, 2 | Service `preWarm` 트랜잭션 롤백 위험 | **False positive** | `ImageCacheAdapter.preWarm` 이 `@Async` + 내부 `catch (RestClientException)` 으로 격리. proxy 통해 caller 트랜잭션과 완전 분리 |
| 3 | `Serializer.startsWith("http")` 가 `http-banner.png` 오인 | ✅ 정당 | `http://` / `https://` 접두사로 한정 |
| 4 | `ImageKeyExtractor` 대소문자 비교 누락 | ✅ 정당 | `ignoreCase = true` 적용 |
| 5 | `spring-boot-dependencies` unused alias → CI 실패 | ✅ 정당 | alias 제거 (Jackson 3 직접 사용으로 BOM 불필요) |
| (+) | `ImageCacheAdapter` 도 동일 패턴 | ✅ | 같이 패치 |

## 🚀 배포 순서 (중요)

**코드 머지가 먼저, DB 마이그레이션은 나중**. 반대로 하면 서비스 장애.

이번 PR 의 코드는 **legacy full URL + key only 두 상태를 모두 처리** 하도록 설계되어 있어서 (Serializer 의 `isAbsoluteUrl` pass-through, `ImageKeyExtractor` 의 idempotent 추출, Adapter 의 full URL skip), 코드만 먼저 머지해도 회귀 없음. 반면 DB 만 먼저 마이그레이션하면 Phase 1 prod 코드가 raw key 를 그대로 응답해버려 즉시 이미지 깨짐.

| DB row 상태 | 응답 동작 |
|---|---|
| `https://...amazonaws.com/poster/abc.jpg` (legacy) | pass-through (이전과 동일) |
| `poster/abc.jpg` (마이그레이션 후) | `cloud.cdn.domain` prefix 조립 |
| 신규 등록 (이번 PR 적용) | extract 로 key only 저장 → 조립 |

### 권장 순서

1. **PR 머지** → dev 자동 배포
2. **dev 검증** — legacy full URL row 가 이전과 동일하게 응답되는지 (회귀 방지), `http-banner.png` 같은 `http` 시작 정상 키도 prefix 가 잘 붙는지
3. **dev DB 마이그레이션** (`image_cdn_url_migration_to_key.sql`)
4. **dev 재검증** — 마이그레이션 후 응답이 `cloud.cdn.domain` prefix 로 나오는지, 신규 공연 등록 → `CDN pre-warm completed for ...` 로그 출현
5. **prod release**
6. **prod 검증** (양쪽 데이터 호환)
7. **prod DB 마이그레이션**
8. **prod 최종 검증**

## ✅ Local Validation
- [x] `./gradlew build` — 전체 모듈 컴파일 + unit test 통과

## 📦 Commit 구성
```
8858385d chore: 신규 image CDN 파일들의 불필요한 주석 정리
e630a9fe feat: ImageKeyExtractor prefix 화이트리스트로 garbage 키 reject
a4aa5836 fix: URL prefix 판별을 scheme 기준으로 한정 + unused alias 정리
3e790ab0 refactor: pre-warm variant 병렬화 + catch 범위 명시
1e17f0d1 fix: ImageCacheAdapter RestClient 에 connect/read timeout 명시
ed8c8d91 refactor: CdnImageUrl Jackson 3 마이그레이션 + 중복 @Import 정리
7fff1cfa refactor: image CDN 처리 단순화 (mapper port + event 제거)
```

## 📢 To Reviewers
- Phase 2 의 코드 변경분 전체. **DB 마이그레이션 은 본 PR 머지 → dev 검증 통과 → 그 후 별도 실행** (순서 거꾸로 하면 즉시 이미지 깨짐 — 위 "배포 순서" 표 참조)
- Service 측은 mapper 주입이 모두 빠져서 생성자 시그니처가 깔끔해짐
- Adapter 측 timeout / 병렬화는 Phase 3 (다수 variant 추가) 에서 미리 받쳐주는 기반
