### PR TITLE
fix: AsyncConfig 의 AsyncConfigurer 를 @Bean 으로 분리

### DIFF
--- a/infra/src/main/java/com/beat/infra/config/AsyncConfig.java
+++ b/infra/src/main/java/com/beat/infra/config/AsyncConfig.java
@@ -18,30 +18,34 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import com.beat.infra.InfraBaseConfig;
 
+// AsyncConfigurer 를 클래스가 직접 implements 하면 Spring Boot 4.0 의
+// AsyncConfigurerWrapperConfiguration BeanPostProcessor 가 @Configuration 인스턴스를
+// wrap 하면서 원본 + wrapper 가 동시에 컨테이너에 남아 "Only one AsyncConfigurer may exist"
+// 가 발생. AsyncConfigurer 는 별도 @Bean 으로 분리해 BeanPostProcessor 가 깔끔하게
+// 단일 인스턴스로 wrap 하도록 유도.
 @Configuration(proxyBeanMethods = false)
 @EnableAsync
 @Import(TaskExecutorConfig.class)
-public class AsyncConfig implements AsyncConfigurer, InfraBaseConfig {
+public class AsyncConfig implements InfraBaseConfig {
 
 	private static final Logger log = LoggerFactory.getLogger(AsyncConfig.class);
 
-	private final ThreadPoolTaskExecutor applicationTaskExecutor;
-
-	public AsyncConfig(@Qualifier("beatApplicationTaskExecutor") ThreadPoolTaskExecutor applicationTaskExecutor) {
-		this.applicationTaskExecutor = applicationTaskExecutor;
-	}
-
-	@Override
-	@Bean(name = "taskExecutor")
-	public Executor getAsyncExecutor() {
-		return applicationTaskExecutor;
-	}
-
-	@Override
 	@Bean
-	public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
-		return (ex, method, params) ->
-			log.error(formatAsyncExceptionMessage(method, params, ex), ex);
+	AsyncConfigurer beatAsyncConfigurer(
+		@Qualifier("beatApplicationTaskExecutor") ThreadPoolTaskExecutor applicationTaskExecutor
+	) {
+		return new AsyncConfigurer() {
+			@Override
+			public Executor getAsyncExecutor() {
+				return applicationTaskExecutor;
+			}
+
+			@Override
+			public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+				return (ex, method, params) ->
+					log.error(formatAsyncExceptionMessage(method, params, ex), ex);
+			}
+		};
 	}
 
 	static String formatAsyncExceptionMessage(Method method, @Nullable Object[] params, Throwable ex) {

--- a/infra/src/test/java/com/beat/infra/config/AsyncConfigTest.java
+++ b/infra/src/test/java/com/beat/infra/config/AsyncConfigTest.java
@@ -6,17 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class AsyncConfigTest {
 
 	@Test
-	void getAsyncExecutorReusesApplicationExecutorWithoutSecuritySpecificWrapper() {
+	void beatAsyncConfigurerReusesApplicationExecutorWithoutSecuritySpecificWrapper() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.initialize();
-		AsyncConfig asyncConfig = new AsyncConfig(executor);
+		AsyncConfigurer configurer = new AsyncConfig().beatAsyncConfigurer(executor);
 
-		assertSame(executor, asyncConfig.getAsyncExecutor());
+		assertSame(executor, configurer.getAsyncExecutor());
 	}
 
 	@Test


### PR DESCRIPTION
## Related issue 🛠
- closes #517
- 표면화 경로: #516 (PR #516 의 ImageCacheAdapter.preWarm @Async 가 처음 동기 호출 경로로 트리거)

## 🎯 Work Description

dev 배포 직후 공연 등록 시점에 발생한 **공연 등록 500 차단** 을 해소. 원인은 PR #516 이 도입한 코드 자체가 아니라 **이전부터 잠재해 있던 platform 설정 미스** — `@Configuration + implements AsyncConfigurer` 동시 패턴이 Spring Boot 4.0 의 신규 `AsyncConfigurerWrapperConfiguration` BeanPostProcessor 와 호환되지 않음.

## 🔬 Root Cause

Spring Boot 4.0.6 의 `TaskExecutorConfigurations` 가 내부 정의:

```java
@Configuration
@ConditionalOnBean(AsyncConfigurer.class)
static class AsyncConfigurerWrapperConfiguration {
    @Bean
    static BeanPostProcessor applicationTaskExecutorAsyncConfigurerBeanPostProcessor(...) {
        return new BeanPostProcessor() {
            public Object postProcessAfterInitialization(Object bean, String name) {
                if (bean instanceof AsyncConfigurer userConfigurer
                    && !(bean instanceof ApplicationTaskExecutorAsyncConfigurer)) {
                    return new ApplicationTaskExecutorAsyncConfigurer(beanFactory, userConfigurer);
                }
                return bean;
            }
        };
    }
}
```

BEAT 의 기존 `infra/config/AsyncConfig`:

```java
@Configuration(proxyBeanMethods = false)
@EnableAsync
public class AsyncConfig implements AsyncConfigurer, InfraBaseConfig {   // ← 동시 역할
    @Bean(name = "taskExecutor")
    public Executor getAsyncExecutor() { ... }
}
```

| 단계 | 동작 |
|------|------|
| 1 | `AsyncConfig` 가 ApplicationContext 에 등록 — `AsyncConfigurer` 타입 + `@Configuration` CGLIB factory source 동시 역할 |
| 2 | Boot 의 BeanPostProcessor 가 `postProcessAfterInitialization` 에서 wrap 한 `ApplicationTaskExecutorAsyncConfigurer` instance return |
| 3 | 그러나 `@Configuration` CGLIB proxy 는 다른 `@Bean` 메서드 factory 라 원본도 살아 있어야 함 → **두 instance 동시 존재** |
| 4 | `AbstractAsyncConfiguration.setConfigurers` 가 `candidates.size() > 1` 감지 → `IllegalStateException: Only one AsyncConfigurer may exist` |

## 🏗️ Fix

`AsyncConfig` 가 `AsyncConfigurer` 를 직접 implement 하지 않고 별도 `@Bean AsyncConfigurer beatAsyncConfigurer(...)` 로 분리. 그러면 BeanPostProcessor 가 그 `@Bean` 인스턴스만 단일 wrap → ApplicationContext 에 `AsyncConfigurer` 타입 bean 1개.

```diff
-public class AsyncConfig implements AsyncConfigurer, InfraBaseConfig {
+public class AsyncConfig implements InfraBaseConfig {
 
-    private final ThreadPoolTaskExecutor applicationTaskExecutor;
-
-    public AsyncConfig(@Qualifier("beatApplicationTaskExecutor") ThreadPoolTaskExecutor executor) {
-        this.applicationTaskExecutor = executor;
-    }
-
-    @Override @Bean(name = "taskExecutor")
-    public Executor getAsyncExecutor() { return applicationTaskExecutor; }
-
-    @Override @Bean
-    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() { ... }
+    @Bean
+    AsyncConfigurer beatAsyncConfigurer(
+        @Qualifier("beatApplicationTaskExecutor") ThreadPoolTaskExecutor executor
+    ) {
+        return new AsyncConfigurer() {
+            @Override public Executor getAsyncExecutor() { return executor; }
+            @Override public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() { ... }
+        };
+    }
 }
```

테스트 (`AsyncConfigTest`) 도 새 구조 (`new AsyncConfig().beatAsyncConfigurer(executor).getAsyncExecutor()`) 에 맞춰 정정.

## ✅ Validation Plan

- [x] `./gradlew build` — 전체 모듈 컴파일 + unit test 통과
- [ ] dev 배포 후 `POST /api/performances` 응답 200 확인 (이전엔 500)
- [ ] dev 로그에서 `CDN pre-warm completed for ...` INFO 출현 확인 (`@Async` 정상 동작)
- [ ] prod release

## 🌍 Upstream

별도로 Spring Boot 측 [신규 issue](https://github.com/spring-projects/spring-boot/issues) 보고 검토 중. 공식 [Spring Framework Scheduling 문서](https://docs.spring.io/spring-framework/reference/integration/scheduling.html#scheduling-annotation-support-async) 가 `@Configuration implements AsyncConfigurer` 패턴을 예시로 권장하는데 Boot 4.0 의 BeanPostProcessor wrap 메커니즘과 호환 안 되는 회귀 사례. (관련 기존 이슈: spring-projects/spring-boot#47897)

## 📦 Commit 구성
```
f1fb8b66 fix: AsyncConfig 의 AsyncConfigurer 를 @Bean 으로 분리
```

## 📢 To Reviewers
- PR #516 자체의 image CDN 변경은 정상 — 이번 fix 는 platform 레벨 hotfix
- 핵심 변경 2 파일 (`AsyncConfig.java`, `AsyncConfigTest.java`), +25 / -20
- 머지 후 dev 즉시 배포 → 공연 등록 정상화 → prod release
