### PR TITLE
fix: 이미지 변환 장애 격리(Graceful Fallback) 및 Lambda 2048MB 증설

### DIFF
--- a/infrastructure/src/main/kotlin/com/beat/infrastructure/external/cdn/ImageCacheAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/beat/infrastructure/external/cdn/ImageCacheAdapter.kt
@@ -64,7 +64,7 @@ internal class ImageCacheAdapter(
 
     private companion object {
         val log = LoggerFactory.getLogger(ImageCacheAdapter::class.java)
-        val TARGET_WIDTHS = listOf(480, 960)
+        val TARGET_WIDTHS = listOf(240, 480, 960)
         val TARGET_FORMATS = listOf("image/avif", "image/webp", "image/jpeg")
         val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(2)
         val READ_TIMEOUT: Duration = Duration.ofSeconds(5)

--- a/infrastructure/src/main/kotlin/com/beat/infrastructure/external/cdn/ImageCacheAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/beat/infrastructure/external/cdn/ImageCacheAdapter.kt
@@ -34,18 +34,23 @@ internal class ImageCacheAdapter(
             return
         }
         val baseUrl = "$cdnBase/$normalizedKey"
-        val variantTasks =
-            TARGET_WIDTHS.flatMap { width ->
-                    TARGET_FORMATS.map { accept ->
-                        CompletableFuture.runAsync(
-                            { warmSingleVariant(baseUrl, width, accept) },
-                            VARIANT_EXECUTOR,
-                        )
-                    }
-                }
-                .toTypedArray()
-        CompletableFuture.allOf(*variantTasks).join()
-        log.info("CDN pre-warm completed for {} ({} variants)", baseUrl, variantTasks.size)
+        CompletableFuture.runAsync(
+            {
+                val variantTasks =
+                    TARGET_WIDTHS.flatMap { width ->
+                            TARGET_FORMATS.map { accept ->
+                                CompletableFuture.runAsync(
+                                    { warmSingleVariant(baseUrl, width, accept) },
+                                    VARIANT_EXECUTOR,
+                                )
+                            }
+                        }
+                        .toTypedArray()
+                CompletableFuture.allOf(*variantTasks).join()
+                log.info("CDN pre-warm completed for {} ({} variants)", baseUrl, variantTasks.size)
+            },
+            VARIANT_EXECUTOR,
+        )
     }
 
     private fun warmSingleVariant(baseUrl: String, width: Int, accept: String) {

--- a/ops/ansible/roles/image_cdn/defaults/main.yml
+++ b/ops/ansible/roles/image_cdn/defaults/main.yml
@@ -16,6 +16,7 @@ image_cdn_lambda_src_relpath: "ops/aws/lambda/image-processing"
 image_cdn_lambda_code_key: "image-cdn/{{ image_cdn_lambda_code_version | default('latest') }}/image-processing.zip"
 
 image_cdn_lambda_memory_mb: 2048
+image_cdn_max_inline_image_size: 4700000
 image_cdn_lambda_timeout_seconds: 30
 image_cdn_lambda_log_retention_days: 14
 image_cdn_transformed_retention_days: 90

--- a/ops/ansible/roles/image_cdn/defaults/main.yml
+++ b/ops/ansible/roles/image_cdn/defaults/main.yml
@@ -15,7 +15,7 @@ image_cdn_lambda_src_relpath: "ops/aws/lambda/image-processing"
 # and live in the same region as the Lambda function.
 image_cdn_lambda_code_key: "image-cdn/{{ image_cdn_lambda_code_version | default('latest') }}/image-processing.zip"
 
-image_cdn_lambda_memory_mb: 1500
+image_cdn_lambda_memory_mb: 2048
 image_cdn_lambda_timeout_seconds: 30
 image_cdn_lambda_log_retention_days: 14
 image_cdn_transformed_retention_days: 90

--- a/ops/ansible/roles/image_cdn/tasks/main.yml
+++ b/ops/ansible/roles/image_cdn/tasks/main.yml
@@ -106,6 +106,7 @@
       AcmCertificateArn: "{{ image_cdn_acm_cert_arn }}"
       AlarmEmail: "{{ image_cdn_alarm_email }}"
       LambdaMemoryMb: "{{ image_cdn_lambda_memory_mb }}"
+      MaxInlineImageSize: "{{ image_cdn_max_inline_image_size }}"
       LambdaTimeoutSeconds: "{{ image_cdn_lambda_timeout_seconds }}"
       LambdaLogRetentionDays: "{{ image_cdn_lambda_log_retention_days }}"
       TransformedImageRetentionDays: "{{ image_cdn_transformed_retention_days }}"

--- a/ops/aws/cloudformation/image-cdn.yml
+++ b/ops/aws/cloudformation/image-cdn.yml
@@ -47,8 +47,8 @@ Parameters:
     Type: Number
     Default: 2048
     Description: >
-      Memory size of the image processor. 2048 MB gives Sharp full multi-threaded
-      vCPU performance and enough headroom for AVIF/WebP encoding without timeouts.
+      Memory size of the image processor. 2048 MB provides additional CPU
+      capacity and memory headroom for Sharp image processing.
   MaxInlineImageSize:
     Type: Number
     Default: 4700000

--- a/ops/aws/cloudformation/image-cdn.yml
+++ b/ops/aws/cloudformation/image-cdn.yml
@@ -45,11 +45,14 @@ Parameters:
 
   LambdaMemoryMb:
     Type: Number
-    Default: 1500
+    Default: 2048
     Description: >
-      Memory size of the image processor. 1500 MB matches the
-      aws-samples/image-optimization default and gives Sharp enough
-      headroom for AVIF encoding without timeouts on cold start.
+      Memory size of the image processor. 2048 MB gives Sharp full multi-threaded
+      vCPU performance and enough headroom for AVIF/WebP encoding without timeouts.
+  MaxInlineImageSize:
+    Type: Number
+    Default: 4700000
+    Description: Maximum raw binary bytes safe to return inline as base64 in a buffered Lambda response.
   LambdaTimeoutSeconds:
     Type: Number
     Default: 30
@@ -153,6 +156,7 @@ Resources:
           ORIGINAL_IMAGE_BUCKET: !Ref OriginalImageBucketName
           TRANSFORMED_IMAGE_BUCKET: !Ref TransformedImageBucket
           TRANSFORMED_IMAGE_CACHE_CONTROL: !Ref TransformedImageCacheControl
+          MAX_INLINE_IMAGE_SIZE: !Ref MaxInlineImageSize
 
   ImageProcessingFunctionUrl:
     Type: AWS::Lambda::Url

--- a/ops/aws/lambda/image-processing/index.mjs
+++ b/ops/aws/lambda/image-processing/index.mjs
@@ -18,7 +18,7 @@ const s3 = new S3Client();
 const ORIGINAL_BUCKET = process.env.ORIGINAL_IMAGE_BUCKET;
 const TRANSFORMED_BUCKET = process.env.TRANSFORMED_IMAGE_BUCKET;
 const TRANSFORMED_CACHE_CONTROL = process.env.TRANSFORMED_IMAGE_CACHE_CONTROL || "public, max-age=31536000, immutable";
-const MAX_IMAGE_SIZE = parseInt(process.env.MAX_IMAGE_SIZE || "6291456", 10);
+const MAX_INLINE_IMAGE_SIZE = parseInt(process.env.MAX_INLINE_IMAGE_SIZE || "4700000", 10);
 
 export const handler = async (event) => {
     if (event?.requestContext?.http?.method !== "GET") {
@@ -41,11 +41,11 @@ export const handler = async (event) => {
 
     const downloadStart = performance.now();
     let originalBytes;
-    let contentType;
+    let originalContentType;
     try {
         const out = await s3.send(new GetObjectCommand({ Bucket: ORIGINAL_BUCKET, Key: originalKey }));
         originalBytes = await out.Body.transformToByteArray();
-        contentType = out.ContentType;
+        originalContentType = resolveOriginalContentType(out.ContentType, originalBytes);
     } catch (error) {
         if (error.name === "NoSuchKey") {
             return errorResponse(404, "original image not found");
@@ -57,8 +57,9 @@ export const handler = async (event) => {
 
     const transformStart = performance.now();
     let transformedBuffer;
+    let transformedContentType;
     try {
-        let pipeline = Sharp(originalBytes, { failOn: "none", animated: true }).rotate();
+        let pipeline = Sharp(originalBytes, { failOn: "none" }).rotate();
 
         if (operations.width || operations.height) {
             pipeline = pipeline.resize({
@@ -69,19 +70,44 @@ export const handler = async (event) => {
         }
 
         if (operations.format) {
-            contentType = `image/${operations.format === "jpeg" ? "jpeg" : operations.format}`;
+            transformedContentType = `image/${operations.format === "jpeg" ? "jpeg" : operations.format}`;
             const formatOpts = operations.quality && isLossy(operations.format)
                 ? { quality: operations.quality }
                 : undefined;
             pipeline = pipeline.toFormat(operations.format, formatOpts);
-        } else if (contentType === "image/svg+xml") {
-            contentType = "image/png";
+        } else if (originalContentType === "image/svg+xml") {
+            transformedContentType = "image/png";
             pipeline = pipeline.toFormat("png");
+        } else {
+            transformedContentType = originalContentType;
         }
 
         transformedBuffer = await pipeline.toBuffer();
     } catch (error) {
-        console.error("Sharp transform failed", { key: originalKey, operations, error });
+        const metadata = await readMetadataSafely(originalBytes);
+        console.error("Sharp transform failed", {
+            originalKey,
+            operations,
+            originalByteSize: originalBytes?.byteLength,
+            originalContentType,
+            errorName: error?.name,
+            errorMessage: error?.message,
+            metadata,
+        });
+
+        if (isBrowserRenderable(originalContentType) && originalBytes.byteLength <= MAX_INLINE_IMAGE_SIZE) {
+            return {
+                statusCode: 200,
+                isBase64Encoded: true,
+                headers: {
+                    "Content-Type": originalContentType,
+                    "Cache-Control": "private, no-store",
+                    "Server-Timing": `download;dur=${downloadMs},transform;dur=0,fallback;dur=1`,
+                },
+                body: Buffer.from(originalBytes).toString("base64"),
+            };
+        }
+
         return errorResponse(500, "image transform failed");
     }
     const transformMs = Math.round(performance.now() - transformStart);
@@ -95,7 +121,7 @@ export const handler = async (event) => {
                 Bucket: TRANSFORMED_BUCKET,
                 Key: transformedKey,
                 Body: transformedBuffer,
-                ContentType: contentType,
+                ContentType: transformedContentType,
                 CacheControl: TRANSFORMED_CACHE_CONTROL,
             }));
         } catch (error) {
@@ -103,15 +129,23 @@ export const handler = async (event) => {
         }
     }
 
-    if (Buffer.byteLength(transformedBuffer) > MAX_IMAGE_SIZE) {
-        return errorResponse(413, "transformed image exceeds Lambda payload limit");
+    if (transformedBuffer.byteLength > MAX_INLINE_IMAGE_SIZE) {
+        const redirectLocation = buildPublicViewerUrl(originalKey, operations);
+        return {
+            statusCode: 302,
+            headers: {
+                Location: redirectLocation,
+                "Cache-Control": "private, no-store",
+                "Server-Timing": timing,
+            },
+        };
     }
 
     return {
         statusCode: 200,
         isBase64Encoded: true,
         headers: {
-            "Content-Type": contentType,
+            "Content-Type": transformedContentType,
             "Cache-Control": TRANSFORMED_CACHE_CONTROL,
             "Server-Timing": timing,
         },
@@ -119,7 +153,36 @@ export const handler = async (event) => {
     };
 };
 
-function parseOperations(prefix) {
+export function buildPublicViewerUrl(originalKey, operations) {
+    const params = [];
+    if (operations?.width) {
+        params.push(`w=${operations.width}`);
+    }
+    if (operations?.format) {
+        params.push(`format=${operations.format}`);
+    }
+    const qs = params.length > 0 ? `?${params.join("&")}` : "";
+    return `/${originalKey}${qs}`;
+}
+
+export async function readMetadataSafely(bytes) {
+    if (!bytes || bytes.length === 0) return null;
+    try {
+        const metadata = await Sharp(bytes, { failOn: "none" }).metadata();
+        return {
+            format: metadata.format,
+            width: metadata.width,
+            height: metadata.height,
+            pages: metadata.pages,
+            space: metadata.space,
+            orientation: metadata.orientation,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function parseOperations(prefix) {
     if (prefix === "original") return {};
 
     const result = {};
@@ -155,14 +218,76 @@ function parseOperations(prefix) {
     return result;
 }
 
-function isLossy(format) {
+export function isLossy(format) {
     return format === "jpeg" || format === "webp" || format === "avif";
+}
+
+export function isBrowserRenderable(mimeType) {
+    if (!mimeType) return false;
+    const lower = mimeType.toLowerCase();
+    return [
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "image/avif",
+        "image/gif",
+        "image/svg+xml",
+    ].includes(lower);
+}
+
+export function resolveOriginalContentType(s3ContentType, bytes) {
+    if (s3ContentType && s3ContentType !== "application/octet-stream" && s3ContentType !== "binary/octet-stream") {
+        return s3ContentType;
+    }
+    return detectMimeType(bytes);
+}
+
+export function detectMimeType(bytes) {
+    if (!bytes || bytes.length < 4) return "application/octet-stream";
+
+    // JPEG: FF D8 FF
+    if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+        return "image/jpeg";
+    }
+
+    // PNG: 89 50 4E 47
+    if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+        return "image/png";
+    }
+
+    // GIF: 47 49 46 38 ('GIF8')
+    if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38) {
+        return "image/gif";
+    }
+
+    // WebP: RIFF....WEBP
+    if (bytes.length >= 12 &&
+        bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+        bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50
+    ) {
+        return "image/webp";
+    }
+
+    // AVIF: ....ftyp(avif|avis)
+    if (bytes.length >= 12 &&
+        bytes[4] === 0x66 && bytes[5] === 0x74 && bytes[6] === 0x79 && bytes[7] === 0x70
+    ) {
+        const majorBrand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11]);
+        if (majorBrand === "avif" || majorBrand === "avis") {
+            return "image/avif";
+        }
+    }
+
+    return "application/octet-stream";
 }
 
 function errorResponse(statusCode, message) {
     return {
         statusCode,
-        headers: { "Content-Type": "text/plain" },
+        headers: {
+            "Content-Type": "text/plain",
+            "Cache-Control": "no-store",
+        },
         body: message,
     };
 }

--- a/ops/aws/lambda/image-processing/index.mjs
+++ b/ops/aws/lambda/image-processing/index.mjs
@@ -114,6 +114,7 @@ export const handler = async (event) => {
 
     const timing = `download;dur=${downloadMs},transform;dur=${transformMs}`;
 
+    let stored = false;
     if (TRANSFORMED_BUCKET) {
         const transformedKey = `${originalKey}/${operationsPrefix}`;
         try {
@@ -124,12 +125,17 @@ export const handler = async (event) => {
                 ContentType: transformedContentType,
                 CacheControl: TRANSFORMED_CACHE_CONTROL,
             }));
+            stored = true;
         } catch (error) {
-            console.error("S3 PutObject (transformed) failed; serving inline", { key: transformedKey, error });
+            console.error("S3 PutObject (transformed) failed", { key: transformedKey, error });
         }
     }
 
     if (transformedBuffer.byteLength > MAX_INLINE_IMAGE_SIZE) {
+        if (!stored) {
+            return errorResponse(500, "transformed image too large and could not be cached");
+        }
+
         const redirectLocation = buildPublicViewerUrl(originalKey, operations);
         return {
             statusCode: 302,


### PR DESCRIPTION
## Related issue 🛠

- Image CDN 500 error & Graceful Fallback Architecture Stabilization

## Work Description ✏️

- **Lambda 이미지 리사이징 변환 실패 시 장애 격리 (Graceful Fallback)**:
  - Sharp 이미지 변환 실패 시 무조건 500 엑박을 반환하던 구조를 개선하여, 브라우저 렌더링 가능한 MIME & 4.7MB 이하 원본에 대해 `200 OK (Cache-Control: private, no-store)` 원본 Fallback 서빙.
  - Fallback 결과는 `Transformed S3`에 절대 저장하지 않아 캐시 오염(Cache Correctness Violation) 방지.
- **대용량 정상 변환 결과(> 4.7MB) 302 Redirect & S3 PUT 실패 시 무한 루프 방지**:
  - `MAX_INLINE_IMAGE_SIZE (4,700,000 bytes)` 초과 시 S3 Transformed 버킷 저장(`stored === true`) 확인 후 Public Viewer URL(`/{env}/{prefix}/{filename}?w=...&format=...`)로 302 Redirect.
  - S3 PUT 실패 시 302 Redirect Loop를 원천 차단하고 `500 transformed image too large and could not be cached`로 명확히 실패 처리.
- **MIME Magic Bytes 정밀 판별 및 Content-Type 분리**:
  - S3 `application/octet-stream` 저장 파일에 대해 Magic Bytes 기반으로 `image/jpeg`, `image/png`, `image/gif`, `image/webp` (RIFF+WEBP 12B), `image/avif` (avif/avis major brand strict) 정밀 판별. (generic `mif1/msf1` 오판 차단).
  - `originalContentType`과 `transformedContentType` 상태를 완전 분리.
- **CloudFormation & Ansible Lambda 메모리 2048MB 및 MaxInlineImageSize 파라미터 SSOT 동기화**:
  - Memory 2048MB 증설을 통해 Sharp 이미지 처리에 필요한 추가 CPU capacity 및 memory headroom 확보.
  - `image_cdn_max_inline_image_size: 4700000` Ansible defaults 및 CloudFormation stack parameters 연동.
- **백엔드 비동기 프리워밍 확장 (`ImageCacheAdapter`)**:
  - `TARGET_WIDTHS = listOf(240, 480, 960)`로 240px 썸네일 배리언트 프리워밍 추가.
  - `preWarm()` 실행을 가상 스레드 기반 `CompletableFuture.runAsync`로 완전 비동기화하여 Promotion 트랜잭션 및 요청 스레드 블로킹 해소.

### 📐 Image CDN 파이프라인 아키텍처 다이어그램

```mermaid
flowchart TD
    Client["유저 브라우저"] --> CF["CloudFront"]
    CF --> S3T{"Transformed S3"}
    S3T -- "Cache HIT (200)" --> CF
    S3T -- "Cache MISS (403/404)" --> Lambda["Lambda (2048MB)"]
    Lambda --> S3O["Original S3 GET"]
    S3O --> Sharp{"Sharp 변환"}
    
    Sharp -- "성공 (Transform Success)" --> PutS3["Transformed S3 PUT"]
    PutS3 --> SizeCheck{"결과 크기 <= 4.7MB ?"}
    SizeCheck -- "Yes" --> Resp200["200 OK (Base64 Inline)"]
    SizeCheck -- "No" --> StoredCheck{"Transformed S3<br/>저장 성공 ?"}
    StoredCheck -- "Yes" --> Resp302["302 Found (Location: Public CF URL)"]
    Resp302 --> CF
    StoredCheck -- "No (Loop 방지)" --> Resp500Loop["500 Internal Server Error<br/>(Cache failed)"]
    
    Sharp -- "실패 (Transform Exception)" --> Log["구조화 에러 로깅 (readMetadataSafely)"]
    Log --> FallbackCheck{"브라우저 렌더링 가능 MIME<br/>& 원본 <= 4.7MB ?"}
    FallbackCheck -- "Yes (안전 범위)" --> RespFallback["200 OK (Original Bytes)<br/>Cache-Control: private, no-store<br/>(Transformed S3 저장 ❌)"]
    FallbackCheck -- "No" --> Resp500["500 Internal Server Error<br/>Cache-Control: no-store"]
```

---

## Trouble Shooting ⚽️

### 1. 문제 현상
- 공연 생성/수정 시 고용량 스태프/포스터 사진을 등록하면 브라우저에서 `500 image transform failed` 에러와 함께 화면에 엑박이 노출됨.

### 2. 원인 분석 (Root Cause)
1. **S3 원본 업로드는 성공**: S3 HEAD 검증 및 다운로드는 정상이었으나, 원본 사진이 초고화질/고용량(수천만 화소)이거나 특이 메타데이터를 포함하여 On-Demand Lambda(Sharp)가 메모리에 디코딩 및 변환하는 과정에서 실패(`catch` 블록 진입).
2. **단일 장애 지점(SPOF) 에러 노출**: 기존 코드는 Sharp 실패 시 500 에러를 던지는 것 외에 Fallback이 전무하여, 원본이 멀쩡히 살아있음에도 사용자 화면 전체가 깨짐.
3. **불필요한 `animated: true` 활성화**: 정적 이미지임에도 다중 프레임 버퍼를 메모리에 전개하여 메모리 사용량이 급증함.

---

## Solution & Architecture Decisions 💡

### 1. 왜 `MAX_INLINE_IMAGE_SIZE = 4,700,000 bytes (4.7MB)` 인가?
- **AWS Lambda Payload Hard Limit**: Lambda Function URL(Buffered 모드)의 단일 HTTP 응답 페이로드 최대 크기는 **6 MiB (6,291,456 bytes)**로 제한됩니다. 1바이트라도 초과 시 `413 Payload Too Large` / `502 Bad Gateway`가 발생합니다.
- **Base64 33% 팽창 역산**: 바이너리 이미지를 JSON 응답 Body에 실어 보낼 때 Base64 인코딩으로 인해 크기가 `4/3 ≈ 1.333배` 증가합니다.
  $$\text{안전 최대 원본 크기} \approx (6,291,456 - 25,000 \text{ Header Buffer}) \times \frac{3}{4} = \mathbf{4,699,842 \text{ bytes}}$$
- 따라서 **`4,700,000 bytes (4.7MB)`**를 인라인 반환의 안전 상한선으로 채택하고, 이를 초과하는 정상 변환물은 S3 저장 후 `302 Redirect`를 통해 CloudFront S3 Direct HIT로 안전하게 서빙합니다.

### 2. S3 PUT 실패 시 302 무한 루프 방지
- 변환물이 4.7MB를 초과하더라도, S3 저장이 실패한 상태에서 302를 반환하면 `302 → CF → S3 MISS → Lambda → 302` 무한 루프가 발생합니다.
- `let stored = false;`를 추적하여 S3 저장이 성공한 경우에만 302를 반환하고, 실패 시 `500`으로 명확히 종료하도록 방어했습니다.

### 3. Cache Correctness 보장 (캐시 오염 방지)
- Sharp AVIF 변환 실패 후 원본 JPEG를 `format=avif,width=480` S3 키에 저장하면 잘못된 파일이 영구 캐싱됩니다.
- Fallback 경로에서는 S3 PUT을 일체 수행하지 않고 `Cache-Control: private, no-store`로 임시 서빙하여 캐시 오염을 원천 차단했습니다.

---

## Trade-offs & Engineering Considerations ⚖️

| 고려 항목 | 채택된 설계 | 트레이드오프 및 근거 |
|---|---|---|
| **On-Demand Edge vs Pre-generation** | CloudFront + Lambda On-Demand | 수천 장의 배리언트를 사전 생성하는 스토리지/비용 낭비를 방지하고, 최초 요청 시에만 On-Demand로 생성하여 S3에 캐싱. |
| **Lambda Memory 2048MB** | 1500MB ➔ 2048MB 증설 | AWS Lambda는 메모리에 비례해 CPU capacity가 증가하므로 Sharp 처리 여유를 확보. 실행 시간 단축으로 실제 비용은 무료 티어 범위 내에서 거의 동일. |
| **Fallback `no-store` 정책** | `private, no-store` 반환 | Fallback 이미지가 CDN에 잘못 캐시되어 영구화되는 위험을 방지하고, 다음 요청에서 정상 변환을 재시도할 수 있도록 보장. |
| **Client 정책과의 경계** | 20MiB Reject + 원본 보존 | FE는 원본 무손실 업로드를 유지하고, 4.7MB 초과 & Sharp 실패라는 극단적 코너 케이스는 5xx + 구조화 로그로 관측 가능하게 유지. |

---

## Related ScreenShot 📷

- 해당 없음 (인프라 / Lambda 백엔드 로직 수정)

## Uncompleted Tasks 😅

- [x] Lambda Handler Fallback & 302 Redirect 구현
- [x] S3 PUT 실패 시 302 Redirect Loop 방지 (`stored` 체크)
- [x] 4,700,000 bytes Base64 팽창 한계 수학적 역산 적용
- [x] Magic Bytes MIME 판별 (AVIF avif/avis major brand strict, WebP RIFF+WEBP)
- [x] CloudFormation & Ansible 2048MB 및 MaxInlineImageSize 파라미터 SSOT 동기화
- [x] ImageCacheAdapter 240px 프리워밍 및 가상 스레드 비동기 처리
- [x] 레거시 없는 프로덕션 코드 5개 파일로 무결성 유지

## To Reviewers 📢

- 이번 PR은 기존 클라이언트 정책(20MiB 초과 reject, 원본 유지) 및 CloudFront Viewer-Request contract(`/{env}/{prefix}/{filename}`)와 100% 호환되도록 정밀 설계되었습니다.
- 리뷰 및 승인 부탁드립니다!
