### PR TITLE
fix: 500 에러 트레이스 Tempo 샘플링 누락 해결

### DIFF
--- a/admin/src/main/java/com/beat/admin/handler/AdminGlobalExceptionHandler.java
+++ b/admin/src/main/java/com/beat/admin/handler/AdminGlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.beat.admin.handler;
 
 import java.util.Optional;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.filter.ServerHttpObservationFilter;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -102,14 +105,20 @@ public class AdminGlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(Exception.class)
-	protected ResponseEntity<ErrorResponse> handleException(final Exception exception) {
+	protected ResponseEntity<ErrorResponse> handleException(final Exception exception, HttpServletRequest request) {
 		log.error("Unexpected server error: ", exception);
+		ServerHttpObservationFilter.findObservationContext(request)
+			.ifPresent(context -> context.setError(exception));
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."));
 	}
 
 	@ExceptionHandler(BeatException.class)
-	public ResponseEntity<ErrorResponse> handleBeatException(final BeatException exception) {
+	public ResponseEntity<ErrorResponse> handleBeatException(final BeatException exception, HttpServletRequest request) {
+		if (exception.getBaseErrorCode().getStatus() >= 500) {
+			ServerHttpObservationFilter.findObservationContext(request)
+				.ifPresent(context -> context.setError(exception));
+		}
 		return ResponseEntity.status(exception.getBaseErrorCode().getStatus())
 			.body(ErrorResponse.from(exception.getBaseErrorCode()));
 	}

--- a/apis/src/main/java/com/beat/apis/common/handler/GlobalExceptionHandler.java
+++ b/apis/src/main/java/com/beat/apis/common/handler/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.beat.apis.common.handler;
 
 import java.util.Optional;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.filter.ServerHttpObservationFilter;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -104,14 +107,20 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(Exception.class)
-	protected ResponseEntity<ErrorResponse> handleException(final Exception exception) {
+	protected ResponseEntity<ErrorResponse> handleException(final Exception exception, HttpServletRequest request) {
 		log.error("Unexpected server error: ", exception);
+		ServerHttpObservationFilter.findObservationContext(request)
+			.ifPresent(context -> context.setError(exception));
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."));
 	}
 
 	@ExceptionHandler(BeatException.class)
-	public ResponseEntity<ErrorResponse> handleBeatException(final BeatException exception) {
+	public ResponseEntity<ErrorResponse> handleBeatException(final BeatException exception, HttpServletRequest request) {
+		if (exception.getBaseErrorCode().getStatus() >= 500) {
+			ServerHttpObservationFilter.findObservationContext(request)
+				.ifPresent(context -> context.setError(exception));
+		}
 		return ResponseEntity.status(exception.getBaseErrorCode().getStatus())
 			.body(ErrorResponse.from(exception.getBaseErrorCode()));
 	}

--- a/infra/ansible/inventories/dev/group_vars/all/main.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/main.yml
@@ -79,13 +79,15 @@ modules:
     container_name: batch
     scheduler_owner: true
 
-# observability_alloy — dev는 metrics-only (t3.micro 1GB 메모리 절약)
-observability_alloy_mem_limit: "128m"
+# observability_alloy — dev는 이제 metrics+logs+traces 활성화 (t3.micro 1GB 환경, 메모리 주의)
+observability_alloy_mem_limit: "256m"
 observability_alloy_cpus: "0.5"
 observability_alloy_scrape_interval: "60s"
 observability_alloy_wal_truncate: "1h"
-observability_alloy_enable_logs: false
-observability_alloy_enable_traces: false
+observability_alloy_enable_logs: true
+observability_alloy_enable_traces: true
 observability_alloy_enable_cadvisor: false
 observability_alloy_published_ports:
   - "127.0.0.1:12345:12345"
+  - "127.0.0.1:4317:4317"
+  - "127.0.0.1:4318:4318"

--- a/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml
@@ -18,7 +18,7 @@ gc_prom_url: ENC[AES256_GCM,data:gK+hbMcfcIaOnPl8l+zABJzEfTe8oC7HQiL+368fC/D/MKG
 gc_prom_user: ENC[AES256_GCM,data:3muQp50jWg==,iv:lH8d++JukUYzWrX895t/kYue/TKyfFcgTxunBLhs3LQ=,tag:nkPDSL5NfkaGgMRew+7tbw==,type:str]
 gc_loki_url: ENC[AES256_GCM,data://Hnf53RscDb/X4Vm7cqQERgVT++BZ39eflLoZmVqj1gUK2Z9iIL11ouCxkeyyo5Jxs=,iv:h4WiP1yw0JlHLamB0w7cl7Z7VgkFMiKlWCSIqND+ZMs=,tag:q6kDIKDwa3OJcu/Rp7WDYw==,type:str]
 gc_loki_user: ENC[AES256_GCM,data:h7Kl7Azk8Q==,iv:3jPAzUtzBZLjWOo1sh8LAlpdrZ7Cucnx4eCc5s3zEfg=,tag:KJI7P8BkGLnytDaAbW/jSw==,type:str]
-gc_tempo_endpoint: ENC[AES256_GCM,data:TSJdNVlRTnVYcre75oOA8c0jOtW5erfxlm8rFh62rYyo4VI/c4kp9XMyugZqln+Ol7YUBPTKO2O6,iv:cfyY67qSDj6sjNIwr+XOpYoCjp8Hi52+vhdn4DHR6UU=,tag:jOtRhAX3bvhPfRf3Qnvzaw==,type:str]
+gc_tempo_endpoint: ENC[AES256_GCM,data:Hz02bMS+OZT9rFiZJj2GYJm3tl75UbOs0KPtAmIqCqLJzA6hk30oQYYySyA8T6481w==,iv:o0heYbP+sxUzAttYrIvB6aVpaQVkn7+9ymjLLVqQbpk=,tag:mxZRtUKSThMyq1Mi6WYUqA==,type:str]
 gc_tempo_user: ENC[AES256_GCM,data:AEbok3tftA==,iv:2Kd0+FZ5ihh4Qs1/FwhH9W0m0apgItdoCgPbVkAakwc=,tag:X1fY1bFdk5UaQpkWWo0Sag==,type:str]
 image_cdn_alarm_email: ENC[AES256_GCM,data:NHa9jXw/30Xf08tCb49kYY/Q4USIIlGTvIuu0K4sTA==,iv:B5ST70gIbd9ZXhAZnpbVBxZjINTIs0q0hFaVvwafmu8=,tag:gtKYEo0GqeDcRfXEMt3INA==,type:str]
 sops:
@@ -50,7 +50,7 @@ sops:
             aThPTEVkZ3k1TFZhWFdWaGF1Q3F0TU0K5bpZQewMIh8Fa/l2wMhMpeQpakm/OPZP
             d9ev5czGQm28TquHDAQEPyFS1l3mUrEdA8rmw6Eui9BxfctrLfCe2w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-23T16:20:36Z"
-    mac: ENC[AES256_GCM,data:GE9hW7q5sbbFdiejvwdDiAs8IHc9SJhpTVnKl/Y0c8qeRWwhDa0xyme7i6isK2EMkfqVxH+6O6jzICK2p+4Ilqkm+P8rwJOKP1CjqRBzQMnTNvrFnJx5Rhja6cFS4GJh31K4C2aGumFZ1BikXSj6j3E/jwB1vkuuFWzyrF1UqSc=,iv:7BfUwwkuw6AG+ydtNlQxsoZIoidNYNhLas0dEzNvwo8=,tag:tZGuu6P1d5PWDaxy/a+Wdw==,type:str]
+    lastmodified: "2026-06-21T17:22:15Z"
+    mac: ENC[AES256_GCM,data:FIFFQ8OrWMfWbJYvcUs4P4yNNLiOY1YUoHI/xhqHhV9X2+alNKyq4SB9gvTWhtfv02v3IEDIvk9pqdX3BEe2aG5O6DWgduGukhEOZXRpE4IItqaO7l0XgbIV5iKtkCC05nhJSzSDkuONFl4bbdpvYvANWBFDyII8x7vAEsjyfSk=,iv:bELrR8P/hShRVzgPbwKb5upK9aIJGP4oAELcrv2enqo=,tag:5Qe3pimOfhYs0Ztq+4bK7g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/infra/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -254,6 +254,14 @@ otelcol.processor.tail_sampling "policy" {
     }
   }
   policy {
+    name = "http_5xx_errors"
+    type = "string_attribute"
+    string_attribute {
+      key = "http.status_code"
+      values = ["500", "501", "502", "503", "504"]
+    }
+  }
+  policy {
     name = "slow"
     type = "latency"
     latency {
@@ -264,7 +272,7 @@ otelcol.processor.tail_sampling "policy" {
     name = "default_probabilistic"
     type = "probabilistic"
     probabilistic {
-      sampling_percentage = 10
+      sampling_percentage = 100
     }
   }
 

--- a/observability/src/main/kotlin/com/beat/observability/tracing/TracingConfig.kt
+++ b/observability/src/main/kotlin/com/beat/observability/tracing/TracingConfig.kt
@@ -1,9 +1,12 @@
 package com.beat.observability.tracing
 
+import io.micrometer.observation.ObservationFilter
 import io.micrometer.tracing.Tracer
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.server.observation.ServerRequestObservationContext
 
 @Configuration(proxyBeanMethods = false)
 class TracingConfig {
@@ -12,5 +15,19 @@ class TracingConfig {
     fun traceContextResolver(tracerProvider: ObjectProvider<Tracer>): TraceContextResolver {
         val tracer = tracerProvider.ifAvailable
         return tracer?.let(::MicrometerTraceContextResolver) ?: NoOpTraceContextResolver
+    }
+
+    @Bean
+    @ConditionalOnClass(name = ["org.springframework.http.server.observation.ServerRequestObservationContext"])
+    fun errorStatusObservationFilter(): ObservationFilter {
+        return ObservationFilter { context ->
+            if (context is ServerRequestObservationContext) {
+                val response = context.response
+                if (response != null && response.status >= 500 && context.error == null) {
+                    context.setError(RuntimeException("HTTP ${response.status}"))
+                }
+            }
+            context
+        }
     }
 }

--- a/observability/src/main/resources/application-observability.yml
+++ b/observability/src/main/resources/application-observability.yml
@@ -85,9 +85,9 @@ management:
     web:
       base-path: ${DEV_ACTUATOR_PATH}
   tracing:
-    enabled: false
-    export:
-      enabled: false
+    enabled: true
+    sampling:
+      probability: 1.0
 
 sentry:
   environment: dev


### PR DESCRIPTION
## Related issue 🛠
- closes #534
## Work Description ✏️
`@RestControllerAdvice`가 예외를 핸들링하면서 OTel Span Status가 `ERROR`로 마킹되지 않아, Grafana Alloy Tail Sampling의 `errors` 정책을 우회하고 500 에러 트레이스가 Tempo에서 유실되던 문제를 해결합니다.
### Primary — 애플리케이션 레벨
- `apis`, `admin` 모듈의 `GlobalExceptionHandler`에 `ServerHttpObservationFilter.findObservationContext(request).ifPresent(context -> context.setError(exception))` 추가
- 5xx 응답을 반환하는 핸들러에서 실제 예외 객체를 OTel Span Event에 직접 바인딩
- Tempo에서 500 에러 트레이스와 스택트레이스를 함께 조회할 수 있도록 개선
### Secondary — Safety Net 1: 애플리케이션 레벨
- `observability` 모듈 `TracingConfig`에 전역 `ObservationFilter` 추가
- 명시적 예외 없이 `ResponseEntity.status(500)`만 반환하는 엣지 케이스 방어
### Secondary — Safety Net 2: 인프라 레벨
- `config.alloy.j2` Tail Sampling에 `http.status_code` 기반 `http_5xx_errors` 정책 추가
- Span Status가 누락되더라도 HTTP 속성만으로 5xx 트레이스를 100% 수집할 수 있도록 보장
### 추가 개선
- `config.alloy.j2` 정상 트래픽 샘플링 비율 `10% → 100%` 상향
  - 현재 Traces 사용량이 1GB / 50GB 수준으로 여유가 있어 일시적으로 상향
- `dev` 환경 로그/트레이스 수집 활성화
- Alloy 메모리 제한 `128m → 256m` 상향
- `application-observability.yml` dev 프로필 tracing `enabled: true` 전환
## Trouble Shooting ⚽️

N/A

## Related ScreenShot 📷

N/A

## Uncompleted Tasks 😅

* dev 환경 Alloy 메모리 사용량 모니터링 필요
    * 128m → 256m로 상향했지만, dev 서버가 t3.micro 1GB 환경이므로 OOM 발생 여부를 주시해야 합니다.

## To Reviewers 📢
* dev 환경에서 traces/logs 수집을 활성화했지만, dev 트래픽이 거의 없기 때문에 Grafana Cloud 용량에는 큰 영향이 없을 것으로 예상됩니다.
* 만약 dev 서버에서 메모리 이슈가 발생한다면 아래 설정으로 빠르게 롤백할 수 있습니다.

observability_alloy_enable_traces: false