### PR TITLE
refactor: dependency-management → Gradle native platform() 전환

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,7 +12,6 @@ group = "com.beat.buildlogic"
 val libsCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val kotlinVersion = libsCatalog.findVersion("kotlin").get().requiredVersion
 val springBootVersion = libsCatalog.findVersion("spring-boot").get().requiredVersion
-val dependencyManagementVersion = libsCatalog.findVersion("dependency-management").get().requiredVersion
 val sentryGradlePluginVersion = libsCatalog.findVersion("sentry-gradle-plugin").get().requiredVersion
 val dependencyAnalysisVersion = libsCatalog.findVersion("dependency-analysis").get().requiredVersion
 val koverVersion = libsCatalog.findVersion("kover").get().requiredVersion
@@ -45,13 +44,6 @@ dependencies {
     implementation(pluginMarker("org.jetbrains.kotlin.plugin.spring", "org.jetbrains.kotlin.plugin.spring.gradle.plugin", kotlinVersion))
     implementation(pluginMarker("org.jetbrains.kotlin.plugin.jpa", "org.jetbrains.kotlin.plugin.jpa.gradle.plugin", kotlinVersion))
     implementation(pluginMarker("org.springframework.boot", "org.springframework.boot.gradle.plugin", springBootVersion))
-    implementation(
-        pluginMarker(
-            "io.spring.dependency-management",
-            "io.spring.dependency-management.gradle.plugin",
-            dependencyManagementVersion,
-        )
-    )
     implementation(
         pluginMarker(
             "io.sentry.jvm.gradle",

--- a/build-logic/src/main/kotlin/beat.spring-boot-app.gradle.kts
+++ b/build-logic/src/main/kotlin/beat.spring-boot-app.gradle.kts
@@ -4,7 +4,6 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     id("org.springframework.boot")
-    id("io.spring.dependency-management")
     kotlin("plugin.spring")
     id("beat.kotlin-base")
     id("beat.test")
@@ -17,6 +16,7 @@ configurations.configureEach {
 }
 
 dependencies {
+    implementation(platform(libs.findLibrary("spring-boot-dependencies").get()))
     implementation(libs.findBundle("boot-app-core").get())
     implementation(libs.findLibrary("spring-boot-starter-log4j2").get())
     compileOnly(libs.findLibrary("lombok").get())

--- a/build-logic/src/main/kotlin/beat.spring-library.gradle.kts
+++ b/build-logic/src/main/kotlin/beat.spring-library.gradle.kts
@@ -1,6 +1,13 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
 plugins {
     id("beat.library")
     id("beat.test")
-    id("io.spring.dependency-management")
     kotlin("plugin.spring")
+}
+
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+dependencies {
+    implementation(platform(libs.findLibrary("spring-boot-dependencies").get()))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 archunit = "1.5.0"
 spring-boot = "4.0.8"
-dependency-management = "1.1.7"
 kotlin = "2.3.21"
 kotlin-logging = "8.0.4"
 ktfmt = "0.64"


### PR DESCRIPTION
## 요약

`io.spring.dependency-management` 플러그인을 제거하고 Spring Boot 공식 문서가 제시하는 두 가지 BOM 관리 방식 중 Gradle native `platform()`으로 전환합니다.

- `beat.spring-boot-app`, `beat.spring-library` 컨벤션: DM 플러그인 제거 → `implementation(platform(libs.spring.boot.dependencies))`
- `build-logic`: DM pluginMarker 의존성 제거
- catalog: `dependency-management = "1.1.7"` 버전 항목 제거

Spring Boot 공식 문서는 native BOM support가 "더 빠른 빌드"를 기대하게 한다고 명시하며(https://docs.spring.io/spring-boot/gradle-plugin/managing-dependencies.html), 이 저장소는 이미 Spring Cloud BOM을 `platform()`으로 import하고 있어 하이브리드 상태였던 것을 통일합니다.

부수 효과: Gradle lockfile(`gradle.lockfile`) 도입 시 공식 미지원 조합(spring DM + locking, spring-gradle-plugins#258/#395)이 해소되어 향후 S8569 대응 경로가 열립니다.

## 변경 범위

4개 파일 / +9 −11. 프로덕션·테스트 코드 무변경.

## 검증

**의존성 해석 동일성 증명** — 마이그레이션 전/후 `runtimeClasspath` resolved 그래프 diff:

| 모듈 | 결과 |
|---|---|
| `:application:frontoffice` | 완전 동일 |
| `:infrastructure` | 완전 동일 |
| `:support:security-web` | 완전 동일 |
| `:apps:api` | log4j-api/core 2.25.5 → **2.26.0 단일 변화** |

log4j 변화는 우연이 아니라 **의도된 수정**입니다: `support:observability`가 카탈로그에 `log4j-layout-template-json = 2.26.0`을 명시 선언해왔으나, 기존 DM 플러그인의 force semantics가 Boot BOM(2.25.5)으로 되눌렀습니다. platform() 권장 semantics에서는 모듈의 명시 선언이 존중됩니다(conflict resolution → 2.26.0). log4j 패치 버전 상승이며 팀의 기존 선언 방향과 일치합니다.

- unused version catalog alias 체커 통과
- `:apps:api:compileKotlin` 통과

## 남은 후속 (별도 PR)

1. Sonar S8569: 본 PR 머지 후 lockfile 도입 여부 결정 가능
2. CI 그린 확인 후 #592 머지 순서 권장