### PR TITLE
refactor: Jackson API 호환성 및 Ansible 이미지 CDN 배포 정비

### DIFF
--- a/.github/actions/setup-ansible-tooling/action.yml
+++ b/.github/actions/setup-ansible-tooling/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Cosign
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       with:
         cosign-release: v3.0.3
 
@@ -49,7 +49,7 @@ runs:
         rm -f "sops-${SOPS_VERSION}.checksums.txt" "sops-${SOPS_VERSION}.checksums.pem" "sops-${SOPS_VERSION}.checksums.sig"
 
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.12"
 

--- a/.github/workflows/_ansible-aws-exec.yml
+++ b/.github/workflows/_ansible-aws-exec.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-ansible-tooling
 

--- a/.github/workflows/_ansible-aws-exec.yml
+++ b/.github/workflows/_ansible-aws-exec.yml
@@ -1,0 +1,69 @@
+name: ansible-aws-exec
+
+on:
+  workflow_call:
+    inputs:
+      environment_name:
+        required: true
+        type: string
+      playbook:
+        required: true
+        type: string
+      inventory_path:
+        required: true
+        type: string
+      aws_region:
+        required: true
+        type: string
+      checkout_ref:
+        required: true
+        type: string
+    secrets:
+      sops_age_key:
+        required: true
+
+jobs:
+  execute:
+    name: "${{ inputs.playbook }} :: ${{ inputs.environment_name }}"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    environment: ${{ inputs.environment_name }}
+    env:
+      AWS_ROLE_TO_ASSUME: ${{ vars.AWS_IMAGE_CDN_DEPLOY_ROLE_ARN }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - uses: ./.github/actions/setup-ansible-tooling
+
+      - name: Verify environment deployment role
+        shell: bash
+        run: |
+          test -n "$AWS_ROLE_TO_ASSUME" || {
+            echo "AWS_IMAGE_CDN_DEPLOY_ROLE_ARN is not configured for this environment." >&2
+            exit 1
+          }
+
+      - name: Configure AWS credentials through OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Run Ansible playbook
+        shell: bash
+        env:
+          SOPS_AGE_KEY: ${{ secrets.sops_age_key }}
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment_name }}
+          PLAYBOOK: ${{ inputs.playbook }}
+          INVENTORY_PATH: ${{ inputs.inventory_path }}
+        run: |
+          set -euo pipefail
+          export SOPS_AGE_KEY
+          cd infra/ansible
+          ansible-playbook "$PLAYBOOK" -i "$INVENTORY_PATH" \
+            -e "deploy_environment=$DEPLOY_ENVIRONMENT"

--- a/.github/workflows/_ansible-exec.yml
+++ b/.github/workflows/_ansible-exec.yml
@@ -77,12 +77,15 @@ jobs:
       - name: Checkout code (current ref)
         if: inputs.checkout_ref == ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Checkout code (requested ref)
         if: inputs.checkout_ref != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling

--- a/.github/workflows/_ansible-exec.yml
+++ b/.github/workflows/_ansible-exec.yml
@@ -59,7 +59,7 @@ on:
 jobs:
   execute:
     name: "${{ inputs.playbook }} :: ${{ inputs.module }} :: ${{ inputs.environment_name }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read
@@ -76,11 +76,11 @@ jobs:
     steps:
       - name: Checkout code (current ref)
         if: inputs.checkout_ref == ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Checkout code (requested ref)
         if: inputs.checkout_ref != ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
 

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -20,11 +20,11 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling

--- a/.github/workflows/ansible-secret-aware-verify.yml
+++ b/.github/workflows/ansible-secret-aware-verify.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling
@@ -86,6 +88,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling

--- a/.github/workflows/ansible-secret-aware-verify.yml
+++ b/.github/workflows/ansible-secret-aware-verify.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   verify-dev:
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/develop' || github.base_ref == 'develop'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment: dev
     strategy:
@@ -42,7 +42,7 @@ jobs:
           - batch
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling
@@ -73,7 +73,7 @@ jobs:
 
   verify-prod:
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.base_ref == 'main'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment: prod
     strategy:
@@ -85,7 +85,7 @@ jobs:
           - batch
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Ansible tooling
         uses: ./.github/actions/setup-ansible-tooling

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,23 +8,23 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: "25"
           distribution: "temurin"
 
       - name: Gradle caching
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-cleanup: on-success
 
