### PR TITLE
chore: dev 서버를 t4g.small 환경으로 전환

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -238,7 +238,7 @@ jobs:
       - resolve-ref
       - verify
     if: needs.detect-changes.outputs.has_modules == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read

--- a/Dockerfile.module
+++ b/Dockerfile.module
@@ -4,7 +4,10 @@ ARG MODULE
 
 # Alpine repositories retain current patch revisions; Trivy is the vulnerability gate.
 RUN apk add --no-cache --upgrade \
+    libcrypto3 \
     libexpat \
+    libssl3 \
+    openssl \
     p11-kit \
     p11-kit-trust
 

--- a/load-tests/k6/README.md
+++ b/load-tests/k6/README.md
@@ -40,7 +40,7 @@ Booking ID·사용자 ID 같은 고카디널리티 값은 metric tag로 사용�
 | `BASE_URL` | 필수 | 측정 대상 API를 지정할 때 | allowlist된 HTTPS origin만 받고, 요청 파일에는 상대 경로만 두어 다른 호스트로 요청이 새지 않게 합니다. |
 | `TEST_ID` | 자동 생성, 지정 권장 | Grafana와 결과 파일을 연결할 때 | 실행 간 지표와 JSON summary를 구분합니다. |
 | `GIT_SHA` | `GITHUB_SHA` 또는 `unknown` | 배포 코드와 결과를 연결할 때 | 모든 k6 지표와 summary에 기록합니다. |
-| `SERVER_TYPE` | 환경 기본값 | 실제 서버 사양이 기본값과 다를 때 | `dev=t3.micro`, `prod=t4g.small` 기본값을 덮어씁니다. |
+| `SERVER_TYPE` | 환경 기본값 | 실제 서버 사양이 기본값과 다를 때 | `dev=t4g.small`, `prod=t4g.small` 기본값을 덮어씁니다. |
 | `DATASET_HASH` | 자동 계산, 지정 선택 | 입력 데이터 무결성을 확인할 때 | 지정하면 파일의 SHA-256과 일치하는지 검증합니다. |
 | `ACCESS_TOKEN` | 없음 | 인증 API를 측정할 때 | Bearer 토큰으로 사용됩니다. 예매 확정 시나리오에는 필수입니다. |
 | `REQUEST_FILE` | `./requests.json` | 범용 HTTP 요청 구성을 바꿀 때 | method, path, body, 예상 상태 코드를 코드 수정 없이 교체합니다. |

