### PR TITLE
refactor: CDN pre-warm 포맷 개선 - avif/webp/jpeg 3종 × 480/960 = 6개 예열

### DIFF
--- a/admin/src/main/java/com/beat/admin/promotion/application/service/command/AdminPromotionCommandService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/service/command/AdminPromotionCommandService.java
@@ -20,6 +20,7 @@ import com.beat.admin.promotion.application.dto.request.PromotionHandleRequest;
 import com.beat.admin.promotion.application.dto.response.CarouselHandleAllResponse;
 import com.beat.admin.promotion.application.dto.result.AdminPromotionResults;
 import com.beat.admin.promotion.application.dto.result.AdminPromotionResults.AdminPromotionResult;
+import com.beat.contracts.cdn.ImageCachePort;
 import com.beat.domain.member.repository.MemberRepository;
 import com.beat.domain.performance.repository.PerformanceRepository;
 import com.beat.domain.promotion.domain.CarouselNumber;
@@ -43,6 +44,7 @@ public class AdminPromotionCommandService {
 	private final MemberRepository memberRepository;
 	private final PromotionRepository promotionRepository;
 	private final PerformanceRepository performanceRepository;
+	private final ImageCachePort imageCachePort;
 
 	@Transactional
 	public CarouselHandleAllResponse processAllPromotionsSortedByCarouselNumber(Long memberId,
@@ -146,12 +148,15 @@ public class AdminPromotionCommandService {
 				Promotion promotion = findPromotionById(modifyRequest.promotionId());
 				Long performanceId = validatePerformanceId(modifyRequest.performanceId());
 
+				String imageKey = ImageKeyExtractor.extract(modifyRequest.newImageUrl());
 				Promotion updatedPromotion = promotion.updatePromotionDetails(
 					toCarouselNumber(modifyRequest.carouselNumber()),
-					ImageKeyExtractor.extract(modifyRequest.newImageUrl()), modifyRequest.isExternal(),
+					imageKey, modifyRequest.isExternal(),
 					modifyRequest.redirectUrl(),
 					performanceId);
-				return promotionRepository.save(updatedPromotion);
+				Promotion saved = promotionRepository.save(updatedPromotion);
+				imageCachePort.preWarm(imageKey);
+				return saved;
 			})
 			.toList();
 	}
@@ -161,11 +166,14 @@ public class AdminPromotionCommandService {
 			.map(generateRequest -> {
 				Long performanceId = validatePerformanceId(generateRequest.performanceId());
 
-				Promotion newPromotion = Promotion.create(ImageKeyExtractor.extract(generateRequest.newImageUrl()),
+				String imageKey = ImageKeyExtractor.extract(generateRequest.newImageUrl());
+				Promotion newPromotion = Promotion.create(imageKey,
 					performanceId,
 					generateRequest.redirectUrl(), generateRequest.isExternal(),
 					toCarouselNumber(generateRequest.carouselNumber()));
-				return promotionRepository.save(newPromotion);
+				Promotion saved = promotionRepository.save(newPromotion);
+				imageCachePort.preWarm(imageKey);
+				return saved;
 			})
 			.toList();
 	}

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
@@ -29,6 +29,7 @@ import com.beat.admin.application.exception.AdminApplicationErrorCode;
 import com.beat.admin.promotion.application.service.command.AdminPromotionCommandService;
 import com.beat.domain.member.domain.Member;
 import com.beat.domain.member.domain.SocialType;
+import com.beat.contracts.cdn.ImageCachePort;
 import com.beat.domain.member.repository.MemberRepository;
 import com.beat.domain.performance.domain.BankName;
 import com.beat.domain.performance.domain.Genre;
@@ -44,6 +45,9 @@ class AdminPromotionCommandServiceTest {
 
 	private static final long MEMBER_ID = 7L;
 	private static final long PERFORMANCE_ID = 11L;
+
+	@Mock
+	private ImageCachePort imageCachePort;
 
 	@Mock
 	private MemberRepository memberRepository;

--- a/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ImageCacheAdapter implements ImageCachePort {
 
     private static final List<Integer> TARGET_WIDTHS = List.of(480, 960);
+    private static final List<String> TARGET_FORMATS = List.of("image/avif", "image/webp", "image/jpeg");
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
     private static final Executor VARIANT_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
@@ -72,22 +74,24 @@ public class ImageCacheAdapter implements ImageCachePort {
         }
         String baseUrl = cdnBase + "/" + normalizedKey;
         CompletableFuture<?>[] variantTasks = TARGET_WIDTHS.stream()
-                .map(width -> CompletableFuture.runAsync(
-                        () -> warmSingleVariant(baseUrl, width), VARIANT_EXECUTOR))
+                .flatMap(width -> TARGET_FORMATS.stream()
+                        .map(accept -> CompletableFuture.runAsync(
+                                () -> warmSingleVariant(baseUrl, width, accept), VARIANT_EXECUTOR)))
                 .toArray(CompletableFuture[]::new);
         CompletableFuture.allOf(variantTasks).join();
-        log.info("CDN pre-warm completed for {}", baseUrl);
+        log.info("CDN pre-warm completed for {} ({} variants)", baseUrl, variantTasks.length);
     }
 
-    private void warmSingleVariant(String baseUrl, int width) {
+    private void warmSingleVariant(String baseUrl, int width, String accept) {
         String targetUrl = baseUrl + "?w=" + width;
         try {
             restClient.get()
                     .uri(targetUrl)
+                    .header(HttpHeaders.ACCEPT, accept)
                     .retrieve()
                     .toBodilessEntity();
         } catch (RestClientException e) {
-            log.warn("CDN pre-warm failed: {} — {}", targetUrl, e.getMessage());
+            log.warn("CDN pre-warm failed: {} [{}] — {}", targetUrl, accept, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary

- Accept 헤더 없이 GET하던 pre-warm 방식을 `image/avif`, `image/webp`, `image/jpeg` 3종으로 분리
- `TARGET_WIDTHS(480, 960) × TARGET_FORMATS(3)` = **6개 CompletableFuture 동시 실행**
- CloudFront Function의 포맷 협상(Accept 헤더 → avif/webp/jpeg 분기) 결과인 6개 캐시 엔트리를 모두 예열

## Problem

기존 `warmSingleVariant`는 Accept 헤더 없이 요청 → CloudFront Function이 jpeg로 폴백  
→ avif/webp 변환본은 첫 실사용자 요청 시 캐시 미스 발생

## Solution

```java
// Before
.map(width -> CompletableFuture.runAsync(() -> warmSingleVariant(baseUrl, width)))

// After
.flatMap(width -> TARGET_FORMATS.stream()
    .map(accept -> CompletableFuture.runAsync(() -> warmSingleVariant(baseUrl, width, accept))))
```

## Changed Files

- `infra/.../cdn/ImageCacheAdapter.java` — `TARGET_FORMATS` 상수 추가, `warmSingleVariant` Accept 헤더 파라미터 추가
- `admin/.../AdminPromotionCommandService.java` — 캐러셀 등록/수정 시 `imageCachePort.preWarm()` 호출

## Test plan

- [ ] 어드민에서 캐러셀 이미지 등록 후 CloudFront 액세스 로그에서 avif/webp/jpeg × 480/960 6개 캐시 HIT 확인
- [ ] `ImageCacheAdapter` preWarm 로그에 `6 variants` 출력 확인
- [ ] 기존 컴파일 및 단위 테스트 통과

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)