### PR TITLE
refactor: 컨테이너 베이스 이미지 보안 패치 재현성 확보

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "build(deps)"
+    assignees:
+      - move-hoon
+      - hyerinhwang-sailin
+      - imddoy

--- a/Dockerfile.module
+++ b/Dockerfile.module
@@ -1,9 +1,12 @@
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25.0.3_9-jre-alpine-3.23@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 
 ARG MODULE
 
-# Trivy reports CVE-2026-2100 against the base image p11-kit 0.25.5-r2 baseline
-RUN apk upgrade --no-cache p11-kit p11-kit-trust
+# Keep security fixes reproducible with the pinned Temurin Alpine base image.
+RUN apk add --no-cache --upgrade \
+    libexpat=2.8.2-r0 \
+    p11-kit=0.26.2-r0 \
+    p11-kit-trust=0.26.2-r0
 
 RUN addgroup -g 10001 -S beat && adduser -S -u 10001 -G beat beat && mkdir -p /app && chown beat:beat /app
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -29,7 +29,7 @@
 | Java bytecode target | root `build.gradle.kts`와 `build-logic/build.gradle.kts`의 `options.release.set(25)` | release `25` |
 | Kotlin JVM target | `build-logic/build.gradle.kts`와 Kotlin convention plugin의 `JvmTarget.JVM_25` (root project는 Kotlin plugin을 적용하지 않음) | JVM `25` |
 | SDKMAN local JDK | `.sdkmanrc`의 `java=25.0.2-tem` 및 BEAT team standard 주석 | JDK `25` |
-| Docker runtime | `Dockerfile.module`의 `eclipse-temurin:25-jre-alpine` | Java `25` |
+| Docker runtime | `Dockerfile.module`의 digest 고정 `eclipse-temurin:25.0.3_9-jre-alpine-3.23` | Java `25` |
 
 확인 명령:
 

--- a/src/test/java/com/beat/SharedBoundaryContractTest.java
+++ b/src/test/java/com/beat/SharedBoundaryContractTest.java
@@ -146,7 +146,10 @@ class SharedBoundaryContractTest {
 		assertTrue(buildLogicBuild.contains("JvmTarget.JVM_25"));
 
 		// ARM native build path compiles the JAR on the GHA runner; Docker image is runtime-only (single jre-alpine stage).
-		assertTrue(dockerfile.contains("eclipse-temurin:25-jre-alpine"));
+		assertTrue(dockerfile.contains("eclipse-temurin:25.0.3_9-jre-alpine-3.23@sha256:"));
+		assertTrue(dockerfile.contains("libexpat=2.8.2-r0"));
+		assertTrue(dockerfile.contains("p11-kit=0.26.2-r0"));
+		assertTrue(dockerfile.contains("p11-kit-trust=0.26.2-r0"));
 	}
 
 	@Test


### PR DESCRIPTION
## 변경 사항
- Temurin Alpine 런타임 이미지를 digest로 고정하고 Trivy 지적 패키지를 고정 버전으로 업데이트했습니다.
- Docker 베이스 이미지의 주기적 보안 업데이트를 Dependabot으로 등록했습니다.
- 런타임 이미지 보안 패치 계약을 테스트와 마이그레이션 문서에 반영했습니다.

## 배경
Alpine `libexpat` 취약점으로 이미지 스캔이 실패했습니다. 태그 기반 이미지는 재현성이 없으므로 digest와 패키지 버전을 함께 고정합니다.

- closes #554