--- a/load-tests/k6/lib/config.js
+++ b/load-tests/k6/lib/config.js
@@ -3,7 +3,7 @@ import { getWorkloadBudget, WORKLOAD_BUDGET_VERSION } from './budgets.js';
 const TARGET_ENVIRONMENTS = Object.freeze({
   dev: Object.freeze({
     allowedHosts: Object.freeze(['api-dev.beatlive.kr']),
-    serverType: 't3.micro',
+    serverType: 't4g.small',
   }),
   prod: Object.freeze({
     allowedHosts: Object.freeze(['api.beatlive.kr']),

--- a/load-tests/k6/tests/config.test.mjs
+++ b/load-tests/k6/tests/config.test.mjs
@@ -15,6 +15,7 @@ function load(overrides = {}, defaults = { scenario: 'generic_http' }) {
 
 test('target environment selects only its allowlisted hostname', () => {
   assert.equal(load().targetEnv, 'dev');
+  assert.equal(load().serverType, 't4g.small');
   assert.equal(
     load({ TARGET_ENV: 'prod', BASE_URL: 'https://api.beatlive.kr' }).serverType,
     't4g.small',

--- a/ops/ansible/inventories/dev/group_vars/all/main.yml
+++ b/ops/ansible/inventories/dev/group_vars/all/main.yml
@@ -61,9 +61,6 @@ modules:
     spring_profile: dev
     app_port: 4001
     hikari_max_pool_size: 10
-    env:
-      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=128m -XX:+UseG1GC -Daws.java.v1.disableDeprecationAnnouncement=true"
-      MALLOC_ARENA_MAX: "2"
     public_smoke_url: "https://{{ nginx_server_name }}/api/main"
     blue_container_name: apis-blue
     green_container_name: apis-green
@@ -73,9 +70,6 @@ modules:
     spring_profile: dev
     app_port: 4000
     hikari_max_pool_size: 1
-    env:
-      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=128m -XX:+UseG1GC -Daws.java.v1.disableDeprecationAnnouncement=true"
-      MALLOC_ARENA_MAX: "2"
     container_name: admin
     nginx_route:
       upstream_name: admin_backend
@@ -86,12 +80,9 @@ modules:
     spring_profile: dev
     app_port: 4002
     hikari_max_pool_size: 1
-    env:
-      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx192m -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=128m -XX:+UseG1GC -Daws.java.v1.disableDeprecationAnnouncement=true"
-      MALLOC_ARENA_MAX: "2"
     container_name: batch
 
-# observability_alloy — dev는 이제 metrics+logs+traces 활성화 (t3.micro 1GB 환경, 메모리 주의)
+# observability_alloy — dev는 이제 metrics+logs+traces 활성화 (t4g.small 2GB 환경)
 observability_alloy_mem_limit: "256m"
 observability_alloy_cpus: "0.5"
 observability_alloy_scrape_interval: "30s"

--- a/ops/ansible/inventories/dev/group_vars/all/secrets.sops.yml
+++ b/ops/ansible/inventories/dev/group_vars/all/secrets.sops.yml
@@ -10,7 +10,7 @@ mysql_password: ENC[AES256_GCM,data:Cx3fgcl3mXHqa+di,iv:JqwF30c9RFG7caupRh6dL3qj
 mysql_root_password: ENC[AES256_GCM,data:m6OjKP1bVrzSPsw=,iv:+2UlDBE1WgnyfOXXDIrNpTF2YuEPkN9goNMng68PrEw=,tag:kBLBhNRB6YdXQaSXLqPs/A==,type:str]
 mysql_user: ENC[AES256_GCM,data:oZtoTaECtw==,iv:aPV5QhrmL6dpkr1vxvYwTpVtbnd1n3tkDGEh9ew9aeY=,tag:yciGjbS6gXzSwDEeSLfPjw==,type:str]
 nginx_server_name: ENC[AES256_GCM,data:ZRekZzuJ4zI52Ub5TfT3rkZJSQ==,iv:hXXnWERMw5QF2j0bAYDIP1zcSKfZwdEg9pU+9r892Yc=,tag:M+2DTvsxi6At8shQddH30A==,type:str]
-ssh_host_fingerprint: ENC[AES256_GCM,data:fnIhspkHAZNI8A26CfA74RnmrPpKlomDlZb3MKwd9SYzQHEzzFFT99KjelPWoaMP7gw=,iv:O/kPWudhYmBj5WpjRPif0TqrmonVBryg+7YSZALg0g0=,tag:gVieXyoJ2Sy8PsOAHjB/ng==,type:str]
+ssh_host_fingerprint: ENC[AES256_GCM,data:EBASRJIR+H4qLBfxCsO3JIlBbwNJyUK+E+0n3QMd6UF9fo14fY5fY/ZstTlBCMasFi8=,iv:5Q4YE/6edmEgOVkq7V2zf9pgC92KVQa9GDQQ68FXzTc=,tag:yfL/3NlO3CAFaqSi0K94qg==,type:str]
 gc_token: ENC[AES256_GCM,data:g2Oes5GwBmb+AXX+AaAkGCCyn4WlhM+jq3TpFaiWxaPlerOIYnkQuv5G8cFjpR3XDT1fPKUKa3HDLfTH78V2BpaDnDC6jSlitysa7E3zt3gPdmM620+R1AbpDtQf6WKdx/fF46R93VwiQuSoIt9a+WxMVjl3nUmLC0u0fyO7s/OKmApwEgqVfAYiAuPCaHOfUlnGoA==,iv:gEZ54v4d3eID7CMOa/HHbcaFSP4f/Bsr4hCcy+qIblY=,tag:0EZ3r54zcnjuTQjQx6U2Hw==,type:str]
 gc_prom_url: ENC[AES256_GCM,data:Gx+6WJAf4ou8nDHNBj8uhlb5ICFnDwGMCGm+EM1TivG9lKVxRF3YtEfIOXez4oNX2+AfFJdakU0c305PpjGXDeZl1uLVyqxi,iv:tdeHBFvEMd3t8Pic2n/snwjWcEJ+lnbp1mbHGYPs6f4=,tag:qf+hVcR2Jf46MEGfaMslcA==,type:str]
 gc_prom_user: ENC[AES256_GCM,data:tLfAAhqctQ==,iv:QPxB+SwLB1e2/iFTK3500tTAToMqCCqt32O40C1NpwE=,tag:VYVFyggLMyt0ubx+AFd6oQ==,type:str]
@@ -52,7 +52,7 @@ sops:
             RnJheWp2VkVIN2FLRU9iWGUvbHZCd00K4dwcAffQFfpFh/M1c4PFez5vW6ubsKDP
             xpkJc7w1RQro4uuFGlLqyMa26UDnLI8F9L7saAg3MAGstQ+/rokhQA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-08-28T07:00:09Z"
-    mac: ENC[AES256_GCM,data:4q/BaXdCHXl+KgUXwYEYMWOcxSfretq45EchekcKbu/IonHsxEMCmdx/2759/fy2kvcl5FwuPJXKNL0bk0xqqH5Hn6ttjK8U17tY6bjSQ5/yMpXVFutQvesfUNJLpemUtnfGDOcPSYYGapsHskoVLnghOIZk9wnETyUx9sgC+sk=,iv:+GPO6C905PbCNKifHa8tA1mY77a3A5OiYAKNFf54MC8=,tag:jF3MhsicBWbmLrslPUFgTA==,type:str]
+    lastmodified: "2026-08-29T16:44:24Z"
+    mac: ENC[AES256_GCM,data:eoIgNCMJ8kD7cLHGdBF/gL2u+4Nww0FLL0f7XsyUF0+pCsWTxKPbYsKUi1ey3IBiBKHKmNb3a3JGSzkfFjiepfR/HYA107dSyE8+SHmszK60VriozsNn/y+CJNceq90UUonoD/Yi2Jt7Qtj+Gd6ffXF7McMa2i+xn5B1t0ilrk4=,iv:VkUh+Gmg2Gkf+XwDt/PUZ6V/14bp6lXCGu5pYxI5RjM=,tag:OmSFRhpkGVdqg2VoKrQUcQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/ops/ansible/inventories/prod/group_vars/all/main.yml
+++ b/ops/ansible/inventories/prod/group_vars/all/main.yml
@@ -83,7 +83,7 @@ modules:
     container_name: batch
 
 # observability_alloy — prod는 metrics+logs+traces 풀스택
-# t3a.small 2GB에 apis(BG)+admin+batch+redis+nginx+alloy 공존 — 보수적 256m로 시작
+# t4g.small 2GB에 apis(BG)+admin+batch+redis+nginx+alloy 공존 — 보수적 256m로 시작
 # 1주차 운영 후 부족하면 inventory에서 384m로 증액
 observability_alloy_mem_limit: "256m"
 observability_alloy_cpus: "1.0"

--- a/ops/ansible/roles/app_cleanup/tasks/main.yml
+++ b/ops/ansible/roles/app_cleanup/tasks/main.yml
@@ -24,7 +24,26 @@
     path: "{{ pending_metadata_path }}"
     state: absent
 
-- name: Assert docker image prune failure policy is supported
+- name: Check whether previous metadata exists
+  ansible.builtin.stat:
+    path: "{{ release_dir }}/previous.json"
+  register: app_cleanup_previous_release_stat
+
+- name: Read previous release metadata
+  ansible.builtin.slurp:
+    src: "{{ release_dir }}/previous.json"
+  register: app_cleanup_previous_release_raw
+  when: app_cleanup_previous_release_stat.stat.exists
+
+- name: Resolve previous release image
+  ansible.builtin.set_fact:
+    app_cleanup_previous_image: >-
+      {{
+        (app_cleanup_previous_release_raw.content | b64decode | from_json).get('image', '')
+      }}
+  when: app_cleanup_previous_release_stat.stat.exists
+
+- name: Assert docker image cleanup failure policy is supported
   ansible.builtin.assert:
     that:
       - docker_image_prune_failure_policy | default('warn') in ['warn', 'fail']
@@ -32,7 +51,104 @@
       docker_image_prune_failure_policy must be either 'warn' or 'fail'
       (got {{ docker_image_prune_failure_policy | default('warn') }}).
 
-- name: Remove dangling Docker images
+- name: Assert deployed image belongs to the BEAT module repository
+  ansible.builtin.assert:
+    that:
+      - image is string
+      - image is match('^[^\s@]+/beat-' ~ module ~ ':[^/:\s@]+$')
+    fail_msg: >-
+      Deployment image must be a tagged BEAT {{ module }} image before cleanup
+      (got {{ image | default('undefined') }}).
+
+- name: Resolve deployed module image repository
+  ansible.builtin.set_fact:
+    app_cleanup_image_repository: "{{ image | regex_replace(':[^:/]+$', '') }}"
+
+- name: List images in the deployed module repository
+  ansible.builtin.command:
+    argv:
+      - docker
+      - image
+      - ls
+      - --format
+      - "{{ '{{.Repository}}:{{.Tag}}' }}"
+      - --filter
+      - "reference={{ app_cleanup_image_repository }}:*"
+  register: app_cleanup_image_list_result
+  changed_when: false
+  failed_when:
+    - app_cleanup_image_list_result.rc != 0
+    - docker_image_prune_failure_policy | default('warn') == 'fail'
+
+- name: Build module image retention set
+  ansible.builtin.set_fact:
+    app_cleanup_keep_images: >-
+      {{
+        [image, app_cleanup_previous_image | default('')]
+        | reject('equalto', '')
+        | unique
+        | list
+      }}
+    app_cleanup_image_refs: >-
+      {{
+        app_cleanup_image_list_result.stdout_lines | default([])
+        | map('trim')
+        | reject('equalto', '')
+        | reject('equalto', '<none>:<none>')
+        | list
+      }}
+  when: app_cleanup_image_list_result.rc == 0
+
+- name: Remove old images from the deployed module repository
+  ansible.builtin.command:
+    argv:
+      - docker
+      - image
+      - rm
+      - --no-prune
+      - "{{ item }}"
+  loop: "{{ app_cleanup_image_refs | default([]) }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - app_cleanup_image_list_result.rc == 0
+    - item not in app_cleanup_keep_images
+  register: app_cleanup_image_remove_result
+  changed_when: app_cleanup_image_remove_result.rc == 0
+  failed_when:
+    - app_cleanup_image_remove_result.rc != 0
+    - docker_image_prune_failure_policy | default('warn') == 'fail'
+
+- name: Report docker image listing cleanup issue
+  ansible.builtin.debug:
+    msg: >-
+      docker image listing failed during cleanup with policy=warn:
+      {{
+        app_cleanup_image_list_result.stderr
+        | default('', true)
+        | default(app_cleanup_image_list_result.stdout | default('unknown error', true), true)
+      }}
+  when:
+    - app_cleanup_image_list_result.rc != 0
+    - docker_image_prune_failure_policy | default('warn') == 'warn'
+
+- name: Report docker image removal cleanup issues
+  ansible.builtin.debug:
+    msg: >-
+      docker image removal failed for {{ item.item }} during cleanup with policy=warn:
+      {{
+        item.stderr
+        | default('', true)
+        | default(item.stdout | default('unknown error', true), true)
+      }}
+  loop: "{{ app_cleanup_image_remove_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('unknown image') }}"
+  when:
+    - item.rc | default(0) != 0
+    - docker_image_prune_failure_policy | default('warn') == 'warn'
+
+- name: Remove dangling Docker images for the deployed module
   ansible.builtin.command:
     argv:
       - docker
@@ -40,7 +156,7 @@
       - prune
       - -f
       - --filter
-      - "until={{ docker_image_prune_retention | default('72h') }}"
+      - "label=beat.module={{ module }}"
   register: app_cleanup_docker_prune_result
   changed_when:
     - app_cleanup_docker_prune_result.rc == 0
@@ -49,7 +165,7 @@
     - app_cleanup_docker_prune_result.rc != 0
     - docker_image_prune_failure_policy | default('warn') == 'fail'
 
-- name: Report docker prune cleanup issue
+- name: Report docker image prune cleanup issue
   ansible.builtin.debug:
     msg: >-
       docker image prune failed during cleanup with policy=warn:

--- a/ops/ansible/roles/observability_alloy/defaults/main.yml
+++ b/ops/ansible/roles/observability_alloy/defaults/main.yml
@@ -14,7 +14,7 @@ observability_alloy_secret_dir: "/opt/beat/alloy/secrets"
 # Paths inside container (where alloy reads files via volume mount)
 observability_alloy_container_secret_dir: "/etc/alloy/secrets"
 
-# Resource limits (dev t3.micro 1GB / prod t3a.small 2GB 기준)
+# Resource limits (dev/prod t4g.small 2GB 기준)
 # Both inventories allocate 256 MiB. Keep the default aligned with that
 # contract so an enabled k6+trace pipeline cannot silently exceed its cgroup.
 observability_alloy_mem_limit: "256m"


### PR DESCRIPTION
## Related issue 🛠

- 관련 이슈 없음

## Work Description ✏️

- dev 애플리케이션 이미지를 prod와 동일한 ARM64 GitHub Actions runner에서 빌드합니다.
- k6 dev 서버 메타데이터를 t4g.small로 갱신합니다.
- dev의 1GiB 대응용 JAVA_TOOL_OPTIONS 및 MALLOC_ARENA_MAX 설정을 제거해 prod JVM 기본 동작과 맞춥니다.
- dev/prod Alloy 리소스 설명을 실제 t4g.small 구성에 맞춥니다.
- 배포 성공 후 모듈별 BEAT 이미지에서 현재 release와 직전 rollback release만 보존합니다.
- beat.module label 기반 dangling 정리로 Alloy, Redis, Nginx 및 다른 모듈 이미지는 제외합니다.
- Alpine OpenSSL 패키지를 최신 보안 패치로 upgrade해 ARM64 이미지 Trivy gate를 충족합니다.

## Trouble Shooting ⚽️

- develop merge 시 dev 앱 배포가 실행되므로 대상 호스트가 aarch64인지 먼저 확인해야 합니다.
- JVM cap 제거 후 Blue/Green 전환 구간에서 docker stats와 호스트 메모리를 확인하고, 메모리 압박 시 기존 t3.micro로 EIP를 롤백합니다.
- 이미지 삭제는 배포된 beat-module repository와 module label에만 제한하며 docker image prune -a는 사용하지 않습니다.

## Related ScreenShot 📷

- 해당 없음

## Uncompleted Tasks 😅

- 해당 없음

## To Reviewers 📢

- actionlint 통과
- k6 Node 테스트 6/6 통과
- ansible-lint 47개 파일 통과
- deploy playbook syntax check 통과
- git diff --check 통과
- 전체 verify는 로컬 Docker daemon을 사용할 수 없어 Testcontainers acceptance test에서 실패했습니다. 변경과 무관한 환경 실패이며 GitHub Actions에서 재검증합니다.
