### PR TITLE
chore: 로컬 bootRun dev secret 자동 준비

### DIFF
--- a/build-logic/src/main/kotlin/beat.spring-boot-app.gradle.kts
+++ b/build-logic/src/main/kotlin/beat.spring-boot-app.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.tasks.Exec
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
@@ -61,7 +62,28 @@ dependencies {
     }
 }
 
+val localDevSecretScript = rootDir.resolve("scripts/generate-local-dev-secret.sh")
+val localVarsScript = rootDir.resolve("scripts/lib/local-vars.sh")
+val localDevSecretSource = rootDir.resolve("infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml")
+val localDevSecretOutput = rootDir.resolve("secret/application-dev-secret.properties")
+
+fun localDevSecretHasRequiredKeys(): Boolean =
+    localDevSecretOutput.exists() &&
+        localDevSecretOutput.useLines { lines ->
+            lines.any { it.startsWith("DB_HIKARI_MAX_POOL_SIZE=") }
+        }
+
+val prepareLocalDevSecret = tasks.register<Exec>("prepareLocalDevSecret") {
+    description = "Generate the repo-local dev secret properties file used by bootRun."
+    group = "application"
+    commandLine(localDevSecretScript.absolutePath)
+    inputs.files(localDevSecretScript, localVarsScript, localDevSecretSource)
+    outputs.file(localDevSecretOutput)
+    outputs.upToDateWhen { localDevSecretHasRequiredKeys() }
+}
+
 tasks.withType<BootRun>().configureEach {
     // Secret imports resolve from the shared repo-level `secret/` directory.
     workingDir = rootDir
+    dependsOn(prepareLocalDevSecret)
 }

--- a/infra/README.md
+++ b/infra/README.md
@@ -1309,6 +1309,12 @@ pipelining 호환성을 확인한다.
 ./gradlew :batch:bootRun
 ```
 
+`DB_HIKARI_MAX_POOL_SIZE`는 필수 런타임 설정입니다. `bootRun`은
+`secret/application-dev-secret.properties`가 없거나 필수값이 빠진 경우
+로컬 dev secret을 자동 생성합니다. 시크릿 원본을 갱신한 뒤 즉시 반영해야 할
+때만 `./gradlew :admin:prepareLocalDevSecret` 또는
+`./scripts/generate-local-dev-secret.sh`를 직접 실행하세요.
+
 ### 로컬 검증
 
 ```bash

--- a/scripts/generate-local-dev-secret.sh
+++ b/scripts/generate-local-dev-secret.sh
@@ -77,13 +77,15 @@ fi
 LOCAL_DEV_DB_URL=$(replace_jdbc_mysql_host "$DEV_DB_URL" "localhost")
 LOCAL_DEV_REDIS_HOST="localhost"
 LOCAL_DEV_KAKAO_REDIRECT_URI="http://localhost:4001/login/oauth2/code/kakao"
+LOCAL_DEV_HIKARI_MAX_POOL_SIZE="3"
 
 awk '
   $0 !~ "^DEV_DB_URL=" &&
   $0 !~ "^DEV_REDIS_HOST=" &&
   $0 !~ "^DEV_ACTUATOR_PORT=" &&
   $0 !~ "^DEV_ACTUATOR_PATH=" &&
-  $0 !~ "^DEV_KAKAO_REDIRECT_URI="
+  $0 !~ "^DEV_KAKAO_REDIRECT_URI=" &&
+  $0 !~ "^DB_HIKARI_MAX_POOL_SIZE="
 ' "$TMP_DIR/app_secret_content.properties" > "$TMP_DIR/app_secret_content.filtered.properties"
 
 {
@@ -93,6 +95,7 @@ awk '
   printf 'DEV_ACTUATOR_PATH=%s\n' "$ACTUATOR_PATH"
   printf 'DEV_REDIS_HOST=%s\n' "$LOCAL_DEV_REDIS_HOST"
   printf 'DEV_KAKAO_REDIRECT_URI=%s\n' "$LOCAL_DEV_KAKAO_REDIRECT_URI"
+  printf 'DB_HIKARI_MAX_POOL_SIZE=%s\n' "$LOCAL_DEV_HIKARI_MAX_POOL_SIZE"
 } > "$TMP_DIR/application-dev-secret.properties"
 
 mv "$TMP_DIR/application-dev-secret.properties" "$OUTPUT_FILE"

--- a/scripts/generate-local-prod-secret.sh
+++ b/scripts/generate-local-prod-secret.sh
@@ -32,20 +32,22 @@ mkdir -p "$(dirname -- "$OUTPUT_FILE")"
 sops -d --extract '["app_secret_content"]' "$SOPS_FILE" > "$TMP_DIR/app_secret_content.properties"
 ACTUATOR_PORT=$(sops -d --extract '["actuator_port"]' "$SOPS_FILE")
 ACTUATOR_PATH=$(sops -d --extract '["actuator_path"]' "$SOPS_FILE")
+LOCAL_PROD_HIKARI_MAX_POOL_SIZE="10"
 
 awk '
   $0 !~ "^PROD_ACTUATOR_PORT=" &&
-  $0 !~ "^PROD_ACTUATOR_PATH="
+  $0 !~ "^PROD_ACTUATOR_PATH=" &&
+  $0 !~ "^DB_HIKARI_MAX_POOL_SIZE="
 ' "$TMP_DIR/app_secret_content.properties" > "$TMP_DIR/app_secret_content.filtered.properties"
 
 {
   cat "$TMP_DIR/app_secret_content.filtered.properties"
   printf '\nPROD_ACTUATOR_PORT=%s\n' "$ACTUATOR_PORT"
   printf 'PROD_ACTUATOR_PATH=%s\n' "$ACTUATOR_PATH"
+  printf 'DB_HIKARI_MAX_POOL_SIZE=%s\n' "$LOCAL_PROD_HIKARI_MAX_POOL_SIZE"
 } > "$TMP_DIR/application-prod-secret.properties"
 
 mv "$TMP_DIR/application-prod-secret.properties" "$OUTPUT_FILE"
 chmod 400 "$OUTPUT_FILE"
 
 printf 'Generated %s from %s\n' "$OUTPUT_FILE" "$SOPS_FILE"
-


### PR DESCRIPTION
## Related issue 🛠

- closes #547

## Work Description ✏️

- `bootRun` 실행 전에 로컬 dev secret을 준비하는 `prepareLocalDevSecret` Gradle task를 연결했습니다.
- 로컬 dev/prod secret 생성기에 필수 Hikari 설정인 `DB_HIKARI_MAX_POOL_SIZE`를 추가했습니다.
- 로컬 실행 문서에 자동 생성 동작과 수동 재생성 방법을 정리했습니다.

## Trouble Shooting ⚽️

- 로컬에서 dev profile로 실행할 때 `DB_HIKARI_MAX_POOL_SIZE`가 없으면 Hikari 설정 바인딩이 실패했습니다.
- 서버 dev/prod는 Ansible container env로 값을 받지만, 로컬 `bootRun`은 repo-local secret 파일을 읽기 때문에 별도 보정이 필요했습니다.

## Related ScreenShot 📷

N/A

## Uncompleted Tasks 😅

N/A

## To Reviewers 📢

검증:
- `git diff --check`
- `./gradlew :admin:bootRun --dry-run`에서 `:admin:prepareLocalDevSecret` 연결 확인
- `./gradlew :admin:prepareLocalDevSecret` 1회 실행 후 재실행 시 `UP-TO-DATE` 확인
