### PR TITLE
fix: 커스텀 비동기 처리용 beatAsyncExecutor 분리 및 격리 등록

### DIFF
--- a/apis/src/main/java/com/beat/apis/external/notification/slack/event/BookingCreatedEventListener.java
+++ b/apis/src/main/java/com/beat/apis/external/notification/slack/event/BookingCreatedEventListener.java
@@ -19,7 +19,7 @@ public class BookingCreatedEventListener {
 
 	private final BookingNotificationPort bookingNotificationPort;
 
-	@Async("taskExecutor")
+	@Async("beatAsyncExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void sendSlackNotification(BookingCreatedEvent event) {
 		try {

--- a/apis/src/main/java/com/beat/apis/external/notification/slack/event/MemberRegisteredEventListener.java
+++ b/apis/src/main/java/com/beat/apis/external/notification/slack/event/MemberRegisteredEventListener.java
@@ -21,7 +21,7 @@ public class MemberRegisteredEventListener {
 	private final MemberService memberService;
 	private final MemberNotificationPort memberNotificationPort;
 
-	@Async("taskExecutor")
+	@Async("beatAsyncExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void sendSlackNotification(MemberRegisteredEvent event) {
 		try {

--- a/infra/src/main/java/com/beat/infra/config/TaskExecutorConfig.java
+++ b/infra/src/main/java/com/beat/infra/config/TaskExecutorConfig.java
@@ -5,40 +5,41 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.task.ThreadPoolTaskExecutorCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskDecorator;
 import org.springframework.core.task.support.CompositeTaskDecorator;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-// Spring Boot 4.0 의 TaskExecutionAutoConfiguration 이 `applicationTaskExecutor`
-// 라는 이름의 ThreadPoolTaskExecutor 를 자동 등록. 우리는 그 default executor 의
-// 설정만 Customizer 로 override → bean 이름 충돌 없이 BEAT 의 thread pool 설정 + TaskDecorator
-// 가 그대로 적용되고, ApplicationTaskExecutorAsyncConfigurer 의 lookup 도 그대로 작동.
+// BEAT 도메인 비동기 작업 전용 executor.
+// Spring Boot가 자동 구성하는 applicationTaskExecutor는 MVC/JPA/WebSocket 등 프레임워크 통합용으로 유지하고,
+// 비즈니스 @Async 작업은 @Async("beatAsyncExecutor")로 명시해 별도 풀에서 실행한다.
+// defaultCandidate=false를 통해 타입 기반 기본 주입 후보에서는 제외하고, 명시적 이름/qualifier로만 사용되게 한다.
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(ThreadPoolProperties.class)
 public class TaskExecutorConfig {
 
-	@Bean
-	ThreadPoolTaskExecutorCustomizer beatThreadPoolTaskExecutorCustomizer(
+	@Bean(name = "beatAsyncExecutor", defaultCandidate = false)
+	public ThreadPoolTaskExecutor beatAsyncExecutor(
 		ThreadPoolProperties threadPoolProperties,
 		ObjectProvider<TaskDecorator> taskDecorators
 	) {
-		return executor -> {
-			executor.setCorePoolSize(threadPoolProperties.getCoreSize());
-			executor.setMaxPoolSize(
-				Math.max(threadPoolProperties.getMaxPoolSize(), threadPoolProperties.getCoreSize()));
-			executor.setQueueCapacity(threadPoolProperties.getQueueCapacity());
-			executor.setThreadNamePrefix(threadPoolProperties.getThreadNamePrefix());
-			executor.setWaitForTasksToCompleteOnShutdown(true);
-			executor.setAwaitTerminationSeconds(30);
-			executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
-			applyTaskDecorator(executor, taskDecorators);
-		};
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(threadPoolProperties.getCoreSize());
+		executor.setMaxPoolSize(
+			Math.max(threadPoolProperties.getMaxPoolSize(), threadPoolProperties.getCoreSize()));
+		executor.setQueueCapacity(threadPoolProperties.getQueueCapacity());
+		executor.setThreadNamePrefix(threadPoolProperties.getThreadNamePrefix());
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(30);
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+		applyTaskDecorator(executor, taskDecorators);
+		executor.initialize();
+		return executor;
 	}
 
 	private static void applyTaskDecorator(
-		org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor executor,
+		ThreadPoolTaskExecutor executor,
 		ObjectProvider<TaskDecorator> taskDecorators
 	) {
 		List<TaskDecorator> decorators = taskDecorators.orderedStream().toList();
@@ -46,7 +47,7 @@ public class TaskExecutorConfig {
 			return;
 		}
 		if (decorators.size() == 1) {
-			executor.setTaskDecorator(decorators.get(0));
+			executor.setTaskDecorator(decorators.getFirst());
 			return;
 		}
 		executor.setTaskDecorator(new CompositeTaskDecorator(decorators));

--- a/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/cdn/ImageCacheAdapter.java
@@ -61,7 +61,7 @@ public class ImageCacheAdapter implements ImageCachePort {
         return domain.endsWith("/") ? domain.substring(0, domain.length() - 1) : domain;
     }
 
-    @Async
+    @Async("beatAsyncExecutor")
     @Override
     public void preWarm(String imageKey) {
         if (imageKey == null || imageKey.isBlank() || cdnBase.isEmpty()) {

--- a/infra/src/test/java/com/beat/infra/config/TaskExecutorConfigTest.java
+++ b/infra/src/test/java/com/beat/infra/config/TaskExecutorConfigTest.java
@@ -21,7 +21,7 @@ class TaskExecutorConfigTest {
 		.withUserConfiguration(TaskExecutorConfig.class);
 
 	@Test
-	void customizerOverridesAutoConfiguredApplicationTaskExecutorWithThreadPoolProperties() {
+	void beatAsyncExecutorConfiguredWithThreadPoolProperties() {
 		contextRunner
 			.withPropertyValues(
 				"thread-pool.core-size=3",
@@ -30,9 +30,10 @@ class TaskExecutorConfigTest {
 				"thread-pool.thread-name-prefix=test-executor-"
 			)
 			.run(context -> {
+				assertTrue(context.containsBean("applicationTaskExecutor"));
 				ThreadPoolProperties properties = context.getBean(ThreadPoolProperties.class);
 				ThreadPoolTaskExecutor executor = context.getBean(
-					"applicationTaskExecutor",
+					"beatAsyncExecutor",
 					ThreadPoolTaskExecutor.class
 				);
 
@@ -49,7 +50,7 @@ class TaskExecutorConfigTest {
 	}
 
 	@Test
-	void appliesAvailableTaskDecoratorBeansToApplicationExecutor() {
+	void appliesAvailableTaskDecoratorBeansToBeatAsyncExecutor() {
 		AtomicBoolean decorated = new AtomicBoolean(false);
 		TaskDecorator taskDecorator = runnable -> () -> {
 			decorated.set(true);
@@ -66,7 +67,7 @@ class TaskExecutorConfigTest {
 			)
 			.run(context -> {
 				ThreadPoolTaskExecutor executor = context.getBean(
-					"applicationTaskExecutor",
+					"beatAsyncExecutor",
 					ThreadPoolTaskExecutor.class
 				);
 				CountDownLatch latch = new CountDownLatch(1);
@@ -75,6 +76,29 @@ class TaskExecutorConfigTest {
 
 				assertTrue(latch.await(3, TimeUnit.SECONDS));
 				assertTrue(decorated.get());
+			});
+	}
+
+	@Test
+	void beatAsyncExecutorIsExcludedFromDefaultInjectionCandidate() {
+		contextRunner
+			.withPropertyValues(
+				"thread-pool.core-size=3",
+				"thread-pool.max-pool-size=5",
+				"thread-pool.queue-capacity=20",
+				"thread-pool.thread-name-prefix=test-executor-"
+			)
+			.run(context -> {
+				// 1. Get Executor by type (since beatAsyncExecutor has defaultCandidate = false,
+				// applicationTaskExecutor must be returned as the default autowire candidate)
+				java.util.concurrent.Executor defaultExecutor = context.getBean(java.util.concurrent.Executor.class);
+				ThreadPoolTaskExecutor appExecutor = context.getBean("applicationTaskExecutor", ThreadPoolTaskExecutor.class);
+				
+				assertEquals(appExecutor, defaultExecutor);
+
+				// 2. beatAsyncExecutor must still be retrievable when explicitly requested by name
+				ThreadPoolTaskExecutor beatExecutor = context.getBean("beatAsyncExecutor", ThreadPoolTaskExecutor.class);
+				assertTrue(beatExecutor != defaultExecutor);
 			});
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

• closes #524

## Work Description ✏️

• 커스텀 비동기 스레드 풀인  beatAsyncExecutor  빈(Bean)을 새롭게 등록했습니다.
• 스프링 부트의 기본  applicationTaskExecutor  자동 구성과 충돌하지 않도록  defaultCandidate = false  옵션을 적용하여 빈을 격리했습니다.
• 기존 애플리케이션 내의 비동기 작업 로직에  @Async("beatAsyncExecutor") 를 명시적으로 지정하도록 수정했습니다.
• 분리된 스레드 풀이 의도대로 주입되고 격리되는지 검증하기 위해 테스트 코드( TaskExecutorConfigTest  등)를 추가/변경했습니다.

## Trouble Shooting ⚽️

• 위험: 기존처럼 애플리케이션에 커스텀 비동기 스레드 풀을 전역으로 등록하면, Spring Boot가 기본으로 제공하는  applicationTaskExecutor 가 백오프(비활성화)되어 이를 의존하는 프레임워크 내부로직이나 라이브러리와 충돌할 위험이 있었습니다.
• 해결:  beatAsyncExecutor  등록 시  defaultCandidate = false 를 부여하여 글로벌 기본 풀을 덮어쓰지 않도록 설정했습니다. 이로써 명시적으로 이름을 지정한 로직에서만 커스텀 풀을 안전하게 사용하도록 해결했습니다.

## Related ScreenShot 📷

(없음)

## Uncompleted Tasks 😅

(없음)

## To Reviewers 📢

• 앞으로 비즈니스 로직에 비동기 처리( @Async )를 추가하실 때는 기본 어노테이션이 아닌  @Async("beatAsyncExecutor") 로 명시해서 사용해 주시면 됩니다.