### PR TITLE
fix: 어드민 라우팅 404 수정 및 통합 Swagger·배치 예외 관측 보강

### DIFF
--- a/admin/src/main/java/com/beat/admin/config/AdminSecurityConfig.java
+++ b/admin/src/main/java/com/beat/admin/config/AdminSecurityConfig.java
@@ -26,7 +26,6 @@ public class AdminSecurityConfig {
 
 	private static final String ROLE_ADMIN = "ROLE_ADMIN";
 	private static final String[] SWAGGER_WHITELIST = {
-		"/v3/api-docs/**",
 		"/api/admin/v3/api-docs/**",
 		"/swagger-ui/**",
 		"/swagger-resources/**",

--- a/admin/src/main/java/com/beat/admin/config/AdminSecurityConfig.java
+++ b/admin/src/main/java/com/beat/admin/config/AdminSecurityConfig.java
@@ -27,6 +27,7 @@ public class AdminSecurityConfig {
 	private static final String ROLE_ADMIN = "ROLE_ADMIN";
 	private static final String[] SWAGGER_WHITELIST = {
 		"/v3/api-docs/**",
+		"/api/admin/v3/api-docs/**",
 		"/swagger-ui/**",
 		"/swagger-resources/**",
 	};

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -41,6 +41,11 @@ springdoc:
     operations-sorter: alpha
     display-request-duration: true
     urls-primary-name: admin
+  # Nginx가 /api/admin/ 만 admin 서버로 프록시하므로(다른 경로는 apis로 흐름), api-docs 도
+  # /api/admin 하위로 노출해야 통합 Swagger(apis)에서 도달 가능하다.
+  # 그룹("admin")이 base path 뒤에 붙어 최종 문서 경로는 /api/admin/v3/api-docs/admin 이 된다.
+  api-docs:
+    path: /api/admin/v3/api-docs
 
 ---
 spring:

--- a/admin/src/test/java/com/beat/admin/AdminModuleContextBootTest.java
+++ b/admin/src/test/java/com/beat/admin/AdminModuleContextBootTest.java
@@ -71,7 +71,7 @@ class AdminModuleContextBootTest extends AbstractAdminIntegrationTest {
 
 	@Test
 	void servesGroupedSwaggerDocsForAdminApis() throws Exception {
-		mockMvc.perform(get("/v3/api-docs/admin"))
+		mockMvc.perform(get("/api/admin/v3/api-docs/admin"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.openapi").exists())
 			.andExpect(jsonPath("$.paths").exists());

--- a/apis/src/main/resources/application.yml
+++ b/apis/src/main/resources/application.yml
@@ -40,7 +40,15 @@ springdoc:
     tags-sorter: alpha
     operations-sorter: alpha
     display-request-duration: true
-    urls-primary-name: general
+    urls-primary-name: "APIS (사용자용)"
+    # 통합 Swagger 드롭다운: apis(general) + admin 문서를 한 UI에서 조회.
+    # admin 문서는 동일 도메인에서 Nginx /api/admin/ 라우팅을 통해 admin 서버로 프록시된다.
+    # (swagger/api-docs는 비-prod에서만 활성 — prod application.yml에서 비활성화됨)
+    urls:
+      - name: "APIS (사용자용)"
+        url: /v3/api-docs/general
+      - name: "ADMIN (관리자용)"
+        url: /api/admin/v3/api-docs/admin
 
 ---
 spring:

--- a/batch/src/main/kotlin/com/beat/batch/config/ScheduledTaskErrorHandler.kt
+++ b/batch/src/main/kotlin/com/beat/batch/config/ScheduledTaskErrorHandler.kt
@@ -1,0 +1,26 @@
+package com.beat.batch.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.util.ErrorHandler
+
+/**
+ * batch TaskScheduler 전역 에러 핸들러.
+ *
+ * 기본 Spring 핸들러(TaskUtils$LoggingErrorHandler)는 `org.springframework.*` 로거로 예외를 남겨
+ * `com.beat` 로거에만 연결된 SentryAppender 경로를 타지 못한다. 이 핸들러는 `com.beat.batch.*`
+ * 로거로 ERROR 로그를 남겨 Sentry(SentryAppender) + stdout(→Loki) 양쪽 수집 경로를 복구한다.
+ *
+ * `@Scheduled` 메서드와 [org.springframework.scheduling.TaskScheduler] 동적 `schedule(...)` 작업의
+ * 예외가 모두 동일한 스케줄러 빈을 통해 이 핸들러로 전달된다.
+ *
+ * 예외를 재전파하지 않으므로(no-rethrow) 반복 작업(fixedDelay/fixedRate/cron)은 다음 주기에 계속
+ * 실행되는 Spring 기본 동작(suppress)을 그대로 유지한다.
+ */
+class ScheduledTaskErrorHandler : ErrorHandler {
+
+    private val log = LoggerFactory.getLogger(ScheduledTaskErrorHandler::class.java)
+
+    override fun handleError(t: Throwable) {
+        log.error("Batch task execution failed", t)
+    }
+}

--- a/batch/src/main/kotlin/com/beat/batch/config/ScheduledTaskErrorHandler.kt
+++ b/batch/src/main/kotlin/com/beat/batch/config/ScheduledTaskErrorHandler.kt
@@ -10,7 +10,7 @@ import org.springframework.util.ErrorHandler
  * `com.beat` 로거에만 연결된 SentryAppender 경로를 타지 못한다. 이 핸들러는 `com.beat.batch.*`
  * 로거로 ERROR 로그를 남겨 Sentry(SentryAppender) + stdout(→Loki) 양쪽 수집 경로를 복구한다.
  *
- * `@Scheduled` 메서드와 [org.springframework.scheduling.TaskScheduler] 동적 `schedule(...)` 작업의
+ * 스케줄 메서드와 [org.springframework.scheduling.TaskScheduler] 동적 `schedule(...)` 작업의
  * 예외가 모두 동일한 스케줄러 빈을 통해 이 핸들러로 전달된다.
  *
  * 예외를 재전파하지 않으므로(no-rethrow) 반복 작업(fixedDelay/fixedRate/cron)은 다음 주기에 계속

--- a/batch/src/main/kotlin/com/beat/batch/config/SchedulingConfig.kt
+++ b/batch/src/main/kotlin/com/beat/batch/config/SchedulingConfig.kt
@@ -1,0 +1,29 @@
+package com.beat.batch.config
+
+import org.springframework.boot.task.ThreadPoolTaskSchedulerCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Spring Boot 오토컨피그가 생성하는 단일 `taskScheduler`(ThreadPoolTaskScheduler)에
+ * [ScheduledTaskErrorHandler]를 주입한다.
+ *
+ * `ThreadPoolTaskSchedulerCustomizer`를 사용해 Boot의 기본 스케줄러 설정(스레드 풀 크기 등)은
+ * 그대로 유지하고 ErrorHandler만 교체한다. 이 스케줄러는 `@Scheduled` 메서드와
+ * `JobSchedulerService`가 주입받는 [org.springframework.scheduling.TaskScheduler] 동적 작업이
+ * 공유하므로, 두 경로의 예외가 모두 동일한 핸들러로 수집된다.
+ */
+@Configuration(proxyBeanMethods = false)
+class SchedulingConfig {
+
+    @Bean
+    fun scheduledTaskErrorHandler(): ScheduledTaskErrorHandler = ScheduledTaskErrorHandler()
+
+    @Bean
+    fun scheduledTaskErrorHandlerCustomizer(
+        scheduledTaskErrorHandler: ScheduledTaskErrorHandler,
+    ): ThreadPoolTaskSchedulerCustomizer =
+        ThreadPoolTaskSchedulerCustomizer { taskScheduler ->
+            taskScheduler.setErrorHandler(scheduledTaskErrorHandler)
+        }
+}

--- a/batch/src/main/kotlin/com/beat/batch/config/SchedulingConfig.kt
+++ b/batch/src/main/kotlin/com/beat/batch/config/SchedulingConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration
  * [ScheduledTaskErrorHandler]를 주입한다.
  *
  * `ThreadPoolTaskSchedulerCustomizer`를 사용해 Boot의 기본 스케줄러 설정(스레드 풀 크기 등)은
- * 그대로 유지하고 ErrorHandler만 교체한다. 이 스케줄러는 `@Scheduled` 메서드와
+ * 그대로 유지하고 ErrorHandler만 교체한다. 이 스케줄러는 스케줄 메서드와
  * `JobSchedulerService`가 주입받는 [org.springframework.scheduling.TaskScheduler] 동적 작업이
  * 공유하므로, 두 경로의 예외가 모두 동일한 핸들러로 수집된다.
  */

--- a/infra/ansible/inventories/dev/group_vars/all/main.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/main.yml
@@ -70,7 +70,7 @@ modules:
     scheduler_owner: false
     nginx_route:
       upstream_name: admin_backend
-      external_path: /admin
+      external_path: /api/admin
       upstream_path: /api/admin
   batch:
     deploy_mode: stop_start

--- a/infra/ansible/inventories/prod/group_vars/all/main.yml
+++ b/infra/ansible/inventories/prod/group_vars/all/main.yml
@@ -70,7 +70,7 @@ modules:
     scheduler_owner: false
     nginx_route:
       upstream_name: admin_backend
-      external_path: /admin
+      external_path: /api/admin
       upstream_path: /api/admin
   batch:
     deploy_mode: stop_start


### PR DESCRIPTION
## Related issue 🛠

- closes #530

## Work Description ✏️

- **어드민 API 404 수정**: 프론트가 호출하는 `/api/admin` 경로를 Nginx가 admin 서버로 라우팅하도록 `nginx_route.external_path`를 `/admin` → `/api/admin`으로 정렬했습니다(dev/prod group_vars).
프론트 코드 변경은 없습니다.
- **통합 Swagger**: apis swagger-ui에 드롭다운(APIS=`/v3/api-docs/general`, ADMIN=`/api/admin/v3/api-docs/admin`)을 구성했습니다. admin api-docs를 Nginx 프록시 경로에 맞춰
`/api/admin/v3/api-docs`로 이동하고, 비-prod swagger 화이트리스트에 새 경로를 추가했습니다.
- **배치 예외 관측 보강**: batch `TaskScheduler`에 중앙 `ScheduledTaskErrorHandler`를 추가했습니다. `@Scheduled`와 동적 `taskScheduler.schedule()` 예외를 `com.beat` 로거로 ERROR 로깅하여, 기존
SentryAppender 경로(→ Sentry)와 stdout(→ Loki) 수집을 복구합니다. Sentry SDK 의존은 추가하지 않았습니다.

## Trouble Shooting ⚽️

- **404 원인**: 프론트는 `VITE_API_BASE_URL(.../api)` + `/admin/...` = `/api/admin/...`을 호출하지만, Nginx는 `/admin`만 노출하고 있어 `/api/admin` 요청이 apis(catch-all `location /`)로 흘러 404가
발생했습니다. `external_path`를 `/api/admin`으로 맞춰 longest-prefix로 admin 서버에 도달하게 했습니다.
- **배치 예외 누락**: Spring 기본 핸들러가 `org.springframework.*` 로거로 예외를 남겨 `com.beat` 전용 SentryAppender 경로를 타지 못해 Sentry/Loki에서 누락되던 문제를, 중앙 ErrorHandler로
복구했습니다.
- **보안**: 통합 Swagger/api-docs는 비-prod에서만 활성(prod application.yml에서 비활성)이라 운영 환경 노출은 없습니다.

## Related ScreenShot 📷

<!-- 배포 후: 통합 Swagger 드롭다운(ADMIN) / 프론트 admin 404 해소 캡처 첨부 -->

## Uncompleted Tasks 😅

- Loki batch 로그 수집 복구는 런타임 증거 기반 진단 후 적용이 필요합니다(진단 런북 별도 보유). 본 PR 미반영.
- 최종 동작 검증(프론트 404 해소, 통합 Swagger 조회, Sentry/Loki 이벤트 확인)은 dev/prod **배포 후** 가능합니다.
- 배포 시 기존 서버에 남은 stale `BEAT MANAGED ROUTE /admin` Nginx 블록 정리가 권장됩니다(무해하나 정리).
- batch ErrorHandler의 단위/통합 테스트는 로컬 검증만 수행했고 본 PR에는 포함하지 않았습니다.

## To Reviewers 📢

- prod 라우팅(`group_vars`) 변경이 포함되어 배포 시 ansible로 반영됩니다. `/api/admin`이 catch-all `location /`보다 longest-prefix로 우선되는지 확인 부탁드립니다.
- 통합 Swagger의 admin 문서 경로가 `/api/admin/v3/api-docs/admin`인 이유: Nginx가 `/api/admin/`만 admin으로 프록시하고, 기존 `GroupedOpenApi`의 group명이 `admin`이라 prefix+group이 겹쳐 보이는
것이며 의도된 구성입니다.
- Trivy(`scan-images`) 체크가 red면 베이스 이미지 openssl CVE에 의한 사전 이슈이며 본 PR과 무관합니다.