@@ -77,7 +77,7 @@ jobs:
 
   scan-images:
     needs: verify
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -87,10 +87,10 @@ jobs:
           - batch
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Download bootJars artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -108,7 +108,7 @@ jobs:
         shell: bash
 
       - name: Build scan image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.module

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,14 +23,14 @@ on:
 
 jobs:
   resolve-ref:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
     outputs:
       commit_sha: ${{ steps.resolve.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -76,15 +76,15 @@ jobs:
           echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
 
   detect-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       has_modules: ${{ steps.matrix.outputs.has_modules }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -102,7 +102,24 @@ jobs:
               - 'gateway/**'
               - 'observability/**'
               - 'infra/src/**'
-              - 'infra/ansible/**'
+              # Runtime Ansible only. Dedicated infrastructure roles have their
+              # own workflows and must not redeploy every application module.
+              - 'infra/ansible/ansible.cfg'
+              - 'infra/ansible/collections/requirements.yml'
+              - 'infra/ansible/playbooks/deploy.yml'
+              - 'infra/ansible/playbooks/foundation.yml'
+              - 'infra/ansible/playbooks/tasks/validate_nginx_fragments.yml'
+              - 'infra/ansible/roles/app_*/**'
+              - 'infra/ansible/roles/foundation_stack/**'
+              - 'infra/ansible/roles/letsencrypt_bootstrap/**'
+              - 'infra/ansible/roles/letsencrypt_cron/**'
+              - 'infra/ansible/roles/nginx_base_config/**'
+              - 'infra/ansible/roles/nginx_config_helper/**'
+              - 'infra/ansible/roles/nginx_fragment_transaction/**'
+              - 'infra/ansible/roles/swapfile/**'
+              - 'infra/ansible/inventories/dev/hosts.yml'
+              - 'infra/ansible/inventories/dev/group_vars/all/main.yml'
+              - 'infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml'
               - 'infra/build.gradle.kts'
               - 'build-logic/**'
               - 'build.gradle.kts'
@@ -164,21 +181,21 @@ jobs:
       - detect-changes
       - resolve-ref
     if: needs.detect-changes.outputs.has_modules == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-ref.outputs.commit_sha }}
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: "25"
           distribution: "temurin"
 
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-cleanup: on-success
 
@@ -216,7 +233,7 @@ jobs:
       - resolve-ref
       - verify
     if: needs.detect-changes.outputs.has_modules == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -226,15 +243,15 @@ jobs:
       max-parallel: 3
       matrix: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-ref.outputs.commit_sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           username: ${{ vars.DEV_DOCKER_LOGIN_USERNAME }}
           password: ${{ secrets.DEV_DOCKER_LOGIN_ACCESSTOKEN }}
@@ -270,7 +287,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.module

--- a/.github/workflows/deploy-image-cdn-dev.yml
+++ b/.github/workflows/deploy-image-cdn-dev.yml
@@ -6,9 +6,12 @@ on:
       - develop
     paths:
       - 'infra/aws/**'
+      - '.sops.yaml'
+      - 'infra/ansible/ansible.cfg'
       - 'infra/ansible/collections/requirements.yml'
       - 'infra/ansible/playbooks/image_cdn.yml'
       - 'infra/ansible/roles/image_cdn/**'
+      - 'infra/ansible/inventories/dev/hosts.yml'
       - 'infra/ansible/inventories/dev/group_vars/all/image_cdn.yml'
       - 'infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml'
       - '.github/actions/setup-ansible-tooling/**'

--- a/.github/workflows/deploy-image-cdn-dev.yml
+++ b/.github/workflows/deploy-image-cdn-dev.yml
@@ -1,0 +1,81 @@
+name: deploy-image-cdn-dev
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'infra/aws/**'
+      - 'infra/ansible/collections/requirements.yml'
+      - 'infra/ansible/playbooks/image_cdn.yml'
+      - 'infra/ansible/roles/image_cdn/**'
+      - 'infra/ansible/inventories/dev/group_vars/all/image_cdn.yml'
+      - 'infra/ansible/inventories/dev/group_vars/all/secrets.sops.yml'
+      - '.github/actions/setup-ansible-tooling/**'
+      - '.github/workflows/_ansible-aws-exec.yml'
+      - '.github/workflows/deploy-image-cdn-dev.yml'
+  workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: "Optional branch, tag, or SHA to deploy (defaults to the triggering commit)"
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  resolve-ref:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Resolve deploy ref
+        id: resolve
+        env:
+          DEPLOY_REF: ${{ github.event.inputs.deploy_ref }}
+          DEFAULT_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          requested="${DEPLOY_REF:-$DEFAULT_SHA}"
+          git fetch --force --prune origin \
+            '+refs/heads/*:refs/remotes/origin/*' \
+            '+refs/tags/*:refs/tags/*'
+          candidates=("$requested")
+          if [[ "$requested" == refs/heads/* ]]; then
+            candidates+=("refs/remotes/origin/${requested#refs/heads/}")
+          elif [[ "$requested" != refs/* ]]; then
+            candidates+=("refs/remotes/origin/$requested" "refs/tags/$requested")
+          fi
+          for candidate in "${candidates[@]}"; do
+            if commit_sha="$(git rev-parse --verify --quiet "${candidate}^{commit}")"; then
+              echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "Invalid deploy_ref: $requested" >&2
+          exit 1
+
+  deploy:
+    needs: resolve-ref
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: dev-image-cdn
+      cancel-in-progress: false
+    uses: ./.github/workflows/_ansible-aws-exec.yml
+    with:
+      environment_name: dev
+      playbook: playbooks/image_cdn.yml
+      inventory_path: inventories/dev/hosts.yml
+      aws_region: ap-northeast-2
+      checkout_ref: ${{ needs.resolve-ref.outputs.commit_sha }}
+    secrets:
+      sops_age_key: ${{ secrets.AGE_SECRET_KEY }}

--- a/.github/workflows/deploy-image-cdn-prod.yml
+++ b/.github/workflows/deploy-image-cdn-prod.yml
@@ -1,0 +1,68 @@
+name: deploy-image-cdn-prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: "Branch, tag, or SHA to deploy (required; must be contained in main)"
+        type: string
+        required: true
+
+jobs:
+  resolve-ref:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Resolve deploy ref from main history
+        id: resolve
+        env:
+          DEPLOY_REF: ${{ github.event.inputs.deploy_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --prune origin \
+            '+refs/heads/*:refs/remotes/origin/*' \
+            '+refs/tags/*:refs/tags/*'
+          requested="$DEPLOY_REF"
+          candidates=("$requested")
+          if [[ "$requested" == refs/heads/* ]]; then
+            candidates+=("refs/remotes/origin/${requested#refs/heads/}")
+          elif [[ "$requested" != refs/* ]]; then
+            candidates+=("refs/remotes/origin/$requested" "refs/tags/$requested")
+          fi
+          for candidate in "${candidates[@]}"; do
+            if commit_sha="$(git rev-parse --verify --quiet "${candidate}^{commit}")"; then
+              if git merge-base --is-ancestor "$commit_sha" origin/main; then
+                echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          done
+          echo "deploy_ref must resolve to a commit contained in origin/main" >&2
+          exit 1
+
+  deploy:
+    needs: resolve-ref
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: prod-image-cdn
+      cancel-in-progress: false
+    uses: ./.github/workflows/_ansible-aws-exec.yml
+    with:
+      environment_name: prod
+      playbook: playbooks/image_cdn.yml
+      inventory_path: inventories/prod/hosts.yml
+      aws_region: ap-northeast-2
+      checkout_ref: ${{ needs.resolve-ref.outputs.commit_sha }}
+    secrets:
+      sops_age_key: ${{ secrets.AGE_SECRET_KEY }}

--- a/.github/workflows/deploy-observability-dev.yml
+++ b/.github/workflows/deploy-observability-dev.yml
@@ -25,14 +25,14 @@ on:
 
 jobs:
   resolve-ref:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
     outputs:
       commit_sha: ${{ steps.resolve.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-observability-prod.yml
+++ b/.github/workflows/deploy-observability-prod.yml
@@ -16,14 +16,14 @@ on:
 
 jobs:
   resolve-ref:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
     outputs:
       commit_sha: ${{ steps.resolve.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,7 +11,7 @@ jobs:
       release_tag: ${{ steps.release.outputs.release_tag }}
       module_matrix: ${{ steps.release.outputs.module_matrix }}
       commit_sha: ${{ steps.git-ref.outputs.commit_sha }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -29,7 +29,7 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo 'module_matrix={"include":[{"module":"admin"},{"module":"apis"},{"module":"batch"}]}' >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ steps.release.outputs.release_tag }}
           fetch-depth: 0
@@ -60,21 +60,21 @@ jobs:
   verify:
     needs:
       - resolve-release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: "25"
           distribution: "temurin"
 
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-cleanup: on-success
 
@@ -109,7 +109,7 @@ jobs:
   secret-preflight:
     needs:
       - resolve-release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -119,7 +119,7 @@ jobs:
       max-parallel: 3
       matrix: ${{ fromJSON(needs.resolve-release.outputs.module_matrix) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
@@ -167,15 +167,15 @@ jobs:
       max-parallel: 3
       matrix: ${{ fromJSON(needs.resolve-release.outputs.module_matrix) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           username: ${{ vars.PROD_DOCKER_LOGIN_USERNAME }}
           password: ${{ secrets.PROD_DOCKER_LOGIN_ACCESSTOKEN }}
@@ -211,7 +211,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.module
@@ -227,7 +227,7 @@ jobs:
           sbom: true
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.1
         with:
           subject-name: docker.io/${{ vars.PROD_DOCKER_LOGIN_USERNAME }}/beat-${{ matrix.module }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@a6a982fee9675c45c1765e9fa5308f7d6c3ecbd4 # v7.2.0
+      - uses: release-drafter/release-drafter@5a60cd8ddda6dc14fce77159675b8fd2cdca4007 # v7.6.0
         with:
           config-name: release-drafter-config.yml
         env:

--- a/admin/src/main/kotlin/com/beat/admin/promotion/api/request/CarouselHandleRequest.kt
+++ b/admin/src/main/kotlin/com/beat/admin/promotion/api/request/CarouselHandleRequest.kt
@@ -1,5 +1,6 @@
 package com.beat.admin.promotion.api.request
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
@@ -22,7 +23,8 @@ data class CarouselHandleRequest(
         val carouselNumber: AdminCarouselNumber?,
         @field:NotNull(message = INVALID_REQUEST_MESSAGE)
         val newImageUrl: String?,
-        @param:JsonProperty("external")
+        @param:JsonProperty("isExternal")
+        @param:JsonAlias("external")
         @field:NotNull(message = INVALID_REQUEST_MESSAGE)
         val isExternal: Boolean?,
         @field:NotNull(message = INVALID_REQUEST_MESSAGE)
@@ -36,7 +38,8 @@ data class CarouselHandleRequest(
         val carouselNumber: AdminCarouselNumber?,
         @field:NotNull(message = INVALID_REQUEST_MESSAGE)
         val newImageUrl: String?,
-        @param:JsonProperty("external")
+        @param:JsonProperty("isExternal")
+        @param:JsonAlias("external")
         @field:NotNull(message = INVALID_REQUEST_MESSAGE)
         val isExternal: Boolean?,
         @field:NotNull(message = INVALID_REQUEST_MESSAGE)

--- a/admin/src/test/java/com/beat/admin/application/AdminDtoJsonContractTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminDtoJsonContractTest.java
@@ -42,7 +42,7 @@ class AdminDtoJsonContractTest {
 	}
 
 	@Test
-	void carouselHandleRequestDeserializesLegacyCarouselNumberValue() throws Exception {
+	void carouselHandleRequestAcceptsCanonicalAndTemporaryExternalFieldNames() throws Exception {
 		String json = """
 			{
 			  "carousels": [
@@ -51,7 +51,7 @@ class AdminDtoJsonContractTest {
 			      "promotionId": 1,
 			      "carouselNumber": "THREE",
 			      "newImageUrl": "image",
-			      "external": true,
+			      "isExternal": true,
 			      "redirectUrl": "redirect",
 			      "performanceId": 11
 			    }
@@ -66,6 +66,12 @@ class AdminDtoJsonContractTest {
 			request.carousels().get(0));
 		assertEquals(AdminCarouselNumber.THREE, modifyRequest.carouselNumber());
 		assertTrue(modifyRequest.isExternal());
+
+		CarouselHandleRequest aliasRequest = objectMapper.readValue(json.replace("\"isExternal\"", "\"external\""),
+			CarouselHandleRequest.class);
+		PromotionModifyRequest aliasModifyRequest = assertInstanceOf(PromotionModifyRequest.class,
+			aliasRequest.carousels().get(0));
+		assertTrue(aliasModifyRequest.isExternal());
 	}
 
 	@Test

--- a/apis/src/main/kotlin/com/beat/apis/file/api/FileApi.kt
+++ b/apis/src/main/kotlin/com/beat/apis/file/api/FileApi.kt
@@ -34,5 +34,6 @@ interface FileApi {
         @RequestParam(required = false) castImages: List<String>?,
         @RequestParam(required = false) staffImages: List<String>?,
         @RequestParam(required = false) performanceImages: List<String>?,
+        @RequestParam(name = "performImages", required = false) legacyPerformanceImages: List<String>?,
     ): ResponseEntity<SuccessResponse<PerformanceMakerPresignedUrlFindAllResponse>>
 }

--- a/apis/src/main/kotlin/com/beat/apis/file/api/FileController.kt
+++ b/apis/src/main/kotlin/com/beat/apis/file/api/FileController.kt
@@ -22,12 +22,13 @@ class FileController(
         @RequestParam(required = false) castImages: List<String>?,
         @RequestParam(required = false) staffImages: List<String>?,
         @RequestParam(required = false) performanceImages: List<String>?,
+        @RequestParam(name = "performImages", required = false) legacyPerformanceImages: List<String>?,
     ): ResponseEntity<SuccessResponse<PerformanceMakerPresignedUrlFindAllResponse>> {
         val response = fileFacade.issueAllPresignedUrlsForPerformanceMaker(
             posterImage,
             castImages,
             staffImages,
-            performanceImages,
+            performanceImages ?: legacyPerformanceImages,
         )
         return ResponseEntity.ok(SuccessResponse.of(FileSuccessCode.PERFORMANCE_MAKER_PRESIGNED_URL_ISSUED, response))
     }

--- a/apis/src/main/kotlin/com/beat/apis/file/application/command/FileCommandService.kt
+++ b/apis/src/main/kotlin/com/beat/apis/file/application/command/FileCommandService.kt
@@ -16,16 +16,19 @@ class FileCommandService(
         staffImages: List<String>?,
         performanceImages: List<String>?,
     ): PerformancePresignedUrls {
-        val fileNames = listOf(posterImage) + castImages.orEmpty() + staffImages.orEmpty() + performanceImages.orEmpty()
+        val normalizedCastImages = castImages.orEmpty().filter(String::isNotBlank)
+        val normalizedStaffImages = staffImages.orEmpty().filter(String::isNotBlank)
+        val normalizedPerformanceImages = performanceImages.orEmpty().filter(String::isNotBlank)
+        val fileNames = listOf(posterImage) + normalizedCastImages + normalizedStaffImages + normalizedPerformanceImages
         if (fileNames.any { !isValidFileName(it) }) {
             throw ApiApplicationException(FileApplicationErrorCode.INVALID_FILE_NAME)
         }
 
         return fileStoragePort.issueAllPresignedUrlsForPerformanceMaker(
             posterImage,
-            castImages.orEmpty(),
-            staffImages.orEmpty(),
-            performanceImages.orEmpty(),
+            normalizedCastImages,
+            normalizedStaffImages,
+            normalizedPerformanceImages,
         )
     }
 

--- a/apis/src/main/kotlin/com/beat/apis/home/api/response/HomePromotionDetail.kt
+++ b/apis/src/main/kotlin/com/beat/apis/home/api/response/HomePromotionDetail.kt
@@ -2,6 +2,7 @@ package com.beat.apis.home.api.response
 
 import com.beat.apis.home.application.result.HomePromotionResult
 import com.beat.global.support.jackson.CdnImageUrl
+import com.fasterxml.jackson.annotation.JsonProperty
 
 @ConsistentCopyVisibility
 data class HomePromotionDetail private constructor(
@@ -9,6 +10,7 @@ data class HomePromotionDetail private constructor(
     @field:CdnImageUrl val promotionPhoto: String?,
     val performanceId: Long?,
     val redirectUrl: String?,
+    @get:JsonProperty("isExternal")
     val isExternal: Boolean,
     val carouselNumber: String?,
 ) {

--- a/apis/src/main/kotlin/com/beat/apis/performance/api/response/BookingPerformanceDetailScheduleResponse.kt
+++ b/apis/src/main/kotlin/com/beat/apis/performance/api/response/BookingPerformanceDetailScheduleResponse.kt
@@ -1,6 +1,7 @@
 package com.beat.apis.performance.api.response
 
 import com.beat.apis.performance.application.result.BookingPerformanceScheduleResult
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 
 @ConsistentCopyVisibility
@@ -9,6 +10,7 @@ data class BookingPerformanceDetailScheduleResponse private constructor(
     val performanceDate: LocalDateTime?,
     val scheduleNumber: String?,
     val availableTicketCount: Int,
+    @get:JsonProperty("isBooking")
     val isBooking: Boolean,
     val dueDate: Int,
 ) {

--- a/apis/src/main/kotlin/com/beat/apis/performance/api/response/PerformanceDetailScheduleResponse.kt
+++ b/apis/src/main/kotlin/com/beat/apis/performance/api/response/PerformanceDetailScheduleResponse.kt
@@ -1,6 +1,7 @@
 package com.beat.apis.performance.api.response
 
 import com.beat.apis.performance.application.result.PerformanceDetailScheduleResult
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 
 @ConsistentCopyVisibility
@@ -9,6 +10,7 @@ data class PerformanceDetailScheduleResponse private constructor(
     val performanceDate: LocalDateTime?,
     val scheduleNumber: String?,
     val dueDate: Int,
+    @get:JsonProperty("isBooking")
     val isBooking: Boolean,
 ) {
     companion object {

--- a/apis/src/main/kotlin/com/beat/apis/performance/api/response/PerformanceModifyDetailResponse.kt
+++ b/apis/src/main/kotlin/com/beat/apis/performance/api/response/PerformanceModifyDetailResponse.kt
@@ -4,6 +4,7 @@ import com.beat.apis.performance.api.type.BankNameType
 import com.beat.apis.performance.api.type.GenreType
 import com.beat.apis.performance.application.result.PerformanceEditResult
 import com.beat.global.support.jackson.CdnImageUrl
+import com.fasterxml.jackson.annotation.JsonProperty
 
 @ConsistentCopyVisibility
 data class PerformanceModifyDetailResponse private constructor(
@@ -28,6 +29,7 @@ data class PerformanceModifyDetailResponse private constructor(
     val performancePeriod: String?,
     val ticketPrice: Int,
     val totalScheduleCount: Int,
+    @get:JsonProperty("isBookerExist")
     val isBookerExist: Boolean,
     val scheduleList: List<ScheduleResponse>,
     val castList: List<CastResponse>,

--- a/apis/src/main/kotlin/com/beat/apis/schedule/api/response/TicketAvailabilityResponse.kt
+++ b/apis/src/main/kotlin/com/beat/apis/schedule/api/response/TicketAvailabilityResponse.kt
@@ -1,6 +1,7 @@
 package com.beat.apis.schedule.api.response
 
 import com.beat.apis.schedule.application.result.TicketAvailabilityResult
+import com.fasterxml.jackson.annotation.JsonProperty
 
 @ConsistentCopyVisibility
 data class TicketAvailabilityResponse private constructor(
@@ -10,6 +11,7 @@ data class TicketAvailabilityResponse private constructor(
     val soldTicketCount: Int,
     val availableTicketCount: Int,
     val requestedTicketCount: Int,
+    @get:JsonProperty("isAvailable")
     val isAvailable: Boolean,
 ) {
     companion object {

--- a/apis/src/test/java/com/beat/apis/file/api/FileControllerTest.java
+++ b/apis/src/test/java/com/beat/apis/file/api/FileControllerTest.java
@@ -1,0 +1,84 @@
+package com.beat.apis.file.api;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.beat.apis.file.api.response.PerformanceMakerPresignedUrlFindAllResponse;
+import com.beat.apis.file.facade.FileFacade;
+
+@ExtendWith(MockitoExtension.class)
+class FileControllerTest {
+
+	@Mock
+	private FileFacade fileFacade;
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = standaloneSetup(new FileController(fileFacade)).build();
+		when(fileFacade.issueAllPresignedUrlsForPerformanceMaker(
+			org.mockito.ArgumentMatchers.anyString(),
+			org.mockito.ArgumentMatchers.any(),
+			org.mockito.ArgumentMatchers.any(),
+			org.mockito.ArgumentMatchers.any()
+		)).thenReturn(mock(PerformanceMakerPresignedUrlFindAllResponse.class));
+	}
+
+	@Test
+	void canonicalPerformanceImagesParameterIsForwarded() throws Exception {
+		mockMvc.perform(get("/api/files/presigned-url")
+				.param("posterImage", "poster.png")
+				.param("performanceImages", "performance.png"))
+			.andExpect(status().isOk());
+
+		verify(fileFacade).issueAllPresignedUrlsForPerformanceMaker(
+			"poster.png", null, null, List.of("performance.png"));
+	}
+
+	@Test
+	void legacyPerformImagesParameterIsForwarded() throws Exception {
+		mockMvc.perform(get("/api/files/presigned-url")
+				.param("posterImage", "poster.png")
+				.param("performImages", "performance.png"))
+			.andExpect(status().isOk());
+
+		verify(fileFacade).issueAllPresignedUrlsForPerformanceMaker(
+			"poster.png", null, null, List.of("performance.png"));
+	}
+
+	@Test
+	void canonicalPerformanceImagesTakesPrecedenceOverLegacyAlias() throws Exception {
+		mockMvc.perform(get("/api/files/presigned-url")
+				.param("posterImage", "poster.png")
+				.param("performanceImages", "canonical.png")
+				.param("performImages", "legacy.png"))
+			.andExpect(status().isOk());
+
+		verify(fileFacade).issueAllPresignedUrlsForPerformanceMaker(
+			"poster.png", null, null, List.of("canonical.png"));
+	}
+
+	@Test
+	void emptyPerformanceImagesPlaceholderIsBoundAsAnEmptyList() throws Exception {
+		mockMvc.perform(get("/api/files/presigned-url")
+				.param("posterImage", "poster.png")
+				.param("performanceImages", ""))
+			.andExpect(status().isOk());
+
+		verify(fileFacade).issueAllPresignedUrlsForPerformanceMaker("poster.png", null, null, List.of());
+	}
+}

--- a/apis/src/test/java/com/beat/apis/file/application/FileCommandServiceTest.java
+++ b/apis/src/test/java/com/beat/apis/file/application/FileCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.beat.apis.file.application;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -71,5 +72,6 @@ class FileCommandServiceTest {
 		);
 
 		assertEquals(FileApplicationErrorCode.INVALID_FILE_NAME, exception.getErrorCode());
+		verifyNoInteractions(fileStoragePort);
 	}
 }

--- a/apis/src/test/java/com/beat/apis/file/application/FileCommandServiceTest.java
+++ b/apis/src/test/java/com/beat/apis/file/application/FileCommandServiceTest.java
@@ -1,0 +1,75 @@
+package com.beat.apis.file.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.beat.apis.exception.ApiApplicationException;
+import com.beat.apis.file.application.command.FileCommandService;
+import com.beat.apis.file.exception.FileApplicationErrorCode;
+import com.beat.contracts.storage.FileStoragePort;
+import com.beat.contracts.storage.PerformancePresignedUrls;
+
+@ExtendWith(MockitoExtension.class)
+class FileCommandServiceTest {
+
+	@Mock
+	private FileStoragePort fileStoragePort;
+
+	private FileCommandService fileService;
+
+	@BeforeEach
+	void setUp() {
+		fileService = new FileCommandService(fileStoragePort);
+	}
+
+	@Test
+	void issueAllPresignedUrlsNormalizesNullableListsBeforeCallingStoragePort() {
+		PerformancePresignedUrls presignedUrls = new PerformancePresignedUrls(
+			Map.of("poster", Map.of("poster.png", "https://example.com/poster.png"))
+		);
+		when(fileStoragePort.issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of()))
+			.thenReturn(presignedUrls);
+
+		fileService.issueAllPresignedUrlsForPerformanceMaker(
+			"poster.png",
+			null,
+			null,
+			null
+		);
+
+		verify(fileStoragePort).issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of());
+	}
+
+	@Test
+	void issueAllPresignedUrlsIgnoresLegacyEmptyListPlaceholders() {
+		fileService.issueAllPresignedUrlsForPerformanceMaker(
+			"poster.png",
+			List.of(""),
+			List.of(""),
+			List.of("")
+		);
+
+		verify(fileStoragePort).issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of());
+	}
+
+	@Test
+	void issueAllPresignedUrlsRejectsPathLikeFileNamesBeforeCallingStorage() {
+		ApiApplicationException exception = assertThrows(
+			ApiApplicationException.class,
+			() -> fileService.issueAllPresignedUrlsForPerformanceMaker("../poster.png", null, null, null)
+		);
+
+		assertEquals(FileApplicationErrorCode.INVALID_FILE_NAME, exception.getErrorCode());
+	}
+}

--- a/apis/src/test/kotlin/com/beat/apis/ApisDtoJsonContractTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/ApisDtoJsonContractTest.kt
@@ -1,0 +1,272 @@
+package com.beat.apis
+
+import com.beat.apis.booking.api.request.BookingRefundRequest
+import com.beat.apis.booking.api.request.GuestBookingRequest
+import com.beat.apis.booking.api.request.MemberBookingRequest
+import com.beat.apis.booking.api.response.GuestBookingResponse
+import com.beat.apis.booking.api.response.MemberBookingResponse
+import com.beat.apis.booking.api.type.BookingStatusType
+import com.beat.apis.booking.application.result.BookingCreationResult
+import com.beat.apis.home.api.response.HomeFindAllResponse
+import com.beat.apis.home.api.type.HomeGenreType
+import com.beat.apis.home.application.result.HomeFindAllResult
+import com.beat.apis.home.application.result.HomePerformanceResult
+import com.beat.apis.home.application.result.HomePromotionResult
+import com.beat.apis.member.api.request.MemberLoginRequest
+import com.beat.apis.member.api.type.SocialTypeRequest
+import com.beat.apis.member.application.command.SocialLoginProvider
+import com.beat.apis.performance.api.type.BankNameType
+import com.beat.apis.performance.api.type.GenreType
+import com.beat.apis.performance.application.command.PerformanceBankName
+import com.beat.apis.performance.application.command.PerformanceGenre
+import com.beat.apis.performance.application.command.PerformanceScheduleNumber
+import com.beat.apis.performance.api.response.BookingPerformanceDetailScheduleResponse
+import com.beat.apis.performance.api.response.PerformanceDetailScheduleResponse
+import com.beat.apis.performance.api.response.PerformanceModifyDetailResponse
+import com.beat.apis.performance.application.result.BookingPerformanceScheduleResult
+import com.beat.apis.performance.application.result.PerformanceDetailScheduleResult
+import com.beat.apis.performance.application.result.PerformanceEditResult
+import com.beat.apis.performance.application.result.PerformanceMutationResult
+import com.beat.apis.schedule.api.response.TicketAvailabilityResponse
+import com.beat.apis.schedule.application.result.TicketAvailabilityResult
+import com.beat.apis.schedule.api.type.ScheduleNumberType
+import com.beat.apis.ticket.application.command.TicketBookingStatus
+import com.beat.domain.booking.model.BookingStatus
+import com.beat.domain.member.model.SocialType
+import com.beat.domain.performance.model.Genre
+import com.beat.domain.schedule.model.ScheduleNumber
+import com.beat.domain.sharedkernel.vo.BankName
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import jakarta.validation.Validation
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ApisDtoJsonContractTest {
+
+    private val objectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `required request collections reject null`() {
+        val validator = Validation.buildDefaultValidatorFactory().validator
+        val request = com.beat.apis.ticket.api.request.TicketRefundRequest(1L, null)
+
+        assertEquals(1, validator.validate(request).size)
+    }
+
+    @Test
+    fun `api enum names stay compatible across api boundary migration`() {
+        assertEquals(listOf("KAKAO"), enumNames(SocialTypeRequest.entries.toTypedArray()))
+        assertEquals(listOf("BAND", "PLAY", "DANCE", "ETC"), enumNames(GenreType.entries.toTypedArray()))
+        assertEquals(listOf("BAND", "PLAY", "DANCE", "ETC"), enumNames(HomeGenreType.entries.toTypedArray()))
+        assertEquals(
+            listOf("FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH", "SIXTH", "SEVENTH", "EIGHTH", "NINTH", "TENTH"),
+            enumNames(ScheduleNumberType.entries.toTypedArray()),
+        )
+        assertEquals(
+            listOf(
+                "NH_NONGHYUP", "KAKAOBANK", "KB_KOOKMIN", "TOSSBANK", "SHINHAN", "WOORI",
+                "IBK_GIUP", "HANA", "SAEMAUL", "BUSAN", "IMBANK_DAEGU", "SINHYEOP",
+                "WOOCHAEGUK", "SCJEIL", "SUHYEOP", "NONE",
+            ),
+            enumNames(BankNameType.entries.toTypedArray()),
+        )
+        assertEquals(
+            listOf("CHECKING_PAYMENT", "BOOKING_CONFIRMED", "BOOKING_CANCELLED", "REFUND_REQUESTED", "BOOKING_DELETED"),
+            enumNames(BookingStatusType.entries.toTypedArray()),
+        )
+
+        assertSameEnumNames(SocialTypeRequest.entries.toTypedArray(), SocialType.entries.toTypedArray())
+        assertSameEnumNames(GenreType.entries.toTypedArray(), Genre.entries.toTypedArray())
+        assertSameEnumNames(HomeGenreType.entries.toTypedArray(), Genre.entries.toTypedArray())
+        assertSameEnumNames(ScheduleNumberType.entries.toTypedArray(), ScheduleNumber.entries.toTypedArray())
+        assertSameEnumNames(BankNameType.entries.toTypedArray(), BankName.entries.toTypedArray())
+        assertSameEnumNames(BookingStatusType.entries.toTypedArray(), BookingStatus.entries.toTypedArray())
+        assertSameEnumNames(SocialTypeRequest.entries.toTypedArray(), SocialLoginProvider.entries.toTypedArray())
+        assertSameEnumNames(GenreType.entries.toTypedArray(), PerformanceGenre.entries.toTypedArray())
+        assertSameEnumNames(BankNameType.entries.toTypedArray(), PerformanceBankName.entries.toTypedArray())
+        assertSameEnumNames(ScheduleNumberType.entries.toTypedArray(), PerformanceScheduleNumber.entries.toTypedArray())
+        assertSameEnumNames(BookingStatusType.entries.toTypedArray(), TicketBookingStatus.entries.toTypedArray())
+    }
+
+    @Test
+    fun `domain enum request json string values stay compatible across api boundary migration`() {
+        val memberLoginRequest = MemberLoginRequest(SocialTypeRequest.KAKAO)
+        val bookingRefundRequest = BookingRefundRequest(1L, BankNameType.KAKAOBANK, "123", "holder")
+        val guestBookingRequest = GuestBookingRequest(
+            1L, 2, ScheduleNumberType.FIRST, "booker", "010-0000-0000", "990101", "password", 20000,
+            BookingStatusType.CHECKING_PAYMENT,
+        )
+        val memberBookingRequest = MemberBookingRequest(
+            1L, ScheduleNumberType.FIRST, 2, "booker", "010-0000-0000", BookingStatusType.CHECKING_PAYMENT, 20000,
+        )
+
+        assertTextField(objectMapper.valueToTree(memberLoginRequest), "socialType", "KAKAO")
+        assertTextField(objectMapper.valueToTree(bookingRefundRequest), "bankName", "KAKAOBANK")
+        val guestBookingJson = objectMapper.valueToTree<JsonNode>(guestBookingRequest)
+        assertTextField(guestBookingJson, "scheduleNumber", "FIRST")
+        assertTextField(guestBookingJson, "bookingStatus", "CHECKING_PAYMENT")
+        val memberBookingJson = objectMapper.valueToTree<JsonNode>(memberBookingRequest)
+        assertTextField(memberBookingJson, "scheduleNumber", "FIRST")
+        assertTextField(memberBookingJson, "bookingStatus", "CHECKING_PAYMENT")
+
+        assertEquals(
+            SocialTypeRequest.KAKAO,
+            objectMapper.readValue("""{"socialType":"KAKAO"}""", MemberLoginRequest::class.java).socialType,
+        )
+        assertEquals(
+            BankNameType.KAKAOBANK,
+            objectMapper.readValue(
+                """{"bookingId":1,"bankName":"KAKAOBANK","accountNumber":"123","accountHolder":"holder"}""",
+                BookingRefundRequest::class.java,
+            ).bankName,
+        )
+        val parsedGuestBookingRequest = objectMapper.readValue(
+            """{"scheduleId":1,"purchaseTicketCount":2,"scheduleNumber":"FIRST","bookerName":"booker",""" +
+                """"bookerPhoneNumber":"010-0000-0000","birthDate":"990101","password":"password",""" +
+                """"totalPaymentAmount":20000,"bookingStatus":"CHECKING_PAYMENT"}""",
+            GuestBookingRequest::class.java,
+        )
+        assertEquals(ScheduleNumberType.FIRST, parsedGuestBookingRequest.scheduleNumber)
+        assertEquals(BookingStatusType.CHECKING_PAYMENT, parsedGuestBookingRequest.bookingStatus)
+        val parsedMemberBookingRequest = objectMapper.readValue(
+            """{"scheduleId":1,"scheduleNumber":"FIRST","purchaseTicketCount":2,"bookerName":"booker",""" +
+                """"bookerPhoneNumber":"010-0000-0000","bookingStatus":"CHECKING_PAYMENT","totalPaymentAmount":20000}""",
+            MemberBookingRequest::class.java,
+        )
+        assertEquals(ScheduleNumberType.FIRST, parsedMemberBookingRequest.scheduleNumber)
+        assertEquals(BookingStatusType.CHECKING_PAYMENT, parsedMemberBookingRequest.bookingStatus)
+    }
+
+    @Test
+    fun `booking response json string values stay compatible across api boundary migration`() {
+        val creationResult = BookingCreationResult(
+            bookingId = 10L,
+            scheduleId = 1L,
+            userId = 30L,
+            purchaseTicketCount = 2,
+            scheduleNumber = "FIRST",
+            bookerName = "booker",
+            bookerPhoneNumber = "010-0000-0000",
+            bookingStatus = "CHECKING_PAYMENT",
+            bankName = "KAKAOBANK",
+            accountNumber = "123",
+            totalPaymentAmount = 20000,
+            createdAt = null,
+        )
+        val guestBookingResponse = GuestBookingResponse.from(creationResult)
+        val memberBookingResponse = MemberBookingResponse.from(creationResult)
+
+        val guestJson = objectMapper.valueToTree<JsonNode>(guestBookingResponse)
+        assertTextField(guestJson, "scheduleNumber", "FIRST")
+        assertTextField(guestJson, "bookingStatus", "CHECKING_PAYMENT")
+        assertTextField(guestJson, "bankName", "KAKAOBANK")
+
+        val memberJson = objectMapper.valueToTree<JsonNode>(memberBookingResponse)
+        assertTextField(memberJson, "scheduleNumber", "FIRST")
+        assertTextField(memberJson, "bookingStatus", "CHECKING_PAYMENT")
+        assertTextField(memberJson, "bankName", "KAKAOBANK")
+    }
+
+    @Test
+    fun `home response json field names and enum values stay compatible`() {
+        val response = HomeFindAllResponse.from(
+            HomeFindAllResult(
+                promotionList = listOf(
+                    HomePromotionResult(1L, "promotion.png", 11L, "redirect", true, "ONE"),
+                ),
+                performanceList = listOf(
+                    HomePerformanceResult(11L, "title", "period", 30000, 3, "BAND", "poster.png", "venue"),
+                ),
+            ),
+        )
+
+        val json = objectMapper.valueToTree<JsonNode>(response)
+        val promotion = json.get("promotionList").get(0)
+        val performance = json.get("performanceList").get(0)
+
+        assertTrue(json.has("promotionList"))
+        assertTrue(json.has("performanceList"))
+        assertTrue(promotion.has("carouselNumber"))
+        assertBooleanField(promotion, "isExternal", true)
+        assertFalse(promotion.has("external"))
+        assertTrue(performance.has("genre"))
+        assertFalse(promotion.get("carouselNumber").isObject)
+        assertFalse(performance.get("genre").isObject)
+        assertEquals("ONE", promotion.get("carouselNumber").asText())
+        assertEquals("BAND", performance.get("genre").asText())
+    }
+
+    @Test
+    fun `boolean response json field names stay compatible`() {
+        val availability = TicketAvailabilityResponse.from(
+            TicketAvailabilityResult(1L, "FIRST", 10, 2, 8, 1, true),
+        )
+        val detailSchedule = PerformanceDetailScheduleResponse.from(
+            PerformanceDetailScheduleResult(1L, null, "FIRST", 3, true),
+        )
+        val bookingSchedule = BookingPerformanceDetailScheduleResponse.from(
+            BookingPerformanceScheduleResult(1L, null, "FIRST", 8, true, 3),
+        )
+        val modifyDetail = PerformanceModifyDetailResponse.from(
+            PerformanceEditResult(
+                PerformanceMutationResult(
+                    userId = 1L,
+                    performanceId = 1L,
+                    performanceTitle = "title",
+                    genre = "BAND",
+                    runningTime = 60,
+                    performanceDescription = "description",
+                    performanceAttentionNote = "note",
+                    bankName = "KAKAOBANK",
+                    accountNumber = "123",
+                    accountHolder = "holder",
+                    posterImage = "poster.png",
+                    performanceTeamName = "team",
+                    performanceVenue = "venue",
+                    roadAddressName = "road",
+                    placeDetailAddress = "detail",
+                    latitude = "0",
+                    longitude = "0",
+                    performanceContact = "010",
+                    performancePeriod = "period",
+                    ticketPrice = 1000,
+                    totalScheduleCount = 1,
+                    schedules = emptyList(),
+                    casts = emptyList(),
+                    staffs = emptyList(),
+                    images = emptyList(),
+                ),
+                isBookerExist = true,
+            ),
+        )
+
+        assertBooleanField(objectMapper.valueToTree(availability), "isAvailable", true)
+        assertFalse(objectMapper.valueToTree<JsonNode>(availability).has("available"))
+        assertBooleanField(objectMapper.valueToTree(detailSchedule), "isBooking", true)
+        assertFalse(objectMapper.valueToTree<JsonNode>(detailSchedule).has("booking"))
+        assertBooleanField(objectMapper.valueToTree(bookingSchedule), "isBooking", true)
+        assertFalse(objectMapper.valueToTree<JsonNode>(bookingSchedule).has("booking"))
+        assertBooleanField(objectMapper.valueToTree(modifyDetail), "isBookerExist", true)
+        assertFalse(objectMapper.valueToTree<JsonNode>(modifyDetail).has("bookerExist"))
+    }
+
+    private fun enumNames(values: Array<out Enum<*>>): List<String> = values.map { it.name }
+
+    private fun assertSameEnumNames(apiValues: Array<out Enum<*>>, domainValues: Array<out Enum<*>>) {
+        assertEquals(enumNames(domainValues), enumNames(apiValues))
+    }
+
+    private fun assertTextField(json: JsonNode, fieldName: String, expectedValue: String) {
+        assertTrue(json.has(fieldName)) { "Missing JSON field: $fieldName" }
+        assertFalse(json.get(fieldName).isObject) { "$fieldName must stay a JSON string" }
+        assertEquals(expectedValue, json.get(fieldName).asText())
+    }
+
+    private fun assertBooleanField(json: JsonNode, fieldName: String, expectedValue: Boolean) {
+        assertTrue(json.has(fieldName)) { "Missing JSON field: $fieldName" }
+        assertEquals(expectedValue, json.get(fieldName).booleanValue())
+    }
+}

--- a/infra/ansible/roles/image_cdn/defaults/main.yml
+++ b/infra/ansible/roles/image_cdn/defaults/main.yml
@@ -4,6 +4,7 @@
 
 image_cdn_stack_name: "beat-image-cdn-{{ deploy_environment }}"
 image_cdn_region: "ap-northeast-2"
+image_cdn_cloudformation_role_arn: "arn:aws:iam::637423615550:role/beat-image-cdn-cloudformation-execution"
 
 # Paths (relative to repo root) of source artifacts.
 image_cdn_template_relpath: "infra/aws/cloudformation/image-cdn.yml"

--- a/infra/ansible/roles/image_cdn/tasks/main.yml
+++ b/infra/ansible/roles/image_cdn/tasks/main.yml
@@ -4,6 +4,7 @@
     that:
       - deploy_environment in ["dev", "prod"]
       - image_cdn_source_bucket | length > 0
+      - image_cdn_cloudformation_role_arn | length > 0
       - image_cdn_alarm_email | length > 0
       - image_cdn_lambda_code_bucket | length > 0
       - image_cdn_transformed_bucket_name is defined
@@ -14,6 +15,7 @@
       - image_cdn_acm_cert_arn | length > 0
     fail_msg: >
       image_cdn role requires deploy_environment, image_cdn_source_bucket,
+      image_cdn_cloudformation_role_arn,
       image_cdn_alarm_email, image_cdn_lambda_code_bucket,
       image_cdn_transformed_bucket_name, image_cdn_custom_domain, and
       image_cdn_acm_cert_arn.
@@ -92,6 +94,7 @@
     template: "{{ image_cdn_repo_root }}/{{ image_cdn_template_relpath }}"
     capabilities:
       - CAPABILITY_IAM
+    role_arn: "{{ image_cdn_cloudformation_role_arn }}"
     template_parameters:
       Environment: "{{ deploy_environment }}"
       OriginalImageBucketName: "{{ image_cdn_source_bucket }}"

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -134,15 +134,24 @@ image_cdn_alarm_email: alerts@example.com
 
 BEAT 의 표준 배포 경로는 **GitHub Actions + Ansible** 입니다
 ([[project_infra_deploy_strategy]]). GHA workflow 가 dev/prod 환경별 AWS
-credentials 를 OIDC role 또는 secrets 로 주입하고, runner 에서
-`ansible-playbook` 을 실행하는 형태입니다. 본 role 도 동일 패턴을
-전제로 합니다 — `amazon.aws` 모듈은 환경변수
+OIDC role 로 임시 자격증명을 주입하고, runner 에서
+`ansible-playbook` 을 실행하는 형태입니다. `deploy-image-cdn-dev.yml`은
+관련 경로가 `develop`에 병합될 때만 실행되고, prod는 `main` 이력의 ref만
+수동 실행합니다. 본 role 은 환경변수
 (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`
 또는 `AWS_PROFILE`) 를 자동 인식합니다.
 
 > [!NOTE]
-> Phase 1 의 GHA 워크플로우 정의는 별도 PR scope. 본 PR 은 role/CFN/JS
-> 만 포함하며, 첫 실 배포까지의 GHA 추가는 후속 작업입니다.
+> OIDC provider와 역할은 최초 1회 AWS에서 만들어야 합니다. GitHub 환경
+> 변수 `AWS_IMAGE_CDN_DEPLOY_ROLE_ARN`에 각 환경 역할 ARN을 설정하세요.
+> 신뢰 정책은 `token.actions.githubusercontent.com:aud=sts.amazonaws.com`과
+> `sub=repo:TEAM-BEAT/BEAT-SERVER:environment:dev|prod`로 각각 제한하고,
+> GitHub `prod` 환경에는 승인·배포 브랜치 보호를 적용합니다.
+
+> [!IMPORTANT]
+> 역할 권한은 image CDN의 원본/변환/아티팩트 버킷, 해당 CloudFormation
+> 스택 및 그 스택이 생성하는 리소스만 허용해야 합니다. 장기 AWS access key를
+> GitHub Secrets에 저장하지 않습니다.
 
 ### 로컬 디버깅 실행
 
@@ -160,7 +169,8 @@ cd infra/ansible
 # dev
 AWS_PROFILE=beat-prod ansible-playbook \
   -i inventories/dev \
-  playbooks/image_cdn.yml
+  playbooks/image_cdn.yml \
+  -e deploy_environment=dev
 
 # prod (dev 검증 통과 후)
 AWS_PROFILE=beat-prod ansible-playbook \

--- a/src/test/java/com/beat/RootRetirementContractTest.java
+++ b/src/test/java/com/beat/RootRetirementContractTest.java
@@ -505,7 +505,7 @@ class RootRetirementContractTest {
 		assertFalse(ansibleExecWorkflow.contains(
 			"inputs.environment_name == 'dev' && secrets.DEV_SSH_HOST || secrets.PROD_SSH_HOST"));
 		assertFalse(ansibleExecWorkflow.contains("PROD_DOCKER_LOGIN_USERNAME"));
-		assertTrue(setupAnsibleTooling.contains("sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003"));
+		assertTrue(setupAnsibleTooling.contains("sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6"));
 		assertTrue(setupAnsibleTooling.contains("Install verified age"));
 		assertTrue(setupAnsibleTooling.contains("cosign verify-blob"));
 		assertTrue(setupAnsibleTooling.contains("sha256sum -c"));


### PR DESCRIPTION
## 변경 사항
- Kotlin DTO의 Boolean JSON 직렬화 키와 캐러셀 `isExternal` 요청 바인딩을 기존 클라이언트 계약에 맞춤
- 기존 `performImages` query parameter 호환 및 빈 이미지 항목 정규화
- API JSON 계약·파일 API 회귀 테스트 추가
- Image CDN 전용 Ansible/OIDC 배포 경로 추가 및 CloudFormation 실행 역할 분리
- dev CDN 변경만 자동 적용하고 prod는 main 이력의 수동 실행으로 제한
- 앱 배포의 Ansible path trigger를 축소해 CDN 변경이 전체 앱 재배포를 유발하지 않도록 정리
- GitHub Actions 최신 고정 SHA 및 ubuntu-24.04 runner 적용

## 배경
Kotlin 마이그레이션에서 Java Boolean/boxed 타입과 Jackson 명명 규칙 차이로 기존 클라이언트 계약이 달라질 수 있었다. 또한 Image CDN Ansible playbook은 존재했지만 GitHub Actions 실행 경로가 없어 선언한 인프라 상태가 자동 적용되지 않았다.

## 검증
- `ansible-playbook ... image_cdn.yml ... --syntax-check`
- `ansible-lint playbooks/image_cdn.yml`
- GitHub workflow YAML 파싱 및 `git diff --check`
- AWS IAM Access Analyzer 및 역할 권한 simulation

Closes #552