### PR TITLE
fix: Dependabot Java 런타임 메이저 업데이트 제한

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
       - move-hoon
       - hyerinhwang-sailin
       - imddoy
+    # Java runtime major upgrades require a coordinated JDK migration.
+    ignore:
+      - dependency-name: eclipse-temurin
+        versions:
+          - ">= 26"


### PR DESCRIPTION
## 변경 사항
- Docker Dependabot에서 `eclipse-temurin` 26 이상 태그를 제외합니다.
- Java 25 계열 보안 패치와 digest 업데이트는 계속 제안됩니다.

## 배경
Dependabot이 프로젝트의 Java 25 런타임 계약을 알 수 없어 Java 26 업데이트 PR(#557)을 생성했습니다. Java 메이저 전환은 Gradle·bytecode·런타임을 함께 검증하는 별도 마이그레이션으로 관리해야 합니다.

## 근거
GitHub 공식 문서는 Docker 이미지 태그에 `ignore.versions`와 Bundler 범위 문법을 사용하도록 안내합니다.

## 검증
- Ruby YAML 파싱
- `eclipse-temurin`, `>= 26` 정책 구조 검증
- `git diff --check`

Closes #558