### PR TITLE
fix: RDS/DB 시간대(UTC) 불일치로 인한 예매 마감 판정 오차 해결

### DIFF
--- a/admin/src/test/java/com/beat/admin/support/AbstractAdminIntegrationTest.java
+++ b/admin/src/test/java/com/beat/admin/support/AbstractAdminIntegrationTest.java
@@ -16,7 +16,8 @@ public abstract class AbstractAdminIntegrationTest {
 
 	@ServiceConnection
 	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.39")
-		.withDatabaseName("beat_admin_test");
+		.withDatabaseName("beat_admin_test")
+		.withCommand("--default-time-zone=+09:00");
 
 	@ServiceConnection
 	static RedisContainer redis =

--- a/apis/src/test/java/com/beat/apis/support/AbstractIntegrationTest.java
+++ b/apis/src/test/java/com/beat/apis/support/AbstractIntegrationTest.java
@@ -15,7 +15,8 @@ public abstract class AbstractIntegrationTest {
 
 	@ServiceConnection
 	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.39")
-		.withDatabaseName("beat_test");
+		.withDatabaseName("beat_test")
+		.withCommand("--default-time-zone=+09:00");
 
 	@ServiceConnection
 	static RedisContainer redis =

--- a/apis/src/test/java/com/beat/apis/support/AbstractIntegrationTest.java
+++ b/apis/src/test/java/com/beat/apis/support/AbstractIntegrationTest.java
@@ -15,7 +15,7 @@ public abstract class AbstractIntegrationTest {
 
 	@ServiceConnection
 	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.39")
-		.withDatabaseName("beat_test")
+		.withDatabaseName("beat_apis_test")
 		.withCommand("--default-time-zone=+09:00");
 
 	@ServiceConnection

--- a/batch/src/test/java/com/beat/batch/support/AbstractBatchIntegrationTest.java
+++ b/batch/src/test/java/com/beat/batch/support/AbstractBatchIntegrationTest.java
@@ -15,7 +15,8 @@ public abstract class AbstractBatchIntegrationTest {
 
 	@ServiceConnection
 	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.39")
-		.withDatabaseName("beat_batch_test");
+		.withDatabaseName("beat_batch_test")
+		.withCommand("--default-time-zone=+09:00");
 
 	static {
 		mysql.start();

--- a/infra/ansible/roles/foundation_stack/templates/foundation.compose.yml.j2
+++ b/infra/ansible/roles/foundation_stack/templates/foundation.compose.yml.j2
@@ -19,6 +19,7 @@ services:
     image: "{{ mysql_image | default('mysql:8.4.5') }}"
     container_name: "{{ mysql_container_name | default('mysql') }}"
     restart: unless-stopped
+    command: ["--default-time-zone=+09:00"]
     ports:
       - "127.0.0.1:3306:3306"
     environment:


### PR DESCRIPTION
## Related issue 🛠

- closes #541

## Work Description ✏️
### prod rds server 이전 작업에서 time_zone 파라미터 설정이 누락

운영 RDS 세션 `time_zone`이 UTC였고 JDBC URL에 시간대 파라미터가 없어, DB가 자체 생성하는 `CURRENT_TIMESTAMP(6)`가 UTC 벽시계 값을 반환하는 문제를 발견했습니다. 반면 애플리케이션이 저장하는 `LocalDateTime` 값(`schedule.performance_date` 등)은 JVM `-Duser.timezone=Asia/Seoul` 덕에 KST 벽시계 값으로 저장되어, DB가 만드는 시각과 애플리케이션이 만드는 시각이 9시간 어긋나는 상태였습니다.

- 운영 RDS 파라미터 그룹의 `time_zone`이 `Dynamic`(재부팅 불필요)임을 확인하여 `Asia/Seoul`로 변경 완료 (인프라 콘솔 조치, 이번 PR 범위 밖)
- dev MySQL 컨테이너(`foundation.compose.yml.j2`)에 `--default-time-zone=+09:00` 추가
- apis/admin/batch 통합테스트의 Testcontainers MySQL에도 동일 시간대 옵션(`withCommand("--default-time-zone=+09:00")`) 적용해 dev/prod/test 시간대 전제를 통일
- Hibernate 세션 레벨 설정(`hibernate.jdbc.time_zone`)으로 우회를 시도했으나, 이 옵션은 MySQL 세션 변수 `time_zone`을 실제로 변경하지 않는다는 것을 통합 테스트로 확인하여 롤백 (이번 PR에는 포함되지 않음)

## Trouble Shooting ⚽️

- `hibernate.jdbc.time_zone=Asia/Seoul`을 먼저 시도했으나, 이 설정은 Hibernate가 JDBC 값을 바인딩/리드할 때 쓰는 변환 기준일 뿐 MySQL 세션 변수 `SET time_zone`을 실행하지 않습니다. `@@session.time_zone`이 여전히 `SYSTEM`(UTC)으로 남고 `CURRENT_TIMESTAMP(6)` 판정에 9시간 오차가 그대로 재현되는 것을 테스트로 확인해 방향을 DB 서버 자체 시간대 통일로 전환했습니다.
- `--default-time-zone`은 `mysqld` 시작 옵션이라 기존 데이터 볼륨을 유지한 채 컨테이너를 재생성해도 안전하게 반영됩니다.

## Related ScreenShot 📷

N/A

## Uncompleted Tasks 😅

- [ ] dev Ansible 재배포로 mysql 컨테이너 재생성 및 반영 확인
- [ ] prod apis/batch/admin 애플리케이션 재기동하여 기존 커넥션 풀에 새 세션 시간대 반영

## To Reviewers 📢

- 이 PR은 dev 컨테이너 시간대 설정과 통합테스트 시간대 정렬만 포함합니다. prod RDS 파라미터 그룹 변경은 인프라 콘솔에서 이미 적용했고 (Dynamic 파라미터, 재부팅 불필요), 애플리케이션 재기동은 별도로 진행됩니다.