### PR TITLE
fix: 전체 이미지 presigned 업로드 계약 및 저장 검증 통일

### DIFF
--- a/admin/src/main/java/com/beat/admin/promotion/api/response/BannerPresignedUrlFindResponse.java
+++ b/admin/src/main/java/com/beat/admin/promotion/api/response/BannerPresignedUrlFindResponse.java
@@ -3,13 +3,18 @@ package com.beat.admin.promotion.api.response;
 import com.beat.admin.promotion.application.result.AdminPromotionPresignedUrlResults.BannerPresignedUrlResult;
 
 public record BannerPresignedUrlFindResponse(
-	String bannerPresignedUrl
+	String bannerPresignedUrl,
+	BannerPresignedUploadResponse bannerPresignedUpload
 ) {
-	private static BannerPresignedUrlFindResponse of(String bannerPresignedUrl) {
-		return new BannerPresignedUrlFindResponse(bannerPresignedUrl);
+	private static BannerPresignedUrlFindResponse of(String bannerPresignedUrl, String bannerImageKey) {
+		return new BannerPresignedUrlFindResponse(bannerPresignedUrl,
+			new BannerPresignedUploadResponse(bannerPresignedUrl, bannerImageKey));
 	}
 
 	public static BannerPresignedUrlFindResponse from(BannerPresignedUrlResult result) {
-		return BannerPresignedUrlFindResponse.of(result.bannerPresignedUrl());
+		return BannerPresignedUrlFindResponse.of(result.bannerPresignedUrl(), result.bannerImageKey());
+	}
+
+	public record BannerPresignedUploadResponse(String uploadUrl, String imageKey) {
 	}
 }

--- a/admin/src/main/java/com/beat/admin/promotion/api/response/CarouselPresignedUrlFindAllResponse.java
+++ b/admin/src/main/java/com/beat/admin/promotion/api/response/CarouselPresignedUrlFindAllResponse.java
@@ -3,15 +3,34 @@ package com.beat.admin.promotion.api.response;
 import java.util.Map;
 
 import com.beat.admin.promotion.application.result.AdminPromotionPresignedUrlResults.CarouselPresignedUrlsResult;
+import com.beat.contracts.storage.CarouselPresignedUpload;
 
 public record CarouselPresignedUrlFindAllResponse(
-	Map<String, String> carouselPresignedUrls
+	Map<String, String> carouselPresignedUrls,
+	Map<String, CarouselPresignedUploadResponse> carouselPresignedUploads
 ) {
-	private static CarouselPresignedUrlFindAllResponse of(Map<String, String> carouselPresignedUrls) {
-		return new CarouselPresignedUrlFindAllResponse(carouselPresignedUrls);
+	private static CarouselPresignedUrlFindAllResponse of(
+		Map<String, CarouselPresignedUpload> carouselPresignedUploads) {
+		Map<String, String> carouselPresignedUrls = carouselPresignedUploads.entrySet().stream()
+			.collect(java.util.stream.Collectors.toUnmodifiableMap(
+				Map.Entry::getKey,
+				entry -> entry.getValue().getUploadUrl()
+			));
+		Map<String, CarouselPresignedUploadResponse> uploadResponses = carouselPresignedUploads.entrySet().stream()
+			.collect(java.util.stream.Collectors.toUnmodifiableMap(
+				Map.Entry::getKey,
+				entry -> CarouselPresignedUploadResponse.from(entry.getValue())
+			));
+		return new CarouselPresignedUrlFindAllResponse(carouselPresignedUrls, uploadResponses);
 	}
 
 	public static CarouselPresignedUrlFindAllResponse from(CarouselPresignedUrlsResult result) {
-		return CarouselPresignedUrlFindAllResponse.of(result.carouselPresignedUrls());
+		return CarouselPresignedUrlFindAllResponse.of(result.carouselPresignedUploads());
+	}
+
+	public record CarouselPresignedUploadResponse(String uploadUrl, String imageKey) {
+		private static CarouselPresignedUploadResponse from(CarouselPresignedUpload upload) {
+			return new CarouselPresignedUploadResponse(upload.getUploadUrl(), upload.getImageKey());
+		}
 	}
 }

--- a/admin/src/main/java/com/beat/admin/promotion/application/command/AdminPromotionCommandService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/command/AdminPromotionCommandService.java
@@ -37,11 +37,6 @@ public class AdminPromotionCommandService {
 		Promotion::getCarouselNumber,
 		Comparator.comparingInt(Enum::ordinal)
 	);
-	private static final long MAX_CAROUSEL_IMAGE_SIZE_BYTES = 10L * 1024 * 1024;
-	private static final Set<String> ALLOWED_CAROUSEL_IMAGE_CONTENT_TYPES = Set.of(
-		"image/jpeg", "image/png", "image/webp", "image/avif"
-	);
-
 	private final MemberRepository memberRepository;
 	private final PromotionRepository promotionRepository;
 	private final PerformanceSummaryReadPort performanceSummaryReadPort;
@@ -79,10 +74,7 @@ public class AdminPromotionCommandService {
 	private void validateCarouselImageObject(String imageUrl) {
 		String imageKey = ImageKeyExtractor.extract(imageUrl);
 		ImageObjectMetadata metadata = fileStoragePort.findCarouselImageObjectMetadata(imageKey);
-		if (metadata == null
-			|| metadata.getContentLength() <= 0
-			|| metadata.getContentLength() > MAX_CAROUSEL_IMAGE_SIZE_BYTES
-			|| !ALLOWED_CAROUSEL_IMAGE_CONTENT_TYPES.contains(metadata.getContentType())) {
+		if (metadata == null) {
 			throw new AdminApplicationException(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD);
 		}
 	}

--- a/admin/src/main/java/com/beat/admin/promotion/application/command/AdminPromotionCommandService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/command/AdminPromotionCommandService.java
@@ -73,7 +73,7 @@ public class AdminPromotionCommandService {
 
 	private void validateCarouselImageObject(String imageUrl) {
 		String imageKey = ImageKeyExtractor.extract(imageUrl);
-		ImageObjectMetadata metadata = fileStoragePort.findCarouselImageObjectMetadata(imageKey);
+		ImageObjectMetadata metadata = fileStoragePort.findImageObjectMetadata(imageKey);
 		if (metadata == null) {
 			throw new AdminApplicationException(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD);
 		}

--- a/admin/src/main/java/com/beat/admin/promotion/application/command/AdminPromotionCommandService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/command/AdminPromotionCommandService.java
@@ -18,6 +18,8 @@ import com.beat.admin.promotion.application.result.AdminPromotionResults.AdminPr
 import com.beat.admin.promotion.exception.PromotionApplicationErrorCode;
 import com.beat.contracts.cdn.ImageCachePort;
 import com.beat.contracts.performance.PerformanceSummaryReadPort;
+import com.beat.contracts.storage.FileStoragePort;
+import com.beat.contracts.storage.ImageObjectMetadata;
 import com.beat.domain.member.repository.MemberRepository;
 import com.beat.domain.promotion.model.CarouselNumber;
 import com.beat.domain.promotion.model.Promotion;
@@ -35,11 +37,16 @@ public class AdminPromotionCommandService {
 		Promotion::getCarouselNumber,
 		Comparator.comparingInt(Enum::ordinal)
 	);
+	private static final long MAX_CAROUSEL_IMAGE_SIZE_BYTES = 10L * 1024 * 1024;
+	private static final Set<String> ALLOWED_CAROUSEL_IMAGE_CONTENT_TYPES = Set.of(
+		"image/jpeg", "image/png", "image/webp", "image/avif"
+	);
 
 	private final MemberRepository memberRepository;
 	private final PromotionRepository promotionRepository;
 	private final PerformanceSummaryReadPort performanceSummaryReadPort;
 	private final ImageCachePort imageCachePort;
+	private final FileStoragePort fileStoragePort;
 	private final PromotionCarouselDomainService promotionCarouselDomainService;
 
 	@Transactional
@@ -49,6 +56,7 @@ public class AdminPromotionCommandService {
 
 		ClassifiedCarouselPromotions classifiedPromotions = classifyCarouselPromotions(command);
 		validateCarouselAssignments(classifiedPromotions);
+		validateCarouselImageObjects(classifiedPromotions);
 
 		List<Promotion> allExistingPromotions = promotionRepository.findAll();
 		List<Long> deletePromotionIds = extractDeletePromotionIds(allExistingPromotions,
@@ -57,6 +65,26 @@ public class AdminPromotionCommandService {
 			classifiedPromotions.generateRequests(), deletePromotionIds);
 
 		return toPromotionResults(changedPromotions);
+	}
+
+	private void validateCarouselImageObjects(ClassifiedCarouselPromotions promotions) {
+		promotions.modifyRequests().stream()
+			.map(PromotionModifyCommand::newImageUrl)
+			.forEach(this::validateCarouselImageObject);
+		promotions.generateRequests().stream()
+			.map(PromotionGenerateCommand::newImageUrl)
+			.forEach(this::validateCarouselImageObject);
+	}
+
+	private void validateCarouselImageObject(String imageUrl) {
+		String imageKey = ImageKeyExtractor.extract(imageUrl);
+		ImageObjectMetadata metadata = fileStoragePort.findCarouselImageObjectMetadata(imageKey);
+		if (metadata == null
+			|| metadata.getContentLength() <= 0
+			|| metadata.getContentLength() > MAX_CAROUSEL_IMAGE_SIZE_BYTES
+			|| !ALLOWED_CAROUSEL_IMAGE_CONTENT_TYPES.contains(metadata.getContentType())) {
+			throw new AdminApplicationException(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD);
+		}
 	}
 
 	private AdminPromotionResults toPromotionResults(List<Promotion> domainPromotions) {

--- a/admin/src/main/java/com/beat/admin/promotion/application/query/AdminPromotionQueryService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/query/AdminPromotionQueryService.java
@@ -38,7 +38,7 @@ public class AdminPromotionQueryService {
 		List<String> carouselImages) {
 		validateMemberExists(memberId);
 		return new CarouselPresignedUrlsResult(
-			fileStoragePort.issueAllPresignedUrlsForCarousel(carouselImages).getCarouselPresignedUrls());
+			fileStoragePort.issueAllPresignedUrlsForCarousel(carouselImages).getCarouselPresignedUploads());
 	}
 
 	public BannerPresignedUrlResult issuePresignedUrlForBanner(Long memberId, String bannerImage) {

--- a/admin/src/main/java/com/beat/admin/promotion/application/query/AdminPromotionQueryService.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/query/AdminPromotionQueryService.java
@@ -43,8 +43,8 @@ public class AdminPromotionQueryService {
 
 	public BannerPresignedUrlResult issuePresignedUrlForBanner(Long memberId, String bannerImage) {
 		validateMemberExists(memberId);
-		return new BannerPresignedUrlResult(
-			fileStoragePort.issuePresignedUrlForBanner(bannerImage).getBannerPresignedUrl());
+		var upload = fileStoragePort.issuePresignedUrlForBanner(bannerImage);
+		return new BannerPresignedUrlResult(upload.getBannerPresignedUrl(), upload.getBannerImageKey());
 	}
 
 	public AdminPromotionResults findAllPromotionsSortedByCarouselNumber(Long memberId) {

--- a/admin/src/main/java/com/beat/admin/promotion/application/result/AdminPromotionPresignedUrlResults.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/result/AdminPromotionPresignedUrlResults.java
@@ -15,6 +15,6 @@ public final class AdminPromotionPresignedUrlResults {
 		}
 	}
 
-	public record BannerPresignedUrlResult(String bannerPresignedUrl) {
+	public record BannerPresignedUrlResult(String bannerPresignedUrl, String bannerImageKey) {
 	}
 }

--- a/admin/src/main/java/com/beat/admin/promotion/application/result/AdminPromotionPresignedUrlResults.java
+++ b/admin/src/main/java/com/beat/admin/promotion/application/result/AdminPromotionPresignedUrlResults.java
@@ -2,14 +2,16 @@ package com.beat.admin.promotion.application.result;
 
 import java.util.Map;
 
+import com.beat.contracts.storage.CarouselPresignedUpload;
+
 public final class AdminPromotionPresignedUrlResults {
 
 	private AdminPromotionPresignedUrlResults() {
 	}
 
-	public record CarouselPresignedUrlsResult(Map<String, String> carouselPresignedUrls) {
+	public record CarouselPresignedUrlsResult(Map<String, CarouselPresignedUpload> carouselPresignedUploads) {
 		public CarouselPresignedUrlsResult {
-			carouselPresignedUrls = Map.copyOf(carouselPresignedUrls);
+			carouselPresignedUploads = Map.copyOf(carouselPresignedUploads);
 		}
 	}
 

--- a/admin/src/main/kotlin/com/beat/admin/promotion/exception/PromotionApplicationErrorCode.kt
+++ b/admin/src/main/kotlin/com/beat/admin/promotion/exception/PromotionApplicationErrorCode.kt
@@ -9,6 +9,7 @@ enum class PromotionApplicationErrorCode(
     private val message: String,
 ) : ApplicationErrorCode {
     INVALID_REQUEST_FORMAT("ADMIN_INVALID_REQUEST_FORMAT", ApplicationErrorType.INVALID_INPUT, "잘못된 요청 형식입니다."),
+    INVALID_IMAGE_UPLOAD("ADMIN_INVALID_IMAGE_UPLOAD", ApplicationErrorType.INVALID_INPUT, "업로드된 이미지가 없거나 유효하지 않습니다."),
     MEMBER_NOT_FOUND("ADMIN_PROMOTION_MEMBER_NOT_FOUND", ApplicationErrorType.NOT_FOUND, "회원이 없습니다"),
     PERFORMANCE_NOT_FOUND("ADMIN_PERFORMANCE_NOT_FOUND", ApplicationErrorType.NOT_FOUND, "해당 공연 정보를 찾을 수 없습니다."),
     PROMOTION_NOT_FOUND("ADMIN_PROMOTION_NOT_FOUND", ApplicationErrorType.NOT_FOUND, "해당 홍보 정보를 찾을 수 없습니다.")

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
@@ -192,7 +192,7 @@ class AdminPromotionCommandServiceTest {
 	void processAllPromotionsRejectsUnsupportedImageMetadataBeforeMutation() {
 		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
 		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/invalid-image"))
-			.thenReturn(new ImageObjectMetadata("application/pdf", 1024L));
+			.thenReturn(ImageObjectMetadata.of("application/pdf", 1024L));
 
 		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
 			PromotionGenerateCommand.of("ONE", "prod/carousel/invalid-image", false, "created-url", null)
@@ -209,7 +209,7 @@ class AdminPromotionCommandServiceTest {
 	void processAllPromotionsRejectsOversizedImageBeforeMutation() {
 		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
 		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/oversized-image"))
-			.thenReturn(new ImageObjectMetadata("image/png", 11L * 1024 * 1024));
+			.thenReturn(ImageObjectMetadata.of("image/png", 11L * 1024 * 1024));
 
 		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
 			PromotionGenerateCommand.of("ONE", "prod/carousel/oversized-image", false, "created-url", null)
@@ -223,7 +223,7 @@ class AdminPromotionCommandServiceTest {
 	}
 
 	private static ImageObjectMetadata validImage() {
-		return new ImageObjectMetadata("image/png", 1024L);
+		return ImageObjectMetadata.of("image/png", 1024L);
 	}
 
 	private static Promotion promotion(Long id, String imageUrl, Long performanceId, String redirectUrl,

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
@@ -188,40 +188,6 @@ class AdminPromotionCommandServiceTest {
 		verify(promotionRepository, never()).save(any());
 	}
 
-	@Test
-	void processAllPromotionsRejectsUnsupportedImageMetadataBeforeMutation() {
-		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
-		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/invalid-image"))
-			.thenReturn(ImageObjectMetadata.of("application/pdf", 1024L));
-
-		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
-			PromotionGenerateCommand.of("ONE", "prod/carousel/invalid-image", false, "created-url", null)
-		));
-
-		AdminApplicationException exception = assertThrows(AdminApplicationException.class,
-			() -> adminPromotionCommandService.processAllPromotionsSortedByCarouselNumber(MEMBER_ID, command));
-
-		assertEquals(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD, exception.getErrorCode());
-		verify(promotionRepository, never()).findAll();
-	}
-
-	@Test
-	void processAllPromotionsRejectsOversizedImageBeforeMutation() {
-		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
-		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/oversized-image"))
-			.thenReturn(ImageObjectMetadata.of("image/png", 11L * 1024 * 1024));
-
-		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
-			PromotionGenerateCommand.of("ONE", "prod/carousel/oversized-image", false, "created-url", null)
-		));
-
-		AdminApplicationException exception = assertThrows(AdminApplicationException.class,
-			() -> adminPromotionCommandService.processAllPromotionsSortedByCarouselNumber(MEMBER_ID, command));
-
-		assertEquals(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD, exception.getErrorCode());
-		verify(promotionRepository, never()).findAll();
-	}
-
 	private static ImageObjectMetadata validImage() {
 		return ImageObjectMetadata.of("image/png", 1024L);
 	}

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
@@ -135,9 +135,9 @@ class AdminPromotionCommandServiceTest {
 		when(promotionRepository.findAll()).thenReturn(List.of(existingPromotion, omittedPromotion));
 		when(promotionRepository.findById(1L)).thenReturn(Optional.of(existingPromotion));
 		when(performanceSummaryReadPort.findById(PERFORMANCE_ID)).thenReturn(Optional.of(performance()));
-		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/modified-image"))
+		when(fileStoragePort.findImageObjectMetadata("prod/carousel/modified-image"))
 			.thenReturn(validImage());
-		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/created-image"))
+		when(fileStoragePort.findImageObjectMetadata("prod/carousel/created-image"))
 			.thenReturn(validImage());
 		when(promotionRepository.save(any(Promotion.class))).thenAnswer(invocation -> {
 			Promotion savedPromotion = invocation.getArgument(0);
@@ -173,7 +173,7 @@ class AdminPromotionCommandServiceTest {
 	@Test
 	void processAllPromotionsRejectsMissingUploadedImageBeforeMutation() {
 		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
-		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/missing-image")).thenReturn(null);
+		when(fileStoragePort.findImageObjectMetadata("prod/carousel/missing-image")).thenReturn(null);
 
 		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
 			PromotionGenerateCommand.of("ONE", "prod/carousel/missing-image", false, "created-url", null)

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionCommandServiceTest.java
@@ -37,6 +37,8 @@ import com.beat.domain.member.repository.MemberRepository;
 import com.beat.domain.performance.model.Genre;
 import com.beat.contracts.performance.PerformanceSummaryReadPort;
 import com.beat.contracts.performance.readmodel.PerformanceSummaryReadModel;
+import com.beat.contracts.storage.FileStoragePort;
+import com.beat.contracts.storage.ImageObjectMetadata;
 import com.beat.domain.performance.vo.PerformancePeriod;
 import com.beat.domain.performance.vo.RunningTime;
 import com.beat.domain.performance.vo.TicketPrice;
@@ -54,6 +56,9 @@ class AdminPromotionCommandServiceTest {
 
 	@Mock
 	private ImageCachePort imageCachePort;
+
+	@Mock
+	private FileStoragePort fileStoragePort;
 
 	@Mock
 	private MemberRepository memberRepository;
@@ -130,6 +135,10 @@ class AdminPromotionCommandServiceTest {
 		when(promotionRepository.findAll()).thenReturn(List.of(existingPromotion, omittedPromotion));
 		when(promotionRepository.findById(1L)).thenReturn(Optional.of(existingPromotion));
 		when(performanceSummaryReadPort.findById(PERFORMANCE_ID)).thenReturn(Optional.of(performance()));
+		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/modified-image"))
+			.thenReturn(validImage());
+		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/created-image"))
+			.thenReturn(validImage());
 		when(promotionRepository.save(any(Promotion.class))).thenAnswer(invocation -> {
 			Promotion savedPromotion = invocation.getArgument(0);
 			if (savedPromotion.getId() == null) {
@@ -159,6 +168,62 @@ class AdminPromotionCommandServiceTest {
 		assertEquals(1L, response.promotionResults().get(1).promotionId());
 		assertEquals("prod/carousel/modified-image", response.promotionResults().get(1).newImageUrl());
 		assertEquals("THREE", response.promotionResults().get(1).carouselNumber());
+	}
+
+	@Test
+	void processAllPromotionsRejectsMissingUploadedImageBeforeMutation() {
+		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
+		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/missing-image")).thenReturn(null);
+
+		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
+			PromotionGenerateCommand.of("ONE", "prod/carousel/missing-image", false, "created-url", null)
+		));
+
+		AdminApplicationException exception = assertThrows(AdminApplicationException.class,
+			() -> adminPromotionCommandService.processAllPromotionsSortedByCarouselNumber(MEMBER_ID, command));
+
+		assertEquals(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD, exception.getErrorCode());
+		verify(promotionRepository, never()).findAll();
+		verify(promotionRepository, never()).deleteByPromotionIds(any());
+		verify(promotionRepository, never()).save(any());
+	}
+
+	@Test
+	void processAllPromotionsRejectsUnsupportedImageMetadataBeforeMutation() {
+		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
+		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/invalid-image"))
+			.thenReturn(new ImageObjectMetadata("application/pdf", 1024L));
+
+		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
+			PromotionGenerateCommand.of("ONE", "prod/carousel/invalid-image", false, "created-url", null)
+		));
+
+		AdminApplicationException exception = assertThrows(AdminApplicationException.class,
+			() -> adminPromotionCommandService.processAllPromotionsSortedByCarouselNumber(MEMBER_ID, command));
+
+		assertEquals(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD, exception.getErrorCode());
+		verify(promotionRepository, never()).findAll();
+	}
+
+	@Test
+	void processAllPromotionsRejectsOversizedImageBeforeMutation() {
+		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
+		when(fileStoragePort.findCarouselImageObjectMetadata("prod/carousel/oversized-image"))
+			.thenReturn(new ImageObjectMetadata("image/png", 11L * 1024 * 1024));
+
+		CarouselHandleCommand command = CarouselHandleCommand.from(List.of(
+			PromotionGenerateCommand.of("ONE", "prod/carousel/oversized-image", false, "created-url", null)
+		));
+
+		AdminApplicationException exception = assertThrows(AdminApplicationException.class,
+			() -> adminPromotionCommandService.processAllPromotionsSortedByCarouselNumber(MEMBER_ID, command));
+
+		assertEquals(PromotionApplicationErrorCode.INVALID_IMAGE_UPLOAD, exception.getErrorCode());
+		verify(promotionRepository, never()).findAll();
+	}
+
+	private static ImageObjectMetadata validImage() {
+		return new ImageObjectMetadata("image/png", 1024L);
 	}
 
 	private static Promotion promotion(Long id, String imageUrl, Long performanceId, String redirectUrl,

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionQueryServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionQueryServiceTest.java
@@ -72,7 +72,7 @@ class AdminPromotionQueryServiceTest {
 		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
 		when(fileStoragePort.issueAllPresignedUrlsForCarousel(List.of("carousel.png")))
 			.thenReturn(new CarouselPresignedUrls(Map.of("carousel.png",
-				new CarouselPresignedUpload("carousel-upload-url", "dev/carousel/carousel.png"))));
+				CarouselPresignedUpload.of("carousel-upload-url", "dev/carousel/carousel.png"))));
 		when(fileStoragePort.issuePresignedUrlForBanner("banner.png"))
 			.thenReturn(new BannerPresignedUrl("banner-url"));
 
@@ -82,7 +82,7 @@ class AdminPromotionQueryServiceTest {
 			adminPromotionQueryService.issuePresignedUrlForBanner(MEMBER_ID, "banner.png");
 
 		assertEquals(Map.of("carousel.png",
-			new CarouselPresignedUpload("carousel-upload-url", "dev/carousel/carousel.png")),
+			CarouselPresignedUpload.of("carousel-upload-url", "dev/carousel/carousel.png")),
 			carouselResponse.carouselPresignedUploads());
 		assertEquals("banner-url", bannerResponse.bannerPresignedUrl());
 		verify(fileStoragePort).issueAllPresignedUrlsForCarousel(List.of("carousel.png"));

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionQueryServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionQueryServiceTest.java
@@ -74,7 +74,7 @@ class AdminPromotionQueryServiceTest {
 			.thenReturn(new CarouselPresignedUrls(Map.of("carousel.png",
 				CarouselPresignedUpload.of("carousel-upload-url", "dev/carousel/carousel.png"))));
 		when(fileStoragePort.issuePresignedUrlForBanner("banner.png"))
-			.thenReturn(new BannerPresignedUrl("banner-url"));
+			.thenReturn(new BannerPresignedUrl("banner-url", "prod/banner/banner.png"));
 
 		CarouselPresignedUrlsResult carouselResponse =
 			adminPromotionQueryService.issueAllPresignedUrlsForCarousel(MEMBER_ID, List.of("carousel.png"));
@@ -85,6 +85,7 @@ class AdminPromotionQueryServiceTest {
 			CarouselPresignedUpload.of("carousel-upload-url", "dev/carousel/carousel.png")),
 			carouselResponse.carouselPresignedUploads());
 		assertEquals("banner-url", bannerResponse.bannerPresignedUrl());
+		assertEquals("prod/banner/banner.png", bannerResponse.bannerImageKey());
 		verify(fileStoragePort).issueAllPresignedUrlsForCarousel(List.of("carousel.png"));
 		verify(fileStoragePort).issuePresignedUrlForBanner("banner.png");
 	}

--- a/admin/src/test/java/com/beat/admin/application/AdminPromotionQueryServiceTest.java
+++ b/admin/src/test/java/com/beat/admin/application/AdminPromotionQueryServiceTest.java
@@ -19,6 +19,7 @@ import com.beat.admin.promotion.application.result.AdminPromotionPresignedUrlRes
 import com.beat.admin.promotion.application.result.AdminPromotionResults;
 import com.beat.admin.promotion.application.query.AdminPromotionQueryService;
 import com.beat.contracts.storage.BannerPresignedUrl;
+import com.beat.contracts.storage.CarouselPresignedUpload;
 import com.beat.contracts.storage.CarouselPresignedUrls;
 import com.beat.contracts.storage.FileStoragePort;
 import com.beat.domain.member.model.Member;
@@ -70,7 +71,8 @@ class AdminPromotionQueryServiceTest {
 	void presignedUrlQueriesStillValidateMemberAndDelegateToStoragePort() {
 		when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member()));
 		when(fileStoragePort.issueAllPresignedUrlsForCarousel(List.of("carousel.png")))
-			.thenReturn(new CarouselPresignedUrls(Map.of("carousel.png", "carousel-url")));
+			.thenReturn(new CarouselPresignedUrls(Map.of("carousel.png",
+				new CarouselPresignedUpload("carousel-upload-url", "dev/carousel/carousel.png"))));
 		when(fileStoragePort.issuePresignedUrlForBanner("banner.png"))
 			.thenReturn(new BannerPresignedUrl("banner-url"));
 
@@ -79,7 +81,9 @@ class AdminPromotionQueryServiceTest {
 		BannerPresignedUrlResult bannerResponse =
 			adminPromotionQueryService.issuePresignedUrlForBanner(MEMBER_ID, "banner.png");
 
-		assertEquals(Map.of("carousel.png", "carousel-url"), carouselResponse.carouselPresignedUrls());
+		assertEquals(Map.of("carousel.png",
+			new CarouselPresignedUpload("carousel-upload-url", "dev/carousel/carousel.png")),
+			carouselResponse.carouselPresignedUploads());
 		assertEquals("banner-url", bannerResponse.bannerPresignedUrl());
 		verify(fileStoragePort).issueAllPresignedUrlsForCarousel(List.of("carousel.png"));
 		verify(fileStoragePort).issuePresignedUrlForBanner("banner.png");

--- a/admin/src/test/java/com/beat/admin/promotion/api/response/CarouselPresignedUrlFindAllResponseTest.java
+++ b/admin/src/test/java/com/beat/admin/promotion/api/response/CarouselPresignedUrlFindAllResponseTest.java
@@ -1,0 +1,25 @@
+package com.beat.admin.promotion.api.response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.beat.admin.promotion.application.result.AdminPromotionPresignedUrlResults.CarouselPresignedUrlsResult;
+import com.beat.contracts.storage.CarouselPresignedUpload;
+
+class CarouselPresignedUrlFindAllResponseTest {
+
+	@Test
+	void responsePreservesLegacyUrlsAndAddsExplicitUploadMetadata() {
+		CarouselPresignedUrlFindAllResponse response = CarouselPresignedUrlFindAllResponse.from(
+			new CarouselPresignedUrlsResult(Map.of("carousel.png",
+				new CarouselPresignedUpload("signed-upload-url", "dev/carousel/carousel.png")))
+		);
+
+		assertEquals(Map.of("carousel.png", "signed-upload-url"), response.carouselPresignedUrls());
+		assertEquals("signed-upload-url", response.carouselPresignedUploads().get("carousel.png").uploadUrl());
+		assertEquals("dev/carousel/carousel.png", response.carouselPresignedUploads().get("carousel.png").imageKey());
+	}
+}

--- a/admin/src/test/java/com/beat/admin/promotion/api/response/CarouselPresignedUrlFindAllResponseTest.java
+++ b/admin/src/test/java/com/beat/admin/promotion/api/response/CarouselPresignedUrlFindAllResponseTest.java
@@ -15,7 +15,7 @@ class CarouselPresignedUrlFindAllResponseTest {
 	void responsePreservesLegacyUrlsAndAddsExplicitUploadMetadata() {
 		CarouselPresignedUrlFindAllResponse response = CarouselPresignedUrlFindAllResponse.from(
 			new CarouselPresignedUrlsResult(Map.of("carousel.png",
-				new CarouselPresignedUpload("signed-upload-url", "dev/carousel/carousel.png")))
+				CarouselPresignedUpload.of("signed-upload-url", "dev/carousel/carousel.png")))
 		);
 
 		assertEquals(Map.of("carousel.png", "signed-upload-url"), response.carouselPresignedUrls());

--- a/admin/src/test/java/com/beat/admin/promotion/facade/AdminPromotionFacadeTest.java
+++ b/admin/src/test/java/com/beat/admin/promotion/facade/AdminPromotionFacadeTest.java
@@ -28,7 +28,7 @@ class AdminPromotionFacadeTest {
 		when(queryService.issueAllPresignedUrlsForCarousel(1L, List.of("carousel.png")))
 			.thenReturn(new CarouselPresignedUrlsResult(Map.of()));
 		when(queryService.issuePresignedUrlForBanner(1L, "banner.png"))
-			.thenReturn(new BannerPresignedUrlResult("banner-url"));
+			.thenReturn(new BannerPresignedUrlResult("banner-url", "prod/banner/banner.png"));
 		when(queryService.findAllPromotionsSortedByCarouselNumber(1L))
 			.thenReturn(new AdminPromotionResults(List.of()));
 		when(commandService.processAllPromotionsSortedByCarouselNumber(1L, CarouselHandleCommand.from(List.of())))

--- a/apis/src/main/kotlin/com/beat/apis/file/api/response/PerformanceMakerPresignedUrlFindAllResponse.kt
+++ b/apis/src/main/kotlin/com/beat/apis/file/api/response/PerformanceMakerPresignedUrlFindAllResponse.kt
@@ -1,13 +1,20 @@
 package com.beat.apis.file.api.response
 
+import com.beat.contracts.storage.ImagePresignedUpload
+
 @ConsistentCopyVisibility
 data class PerformanceMakerPresignedUrlFindAllResponse private constructor(
     val performanceMakerPresignedUrls: Map<String, Map<String, String>>,
+    val performanceMakerPresignedUploads: Map<String, Map<String, ImagePresignedUpload>>,
 ) {
     companion object {
         fun from(
-            performanceMakerPresignedUrls: Map<String, Map<String, String>>,
-        ): PerformanceMakerPresignedUrlFindAllResponse =
-            PerformanceMakerPresignedUrlFindAllResponse(performanceMakerPresignedUrls)
+            performanceMakerPresignedUploads: Map<String, Map<String, ImagePresignedUpload>>,
+        ): PerformanceMakerPresignedUrlFindAllResponse {
+            val legacyUrls = performanceMakerPresignedUploads.mapValues { (_, uploads) ->
+                uploads.mapValues { (_, upload) -> upload.uploadUrl }
+            }
+            return PerformanceMakerPresignedUrlFindAllResponse(legacyUrls, performanceMakerPresignedUploads)
+        }
     }
 }

--- a/apis/src/main/kotlin/com/beat/apis/file/facade/FileFacade.kt
+++ b/apis/src/main/kotlin/com/beat/apis/file/facade/FileFacade.kt
@@ -14,11 +14,11 @@ class FileFacade(
         staffImages: List<String>?,
         performanceImages: List<String>?,
     ): PerformanceMakerPresignedUrlFindAllResponse = PerformanceMakerPresignedUrlFindAllResponse.from(
-        performanceMakerPresignedUrls = fileCommandService.issueAllPresignedUrlsForPerformanceMaker(
+        performanceMakerPresignedUploads = fileCommandService.issueAllPresignedUrlsForPerformanceMaker(
             posterImage,
             castImages,
             staffImages,
             performanceImages,
-        ).performanceMakerPresignedUrls,
+        ).performanceMakerPresignedUploads,
     )
 }

--- a/apis/src/main/kotlin/com/beat/apis/performance/application/PerformanceImageKey.kt
+++ b/apis/src/main/kotlin/com/beat/apis/performance/application/PerformanceImageKey.kt
@@ -2,6 +2,7 @@ package com.beat.apis.performance.application
 
 import com.beat.apis.exception.ApiApplicationException
 import com.beat.apis.performance.exception.PerformanceApplicationErrorCode
+import com.beat.contracts.storage.FileStoragePort
 import com.beat.global.support.utils.ImageKeyExtractor
 
 internal fun extractPerformanceImageKey(value: String?): String? =
@@ -17,3 +18,19 @@ internal fun extractPerformanceImageKey(value: String?): String? =
 internal fun extractRequiredPerformanceImageKey(value: String?): String =
     extractPerformanceImageKey(value)
         ?: throw ApiApplicationException(PerformanceApplicationErrorCode.INVALID_IMAGE_KEY)
+
+internal fun validateStoredPerformanceImage(
+    fileStoragePort: FileStoragePort,
+    value: String?,
+    category: String,
+    required: Boolean = true,
+): String {
+    if (!required && value.isNullOrBlank()) return ""
+    val imageKey = extractRequiredPerformanceImageKey(value)
+    if (imageKey.split("/", limit = 3).getOrNull(1) != category ||
+        fileStoragePort.findImageObjectMetadata(imageKey) == null
+    ) {
+        throw ApiApplicationException(PerformanceApplicationErrorCode.INVALID_IMAGE_KEY)
+    }
+    return imageKey
+}

--- a/apis/src/main/kotlin/com/beat/apis/performance/application/command/PerformanceCreateCommandService.kt
+++ b/apis/src/main/kotlin/com/beat/apis/performance/application/command/PerformanceCreateCommandService.kt
@@ -8,10 +8,11 @@ import com.beat.apis.performance.application.result.PerformanceMutationResult
 import com.beat.apis.performance.application.result.ScheduleResult
 import com.beat.apis.performance.application.result.StaffResult
 import com.beat.apis.performance.application.formatPerformancePeriod
-import com.beat.apis.performance.application.extractRequiredPerformanceImageKey
+import com.beat.apis.performance.application.validateStoredPerformanceImage
 import com.beat.apis.performance.application.event.PerformancePosterChangedEvent
 import com.beat.apis.performance.exception.PerformanceApplicationErrorCode
 import com.beat.apis.schedule.application.calculateDueDate
+import com.beat.contracts.storage.FileStoragePort
 import com.beat.domain.performance.model.Cast
 import com.beat.domain.member.repository.MemberRepository
 import com.beat.domain.performance.model.Performance
@@ -43,6 +44,7 @@ class PerformanceCreateCommandService(
     private val eventPublisher: ApplicationEventPublisher,
     private val scheduleSequenceDomainService: ScheduleSequenceDomainService,
     private val clock: Clock,
+    private val fileStoragePort: FileStoragePort,
 ) {
     @Transactional
     fun createPerformance(memberId: Long, command: PerformanceCreateCommand): PerformanceMutationResult {
@@ -56,18 +58,18 @@ class PerformanceCreateCommandService(
             Cast.create(
                 castCommand.name,
                 castCommand.role,
-                extractRequiredPerformanceImageKey(castCommand.photo),
+                validateStoredPerformanceImage(fileStoragePort, castCommand.photo, "cast", required = false),
             )
         }
         val staffs = command.staffs.map { staffCommand ->
             Staff.create(
                 staffCommand.name,
                 staffCommand.role,
-                extractRequiredPerformanceImageKey(staffCommand.photo),
+                validateStoredPerformanceImage(fileStoragePort, staffCommand.photo, "staff", required = false),
             )
         }
         val images = command.images.map { imageCommand ->
-            PerformanceImage.create(extractRequiredPerformanceImageKey(imageCommand.image))
+            PerformanceImage.create(validateStoredPerformanceImage(fileStoragePort, imageCommand.image, "performance"))
         }
         val performance = Performance.create(
             command.performanceTitle,
@@ -80,7 +82,7 @@ class PerformanceCreateCommandService(
                 command.accountNumber,
                 command.accountHolder,
             ),
-            extractRequiredPerformanceImageKey(command.posterImage),
+            validateStoredPerformanceImage(fileStoragePort, command.posterImage, "poster"),
             command.performanceTeamName,
             command.performanceVenue,
             command.roadAddressName,

--- a/apis/src/main/kotlin/com/beat/apis/performance/application/command/PerformanceModifyCommandService.kt
+++ b/apis/src/main/kotlin/com/beat/apis/performance/application/command/PerformanceModifyCommandService.kt
@@ -8,13 +8,14 @@ import com.beat.apis.performance.application.result.PerformanceMutationResult
 import com.beat.apis.performance.application.result.ScheduleResult
 import com.beat.apis.performance.application.result.StaffResult
 import com.beat.apis.performance.application.formatPerformancePeriod
-import com.beat.apis.performance.application.extractRequiredPerformanceImageKey
+import com.beat.apis.performance.application.validateStoredPerformanceImage
 import com.beat.apis.performance.application.event.PerformancePosterChangedEvent
 import com.beat.apis.performance.exception.PerformanceApplicationErrorCode
 import com.beat.apis.performance.exception.CastApplicationErrorCode
 import com.beat.apis.performance.exception.PerformanceImageApplicationErrorCode
 import com.beat.apis.performance.exception.StaffApplicationErrorCode
 import com.beat.contracts.performance.PerformanceContentOwnershipReadPort
+import com.beat.contracts.storage.FileStoragePort
 import com.beat.domain.member.model.Member
 import com.beat.domain.member.repository.MemberRepository
 import com.beat.domain.performance.model.Cast
@@ -39,6 +40,7 @@ class PerformanceModifyCommandService internal constructor(
     private val eventPublisher: ApplicationEventPublisher,
     private val scheduleSynchronizer: ScheduleSynchronizer,
     private val contentOwnershipReadPort: PerformanceContentOwnershipReadPort,
+    private val fileStoragePort: FileStoragePort,
 ) {
 
     @Transactional
@@ -115,7 +117,7 @@ class PerformanceModifyCommandService internal constructor(
                 command.accountNumber,
                 command.accountHolder,
             ),
-            extractRequiredPerformanceImageKey(command.posterImage),
+            validateStoredPerformanceImage(fileStoragePort, command.posterImage, "poster"),
             command.performanceTeamName,
             command.performanceVenue,
             command.roadAddressName,
@@ -137,14 +139,14 @@ class PerformanceModifyCommandService internal constructor(
                 Cast.create(
                     command.name,
                     command.role,
-                    extractRequiredPerformanceImageKey(command.photo),
+                    validateStoredPerformanceImage(fileStoragePort, command.photo, "cast", required = false),
                 )
             } else {
                 val cast = existing[castId] ?: throwInvalidCast(castId)
                 cast.update(
                     command.name,
                     command.role,
-                    extractRequiredPerformanceImageKey(command.photo),
+                    validateStoredPerformanceImage(fileStoragePort, command.photo, "cast", required = false),
                 )
             }
         }
@@ -158,14 +160,14 @@ class PerformanceModifyCommandService internal constructor(
                 Staff.create(
                     command.name,
                     command.role,
-                    extractRequiredPerformanceImageKey(command.photo),
+                    validateStoredPerformanceImage(fileStoragePort, command.photo, "staff", required = false),
                 )
             } else {
                 val staff = existing[staffId] ?: throwInvalidStaff(staffId)
                 staff.update(
                     command.name,
                     command.role,
-                    extractRequiredPerformanceImageKey(command.photo),
+                    validateStoredPerformanceImage(fileStoragePort, command.photo, "staff", required = false),
                 )
             }
         }
@@ -178,7 +180,7 @@ class PerformanceModifyCommandService internal constructor(
         val existing = performance.getImages().associateBy { it.getId() }
         return commands.map { command ->
             val imageId = command.id
-            val imageKey = extractRequiredPerformanceImageKey(command.image)
+            val imageKey = validateStoredPerformanceImage(fileStoragePort, command.image, "performance")
             if (imageId == null) {
                 PerformanceImage.create(imageKey)
             } else {

--- a/apis/src/test/java/com/beat/apis/file/application/FileCommandServiceTest.java
+++ b/apis/src/test/java/com/beat/apis/file/application/FileCommandServiceTest.java
@@ -20,6 +20,7 @@ import com.beat.apis.file.application.command.FileCommandService;
 import com.beat.apis.file.exception.FileApplicationErrorCode;
 import com.beat.contracts.storage.FileStoragePort;
 import com.beat.contracts.storage.PerformancePresignedUrls;
+import com.beat.contracts.storage.ImagePresignedUpload;
 
 @ExtendWith(MockitoExtension.class)
 class FileCommandServiceTest {
@@ -37,7 +38,8 @@ class FileCommandServiceTest {
 	@Test
 	void issueAllPresignedUrlsNormalizesNullableListsBeforeCallingStoragePort() {
 		PerformancePresignedUrls presignedUrls = new PerformancePresignedUrls(
-			Map.of("poster", Map.of("poster.png", "https://example.com/poster.png"))
+			Map.of("poster", Map.of("poster.png",
+				ImagePresignedUpload.of("https://example.com/poster.png", "dev/poster/poster.png")))
 		);
 		when(fileStoragePort.issueAllPresignedUrlsForPerformanceMaker("poster.png", List.of(), List.of(), List.of()))
 			.thenReturn(presignedUrls);

--- a/apis/src/test/kotlin/com/beat/apis/performance/application/PerformanceImageKeyTest.kt
+++ b/apis/src/test/kotlin/com/beat/apis/performance/application/PerformanceImageKeyTest.kt
@@ -1,0 +1,58 @@
+package com.beat.apis.performance.application
+
+import com.beat.apis.exception.ApiApplicationException
+import com.beat.contracts.storage.FileStoragePort
+import com.beat.contracts.storage.ImageObjectMetadata
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+
+class PerformanceImageKeyTest {
+
+    private val fileStoragePort = mock(FileStoragePort::class.java)
+
+    @Test
+    fun `validates an uploaded image in the expected category`() {
+        val imageKey = "dev/poster/poster.png"
+        `when`(fileStoragePort.findImageObjectMetadata(imageKey))
+            .thenReturn(ImageObjectMetadata.of("image/png", 1024L))
+
+        val result = validateStoredPerformanceImage(fileStoragePort, imageKey, "poster")
+
+        assertEquals(imageKey, result)
+    }
+
+    @Test
+    fun `rejects an uploaded image from another category`() {
+        assertThrows(ApiApplicationException::class.java) {
+            validateStoredPerformanceImage(fileStoragePort, "dev/staff/staff.png", "cast")
+        }
+        verifyNoInteractions(fileStoragePort)
+    }
+
+    @Test
+    fun `rejects an image missing from object storage`() {
+        val imageKey = "dev/performance/detail.png"
+        `when`(fileStoragePort.findImageObjectMetadata(imageKey)).thenReturn(null)
+
+        assertThrows(ApiApplicationException::class.java) {
+            validateStoredPerformanceImage(fileStoragePort, imageKey, "performance")
+        }
+    }
+
+    @Test
+    fun `allows an empty optional image without object storage access`() {
+        val result = validateStoredPerformanceImage(
+            fileStoragePort = fileStoragePort,
+            value = "",
+            category = "staff",
+            required = false,
+        )
+
+        assertEquals("", result)
+        verifyNoInteractions(fileStoragePort)
+    }
+}

--- a/infra/src/main/java/com/beat/infra/external/storage/s3/S3FileStorageAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/storage/s3/S3FileStorageAdapter.java
@@ -86,7 +86,7 @@ public class S3FileStorageAdapter implements FileStoragePort {
 			URL carouselPresignedUrl = amazonS3.generatePresignedUrl(
 				buildPresignedUrlRequest(bucket, carouselFilePath));
 			carouselPresignedUploads.put(carouselImage,
-				new CarouselPresignedUpload(carouselPresignedUrl.toString(), carouselFilePath));
+				CarouselPresignedUpload.of(carouselPresignedUrl.toString(), carouselFilePath));
 		}
 
 		return new CarouselPresignedUrls(carouselPresignedUploads);
@@ -99,7 +99,7 @@ public class S3FileStorageAdapter implements FileStoragePort {
 		}
 		try {
 			ObjectMetadata objectMetadata = amazonS3.getObjectMetadata(bucket, imageKey);
-			return new ImageObjectMetadata(objectMetadata.getContentType(), objectMetadata.getContentLength());
+			return ImageObjectMetadata.of(objectMetadata.getContentType(), objectMetadata.getContentLength());
 		} catch (AmazonS3Exception exception) {
 			if (exception.getStatusCode() == 404) {
 				return null;

--- a/infra/src/main/java/com/beat/infra/external/storage/s3/S3FileStorageAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/storage/s3/S3FileStorageAdapter.java
@@ -10,6 +10,7 @@ import com.beat.contracts.storage.CarouselPresignedUpload;
 import com.beat.contracts.storage.CarouselPresignedUrls;
 import com.beat.contracts.storage.FileStoragePort;
 import com.beat.contracts.storage.ImageObjectMetadata;
+import com.beat.contracts.storage.ImagePresignedUpload;
 import com.beat.contracts.storage.PerformancePresignedUrls;
 import java.net.URL;
 import java.util.Date;
@@ -41,40 +42,41 @@ public class S3FileStorageAdapter implements FileStoragePort {
 		List<String> staffImages,
 		List<String> performanceImages
 	) {
-		Map<String, Map<String, String>> performanceMakerPresignedUrls = new HashMap<>();
+		Map<String, Map<String, ImagePresignedUpload>> performanceMakerPresignedUploads = new HashMap<>();
 
-		Map<String, String> posterUrl = new HashMap<>();
+		Map<String, ImagePresignedUpload> posterUrl = new HashMap<>();
 		String posterFilePath = generatePath("poster", posterImage);
 		URL posterPresignedUrl = amazonS3.generatePresignedUrl(buildPresignedUrlRequest(bucket, posterFilePath));
-		posterUrl.put(posterImage, posterPresignedUrl.toString());
-		performanceMakerPresignedUrls.put("poster", posterUrl);
+		posterUrl.put(posterImage, ImagePresignedUpload.of(posterPresignedUrl.toString(), posterFilePath));
+		performanceMakerPresignedUploads.put("poster", posterUrl);
 
-		Map<String, String> castUrls = new HashMap<>();
+		Map<String, ImagePresignedUpload> castUrls = new HashMap<>();
 		for (String castImage : castImages) {
 			String castFilePath = generatePath("cast", castImage);
 			URL castPresignedUrl = amazonS3.generatePresignedUrl(buildPresignedUrlRequest(bucket, castFilePath));
-			castUrls.put(castImage, castPresignedUrl.toString());
+			castUrls.put(castImage, ImagePresignedUpload.of(castPresignedUrl.toString(), castFilePath));
 		}
-		performanceMakerPresignedUrls.put("cast", castUrls);
+		performanceMakerPresignedUploads.put("cast", castUrls);
 
-		Map<String, String> staffUrls = new HashMap<>();
+		Map<String, ImagePresignedUpload> staffUrls = new HashMap<>();
 		for (String staffImage : staffImages) {
 			String staffFilePath = generatePath("staff", staffImage);
 			URL staffPresignedUrl = amazonS3.generatePresignedUrl(buildPresignedUrlRequest(bucket, staffFilePath));
-			staffUrls.put(staffImage, staffPresignedUrl.toString());
+			staffUrls.put(staffImage, ImagePresignedUpload.of(staffPresignedUrl.toString(), staffFilePath));
 		}
-		performanceMakerPresignedUrls.put("staff", staffUrls);
+		performanceMakerPresignedUploads.put("staff", staffUrls);
 
-		Map<String, String> performanceImageUrls = new HashMap<>();
+		Map<String, ImagePresignedUpload> performanceImageUrls = new HashMap<>();
 		for (String performanceImage : performanceImages) {
 			String performanceImageFilePath = generatePath("performance", performanceImage);
 			URL performanceImagePresignedUrl = amazonS3.generatePresignedUrl(
 				buildPresignedUrlRequest(bucket, performanceImageFilePath));
-			performanceImageUrls.put(performanceImage, performanceImagePresignedUrl.toString());
+			performanceImageUrls.put(performanceImage,
+				ImagePresignedUpload.of(performanceImagePresignedUrl.toString(), performanceImageFilePath));
 		}
-		performanceMakerPresignedUrls.put("performance", performanceImageUrls);
+		performanceMakerPresignedUploads.put("performance", performanceImageUrls);
 
-		return new PerformancePresignedUrls(performanceMakerPresignedUrls);
+		return new PerformancePresignedUrls(performanceMakerPresignedUploads);
 	}
 
 	@Override
@@ -93,8 +95,8 @@ public class S3FileStorageAdapter implements FileStoragePort {
 	}
 
 	@Override
-	public ImageObjectMetadata findCarouselImageObjectMetadata(String imageKey) {
-		if (!imageKey.startsWith(carouselKeyPrefix())) {
+	public ImageObjectMetadata findImageObjectMetadata(String imageKey) {
+		if (!imageKey.startsWith(imageKeyPrefix())) {
 			return null;
 		}
 		try {
@@ -112,7 +114,7 @@ public class S3FileStorageAdapter implements FileStoragePort {
 	public BannerPresignedUrl issuePresignedUrlForBanner(String bannerImage) {
 		String bannerFilePath = generatePath("banner", bannerImage);
 		URL bannerPresignedUrl = amazonS3.generatePresignedUrl(buildPresignedUrlRequest(bucket, bannerFilePath));
-		return new BannerPresignedUrl(bannerPresignedUrl.toString());
+		return new BannerPresignedUrl(bannerPresignedUrl.toString(), bannerFilePath);
 	}
 
 	private GeneratePresignedUrlRequest buildPresignedUrlRequest(String bucket, String fileName) {
@@ -144,8 +146,8 @@ public class S3FileStorageAdapter implements FileStoragePort {
 		return keyPrefix.replaceAll("^/+", "").replaceAll("/+$", "");
 	}
 
-	private String carouselKeyPrefix() {
+	private String imageKeyPrefix() {
 		String normalizedKeyPrefix = normalizeKeyPrefix();
-		return normalizedKeyPrefix.isEmpty() ? "carousel/" : normalizedKeyPrefix + "/carousel/";
+		return normalizedKeyPrefix.isEmpty() ? "" : normalizedKeyPrefix + "/";
 	}
 }

--- a/infra/src/main/java/com/beat/infra/external/storage/s3/S3FileStorageAdapter.java
+++ b/infra/src/main/java/com/beat/infra/external/storage/s3/S3FileStorageAdapter.java
@@ -3,9 +3,13 @@ package com.beat.infra.external.storage.s3;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.beat.contracts.storage.BannerPresignedUrl;
+import com.beat.contracts.storage.CarouselPresignedUpload;
 import com.beat.contracts.storage.CarouselPresignedUrls;
 import com.beat.contracts.storage.FileStoragePort;
+import com.beat.contracts.storage.ImageObjectMetadata;
 import com.beat.contracts.storage.PerformancePresignedUrls;
 import java.net.URL;
 import java.util.Date;
@@ -75,16 +79,33 @@ public class S3FileStorageAdapter implements FileStoragePort {
 
 	@Override
 	public CarouselPresignedUrls issueAllPresignedUrlsForCarousel(List<String> carouselImages) {
-		Map<String, String> carouselPresignedUrls = new HashMap<>();
+		Map<String, CarouselPresignedUpload> carouselPresignedUploads = new HashMap<>();
 
 		for (String carouselImage : carouselImages) {
 			String carouselFilePath = generatePath("carousel", carouselImage);
 			URL carouselPresignedUrl = amazonS3.generatePresignedUrl(
 				buildPresignedUrlRequest(bucket, carouselFilePath));
-			carouselPresignedUrls.put(carouselImage, carouselPresignedUrl.toString());
+			carouselPresignedUploads.put(carouselImage,
+				new CarouselPresignedUpload(carouselPresignedUrl.toString(), carouselFilePath));
 		}
 
-		return new CarouselPresignedUrls(carouselPresignedUrls);
+		return new CarouselPresignedUrls(carouselPresignedUploads);
+	}
+
+	@Override
+	public ImageObjectMetadata findCarouselImageObjectMetadata(String imageKey) {
+		if (!imageKey.startsWith(carouselKeyPrefix())) {
+			return null;
+		}
+		try {
+			ObjectMetadata objectMetadata = amazonS3.getObjectMetadata(bucket, imageKey);
+			return new ImageObjectMetadata(objectMetadata.getContentType(), objectMetadata.getContentLength());
+		} catch (AmazonS3Exception exception) {
+			if (exception.getStatusCode() == 404) {
+				return null;
+			}
+			throw exception;
+		}
 	}
 
 	@Override
@@ -121,5 +142,10 @@ public class S3FileStorageAdapter implements FileStoragePort {
 			return "";
 		}
 		return keyPrefix.replaceAll("^/+", "").replaceAll("/+$", "");
+	}
+
+	private String carouselKeyPrefix() {
+		String normalizedKeyPrefix = normalizeKeyPrefix();
+		return normalizedKeyPrefix.isEmpty() ? "carousel/" : normalizedKeyPrefix + "/carousel/";
 	}
 }

--- a/infra/src/test/java/com/beat/infra/external/storage/s3/S3FileStorageAdapterTest.java
+++ b/infra/src/test/java/com/beat/infra/external/storage/s3/S3FileStorageAdapterTest.java
@@ -29,7 +29,7 @@ class S3FileStorageAdapterTest {
 		metadata.setContentLength(1024L);
 		when(amazonS3.getObjectMetadata("bucket", "dev/carousel/image.png")).thenReturn(metadata);
 
-		ImageObjectMetadata result = adapter.findCarouselImageObjectMetadata("dev/carousel/image.png");
+		ImageObjectMetadata result = adapter.findImageObjectMetadata("dev/carousel/image.png");
 
 		assertEquals("image/png", result.getContentType());
 		assertEquals(1024L, result.getContentLength());
@@ -42,14 +42,14 @@ class S3FileStorageAdapterTest {
 		exception.setStatusCode(404);
 		when(amazonS3.getObjectMetadata("bucket", "dev/carousel/missing.png")).thenThrow(exception);
 
-		assertNull(adapter.findCarouselImageObjectMetadata("dev/carousel/missing.png"));
+		assertNull(adapter.findImageObjectMetadata("dev/carousel/missing.png"));
 	}
 
 	@Test
-	void findCarouselImageObjectMetadataRejectsOtherImageCategoriesWithoutHeadObject() {
+	void findImageObjectMetadataRejectsOtherEnvironmentsWithoutHeadObject() {
 		S3FileStorageAdapter adapter = adapter();
 
-		assertNull(adapter.findCarouselImageObjectMetadata("dev/poster/poster.png"));
+		assertNull(adapter.findImageObjectMetadata("prod/poster/poster.png"));
 
 		verifyNoInteractions(amazonS3);
 	}

--- a/infra/src/test/java/com/beat/infra/external/storage/s3/S3FileStorageAdapterTest.java
+++ b/infra/src/test/java/com/beat/infra/external/storage/s3/S3FileStorageAdapterTest.java
@@ -1,0 +1,63 @@
+package com.beat.infra.external.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.beat.contracts.storage.ImageObjectMetadata;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileStorageAdapterTest {
+
+	@Mock
+	private AmazonS3 amazonS3;
+
+	@Test
+	void findImageObjectMetadataReturnsHeadObjectMetadata() {
+		S3FileStorageAdapter adapter = adapter();
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentType("image/png");
+		metadata.setContentLength(1024L);
+		when(amazonS3.getObjectMetadata("bucket", "dev/carousel/image.png")).thenReturn(metadata);
+
+		ImageObjectMetadata result = adapter.findCarouselImageObjectMetadata("dev/carousel/image.png");
+
+		assertEquals("image/png", result.getContentType());
+		assertEquals(1024L, result.getContentLength());
+	}
+
+	@Test
+	void findImageObjectMetadataReturnsNullWhenObjectDoesNotExist() {
+		S3FileStorageAdapter adapter = adapter();
+		AmazonS3Exception exception = new AmazonS3Exception("not found");
+		exception.setStatusCode(404);
+		when(amazonS3.getObjectMetadata("bucket", "dev/carousel/missing.png")).thenThrow(exception);
+
+		assertNull(adapter.findCarouselImageObjectMetadata("dev/carousel/missing.png"));
+	}
+
+	@Test
+	void findCarouselImageObjectMetadataRejectsOtherImageCategoriesWithoutHeadObject() {
+		S3FileStorageAdapter adapter = adapter();
+
+		assertNull(adapter.findCarouselImageObjectMetadata("dev/poster/poster.png"));
+
+		verifyNoInteractions(amazonS3);
+	}
+
+	private S3FileStorageAdapter adapter() {
+		S3FileStorageAdapter adapter = new S3FileStorageAdapter(amazonS3);
+		ReflectionTestUtils.setField(adapter, "bucket", "bucket");
+		ReflectionTestUtils.setField(adapter, "keyPrefix", "dev");
+		return adapter;
+	}
+}

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/BannerPresignedUrl.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/BannerPresignedUrl.kt
@@ -2,4 +2,5 @@ package com.beat.contracts.storage
 
 data class BannerPresignedUrl(
     val bannerPresignedUrl: String,
+    val bannerImageKey: String,
 )

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/CarouselPresignedUpload.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/CarouselPresignedUpload.kt
@@ -1,6 +1,15 @@
 package com.beat.contracts.storage
 
-data class CarouselPresignedUpload(
+import kotlin.ConsistentCopyVisibility
+
+@ConsistentCopyVisibility
+data class CarouselPresignedUpload private constructor(
     val uploadUrl: String,
     val imageKey: String,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun of(uploadUrl: String, imageKey: String): CarouselPresignedUpload =
+            CarouselPresignedUpload(uploadUrl, imageKey)
+    }
+}

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/CarouselPresignedUpload.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/CarouselPresignedUpload.kt
@@ -1,0 +1,6 @@
+package com.beat.contracts.storage
+
+data class CarouselPresignedUpload(
+    val uploadUrl: String,
+    val imageKey: String,
+)

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/CarouselPresignedUrls.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/CarouselPresignedUrls.kt
@@ -1,5 +1,5 @@
 package com.beat.contracts.storage
 
 data class CarouselPresignedUrls(
-    val carouselPresignedUrls: Map<String, String>,
+    val carouselPresignedUploads: Map<String, CarouselPresignedUpload>,
 )

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/FileStoragePort.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/FileStoragePort.kt
@@ -12,7 +12,7 @@ interface FileStoragePort {
 
     fun issueAllPresignedUrlsForCarousel(carouselImages: List<String>): CarouselPresignedUrls
 
-    fun findCarouselImageObjectMetadata(imageKey: String): ImageObjectMetadata?
+    fun findImageObjectMetadata(imageKey: String): ImageObjectMetadata?
 
     fun issuePresignedUrlForBanner(bannerImage: String): BannerPresignedUrl
 }

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/FileStoragePort.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/FileStoragePort.kt
@@ -12,5 +12,7 @@ interface FileStoragePort {
 
     fun issueAllPresignedUrlsForCarousel(carouselImages: List<String>): CarouselPresignedUrls
 
+    fun findCarouselImageObjectMetadata(imageKey: String): ImageObjectMetadata?
+
     fun issuePresignedUrlForBanner(bannerImage: String): BannerPresignedUrl
 }

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/ImageObjectMetadata.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/ImageObjectMetadata.kt
@@ -1,0 +1,6 @@
+package com.beat.contracts.storage
+
+data class ImageObjectMetadata(
+    val contentType: String?,
+    val contentLength: Long,
+)

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/ImageObjectMetadata.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/ImageObjectMetadata.kt
@@ -1,6 +1,15 @@
 package com.beat.contracts.storage
 
-data class ImageObjectMetadata(
+import kotlin.ConsistentCopyVisibility
+
+@ConsistentCopyVisibility
+data class ImageObjectMetadata private constructor(
     val contentType: String?,
     val contentLength: Long,
-)
+) {
+    companion object {
+        @JvmStatic
+        fun of(contentType: String?, contentLength: Long): ImageObjectMetadata =
+            ImageObjectMetadata(contentType, contentLength)
+    }
+}

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/ImagePresignedUpload.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/ImagePresignedUpload.kt
@@ -1,0 +1,15 @@
+package com.beat.contracts.storage
+
+import kotlin.ConsistentCopyVisibility
+
+@ConsistentCopyVisibility
+data class ImagePresignedUpload private constructor(
+    val uploadUrl: String,
+    val imageKey: String,
+) {
+    companion object {
+        @JvmStatic
+        fun of(uploadUrl: String, imageKey: String): ImagePresignedUpload =
+            ImagePresignedUpload(uploadUrl, imageKey)
+    }
+}

--- a/module-contracts/src/main/kotlin/com/beat/contracts/storage/PerformancePresignedUrls.kt
+++ b/module-contracts/src/main/kotlin/com/beat/contracts/storage/PerformancePresignedUrls.kt
@@ -1,5 +1,5 @@
 package com.beat.contracts.storage
 
 data class PerformancePresignedUrls(
-    val performanceMakerPresignedUrls: Map<String, Map<String, String>>,
+    val performanceMakerPresignedUploads: Map<String, Map<String, ImagePresignedUpload>>,
 )


### PR DESCRIPTION
## 요약
- 공연 포스터·출연진·스태프·상세 이미지, 캐러셀, 배너의 presigned 응답을 `uploadUrl`과 `imageKey` 계약으로 통일했습니다.
- 공연 등록·수정과 캐러셀 저장 전에 현재 환경 원본 버킷의 객체 존재 여부를 HeadObject로 확인합니다.
- 공연 이미지는 요청 카테고리와 실제 키 카테고리도 일치해야 저장됩니다.
- 선택 항목인 출연진·스태프의 빈 이미지는 기존 계약대로 허용합니다.
- 기존 응답 필드는 동시 배포 안전성을 위해 유지하고 새 구조화 필드를 추가했습니다.

## 응답 계약
- 공연: `performanceMakerPresignedUploads.{poster|cast|staff|performance}[filename].{uploadUrl,imageKey}`
- 캐러셀: `carouselPresignedUploads[filename].{uploadUrl,imageKey}`
- 배너: `bannerPresignedUpload.{uploadUrl,imageKey}`

클라이언트는 `uploadUrl` 원문으로 PUT을 완료한 뒤 `imageKey`만 등록·수정 요청에 전달합니다.

## 검증
- `./gradlew :apis:test --tests com.beat.apis.performance.application.PerformanceImageKeyTest :admin:test --tests com.beat.admin.application.AdminPromotionQueryServiceTest --tests com.beat.admin.application.AdminPromotionCommandServiceTest :infra:test --tests com.beat.infra.external.storage.s3.S3FileStorageAdapterTest --no-daemon --console=plain --max-workers=1`
- `./gradlew :apis:compileKotlin :apis:compileTestKotlin :admin:compileJava :infra:compileJava --no-daemon --console=plain --max-workers=1`
- BEAT-Client #523과 함께 배포해야 합니다.

Closes #563
