### PR TITLE
fix: LGTM 메트릭 카디널리티 및 대시보드 오류 수정

### DIFF
--- a/ops/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/ops/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -186,7 +186,7 @@ prometheus.relabel "cleanup" {
   rule {
     source_labels = ["__name__", "le"]
     separator     = ";"
-    regex         = "http_server_requests_seconds_bucket;(0\\.01|0\\.025|0\\.05|10\\.0|30\\.0).*"
+    regex         = "http_server_requests_seconds_bucket;(0\\.01|0\\.025|0\\.05).*"
     action        = "drop"
   }
   rule {

--- a/ops/grafana/generated/00-system-overview.json
+++ b/ops/grafana/generated/00-system-overview.json
@@ -145,7 +145,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(rate(http_server_requests_seconds_count{env=~\"$env\",application=~\"$application\",uri=~\"^/api(/.*)?$\",uri!~\"^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$\",status=~\"5..\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_server_requests_seconds_count{env=~\"$env\",application=~\"$application\",uri=~\"^/api(/.*)?$\",uri!~\"^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$\",status=~\"5..\"}[$__rate_interval])) or 0 * sum(rate(http_server_requests_seconds_count{env=~\"$env\",application=~\"$application\",uri=~\"^/api(/.*)?$\",uri!~\"^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "5xx",
           "range": true,
@@ -157,7 +157,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(rate(http_server_requests_seconds_count{env=~\"$env\",application=~\"$application\",uri=~\"^/api(/.*)?$\",uri!~\"^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$\",status=\"429\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_server_requests_seconds_count{env=~\"$env\",application=~\"$application\",uri=~\"^/api(/.*)?$\",uri!~\"^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$\",status=\"429\"}[$__rate_interval])) or 0 * sum(rate(http_server_requests_seconds_count{env=~\"$env\",application=~\"$application\",uri=~\"^/api(/.*)?$\",uri!~\"^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "429",
           "range": true,
@@ -606,6 +606,7 @@
         "multi": false,
         "name": "DS_LOKI",
         "query": "loki",
+        "regex": "/^grafanacloud-.*-logs$/i",
         "skipUrlSync": false,
         "type": "datasource"
       },

--- a/ops/grafana/generated/01-service-deep-dive.json
+++ b/ops/grafana/generated/01-service-deep-dive.json
@@ -510,6 +510,7 @@
         "multi": false,
         "name": "DS_LOKI",
         "query": "loki",
+        "regex": "/^grafanacloud-.*-logs$/i",
         "skipUrlSync": false,
         "type": "datasource"
       },

--- a/ops/grafana/generated/02-jvm-hikari.json
+++ b/ops/grafana/generated/02-jvm-hikari.json
@@ -144,7 +144,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (instance, color) (rate(jvm_memory_allocated_bytes_total{env=~\"$env\",application=~\"$application\",instance=~\"$instance\",color=~\"$color\"}[$__rate_interval]))",
+          "expr": "sum by (instance, color) (rate(jvm_gc_memory_allocated_bytes_total{env=~\"$env\",application=~\"$application\",instance=~\"$instance\",color=~\"$color\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "{{instance}} {{color}}",
           "range": true,

--- a/ops/grafana/generated/04-infrastructure.json
+++ b/ops/grafana/generated/04-infrastructure.json
@@ -222,7 +222,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "cAdvisor is enabled for prod only; an empty dev panel is expected and documented by the dashboard description.",
+      "description": "cAdvisor is enabled for prod only; compose service is preferred, with a name fallback for exporter label compatibility.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -257,9 +257,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (name) (rate(container_cpu_usage_seconds_total{env=~\"$env\",name!=\"\"}[$__rate_interval]))",
+          "expr": "sum by (container) (label_replace(rate(container_cpu_usage_seconds_total{env=~\"$env\",container_label_com_docker_compose_service!=\"\"}[$__rate_interval]), \"container\", \"$1\", \"container_label_com_docker_compose_service\", \"(.+)\")) or sum by (container) (label_replace(rate(container_cpu_usage_seconds_total{env=~\"$env\",container_label_com_docker_compose_service=\"\",name!=\"\"}[$__rate_interval]), \"container\", \"$1\", \"name\", \"(.+)\"))",
           "instant": false,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{container}}",
           "range": true,
           "refId": "A"
         }
@@ -273,7 +273,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "cAdvisor is enabled for prod only; an empty dev panel is expected and documented by the dashboard description.",
+      "description": "cAdvisor is enabled for prod only; compose service is preferred, with a name fallback for exporter label compatibility.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -308,9 +308,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (name) (container_memory_working_set_bytes{env=~\"$env\",name!=\"\"})",
+          "expr": "sum by (container) (label_replace(container_memory_working_set_bytes{env=~\"$env\",container_label_com_docker_compose_service!=\"\"}, \"container\", \"$1\", \"container_label_com_docker_compose_service\", \"(.+)\")) or sum by (container) (label_replace(container_memory_working_set_bytes{env=~\"$env\",container_label_com_docker_compose_service=\"\",name!=\"\"}, \"container\", \"$1\", \"name\", \"(.+)\"))",
           "instant": false,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{container}}",
           "range": true,
           "refId": "A"
         }

--- a/ops/grafana/generated/05-observability-pipeline.json
+++ b/ops/grafana/generated/05-observability-pipeline.json
@@ -407,15 +407,82 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANA_CLOUD_USAGE}"
+      },
+      "description": "Grafana Cloud Free plan allows 10,000 active series. This sums grafanacloud_instance_active_series across the usage datasource's id labels; keep below the 70% target (7,000).",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 7000
+              },
+              {
+                "color": "red",
+                "value": 10000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 6,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 32
       },
       "id": 9,
       "options": {
-        "content": "\nThe first 14-day operating window targets **<70% of the Grafana Cloud Free plan limits** before adding more signals. Check Cloud Usage in the Grafana Cloud portal for the authoritative active-series and logs/traces usage numbers.\n\nThis dashboard deliberately does not invent a Cloud Usage metric name or datasource UID.\n",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANA_CLOUD_USAGE}"
+          },
+          "exemplar": true,
+          "expr": "sum(grafanacloud_instance_active_series)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Grafana Cloud active series",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 10,
+      "options": {
+        "content": "\nThe first 14-day operating window targets **<70% of the Grafana Cloud Free plan limits** before adding more signals. The active-series stat uses the selected Grafana Cloud usage datasource and marks the 7,000 target and 10,000 Free plan limit.\n",
         "mode": "markdown"
       },
       "repeatDirection": "h",
@@ -526,6 +593,21 @@
         "refresh": 1,
         "skipUrlSync": false,
         "type": "query"
+      },
+      {
+        "allowCustomValue": true,
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "description": "Grafana Cloud usage is selected at dashboard load; its UID is never committed.",
+        "includeAll": false,
+        "label": "Grafana Cloud usage",
+        "multi": false,
+        "name": "DS_GRAFANA_CLOUD_USAGE",
+        "query": "prometheus",
+        "regex": "/^grafanacloud-usage$/",
+        "skipUrlSync": false,
+        "type": "datasource"
       }
     ]
   },

--- a/ops/grafana/src/index.ts
+++ b/ops/grafana/src/index.ts
@@ -7,10 +7,13 @@ import {
   DashboardBuilder,
   DatasourceVariableBuilder,
   QueryVariableBuilder,
+  ThresholdsConfigBuilder,
+  ThresholdsMode,
   TextBoxVariableBuilder,
   VariableHide,
   VariableRefresh,
   type Panel,
+  type ThresholdsConfig,
   type VariableModel,
 } from "@grafana/grafana-foundation-sdk/dashboard";
 import type { Builder as FoundationBuilder, Dataquery } from "@grafana/grafana-foundation-sdk/cog";
@@ -42,6 +45,19 @@ const CLOUDWATCH: DataSourceRef = {
   type: "cloudwatch",
   uid: "${DS_CLOUDWATCH}",
 };
+const CLOUD_USAGE: DataSourceRef = {
+  type: "prometheus",
+  uid: "${DS_GRAFANA_CLOUD_USAGE}",
+};
+const GRAFANA_CLOUD_LOGS_DATASOURCE_REGEX =
+  "/^grafanacloud-.*-logs$/i";
+const FREE_PLAN_ACTIVE_SERIES_THRESHOLDS = new ThresholdsConfigBuilder()
+  .mode(ThresholdsMode.Absolute)
+  .steps([
+    { value: null, color: "green" },
+    { value: 7000, color: "orange" },
+    { value: 10000, color: "red" },
+  ]);
 
 const ROUTE_EXCLUSIONS =
   "^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$";
@@ -60,11 +76,16 @@ const datasourceVariable = (
   name: string,
   type: string,
   label: string,
+  regex?: string,
 ): Builder<VariableModel> =>
-  new DatasourceVariableBuilder(name)
+  (() => {
+    const builder = new DatasourceVariableBuilder(name)
     .type(type)
     .label(label)
     .description(`${label} is selected at dashboard load; its UID is never committed.`);
+    if (regex) builder.regex(regex);
+    return builder;
+  })();
 
 function queryVariable(
   name: string,
@@ -94,6 +115,7 @@ function dashboardVariables(options: {
   logs?: boolean;
   traces?: boolean;
   cloudwatch?: boolean;
+  cloudUsage?: boolean;
   loadTest?: boolean;
 }): Builder<VariableModel>[] {
   const variables: Builder<VariableModel>[] = [
@@ -127,7 +149,12 @@ function dashboardVariables(options: {
 
   if (options.logs) {
     variables.push(
-      datasourceVariable("DS_LOKI", "loki", "Loki"),
+      datasourceVariable(
+        "DS_LOKI",
+        "loki",
+        "Loki",
+        GRAFANA_CLOUD_LOGS_DATASOURCE_REGEX,
+      ),
       queryVariable(
         "module",
         "Log module",
@@ -160,6 +187,17 @@ function dashboardVariables(options: {
         .description(
           "Required CloudWatch dimension filter. Enter the existing shared RDS DBInstanceIdentifier; panels never search all RDS instances.",
         ),
+    );
+  }
+
+  if (options.cloudUsage) {
+    variables.push(
+      datasourceVariable(
+        "DS_GRAFANA_CLOUD_USAGE",
+        "prometheus",
+        "Grafana Cloud usage",
+        "/^grafanacloud-usage$/",
+      ),
     );
   }
 
@@ -208,11 +246,12 @@ function promQuery(
   refId = "A",
   legendFormat?: string,
   instant = false,
+  datasource: DataSourceRef = PROMETHEUS,
 ): Builder<Dataquery> {
   const query = new PrometheusQuery()
     .refId(refId)
     .expr(expression)
-    .datasource(PROMETHEUS)
+    .datasource(datasource)
     .exemplar(true);
 
   if (legendFormat) {
@@ -241,13 +280,15 @@ function metricPanel(
     span?: number;
     height?: number;
     refId?: string;
+    datasource?: DataSourceRef;
+    thresholds?: Builder<ThresholdsConfig>;
   } = {},
 ): PanelBuilder {
   const Panel = options.stat ? StatPanel : TimeseriesPanel;
   const panel = new Panel()
     .id(id)
     .title(title)
-    .datasource(PROMETHEUS)
+    .datasource(options.datasource ?? PROMETHEUS)
     .span(options.span ?? 12)
     .height(options.height ?? 8)
     .withTarget(
@@ -256,6 +297,7 @@ function metricPanel(
         options.refId ?? "A",
         options.legendFormat,
         options.instant ?? Boolean(options.stat),
+        options.datasource ?? PROMETHEUS,
       ),
     );
 
@@ -264,6 +306,9 @@ function metricPanel(
   }
   if (options.unit) {
     panel.unit(options.unit);
+  }
+  if (options.thresholds) {
+    panel.thresholds(options.thresholds);
   }
 
   return panel;
@@ -281,16 +326,17 @@ function dualMetricPanel(
     secondLegend?: string;
     span?: number;
     height?: number;
+    datasource?: DataSourceRef;
   } = {},
 ): PanelBuilder {
   const panel = new TimeseriesPanel()
     .id(id)
     .title(title)
-    .datasource(PROMETHEUS)
+    .datasource(options.datasource ?? PROMETHEUS)
     .span(options.span ?? 12)
     .height(options.height ?? 8)
-    .withTarget(promQuery(firstExpression, "A", options.firstLegend))
-    .withTarget(promQuery(secondExpression, "B", options.secondLegend));
+    .withTarget(promQuery(firstExpression, "A", options.firstLegend, false, options.datasource ?? PROMETHEUS))
+    .withTarget(promQuery(secondExpression, "B", options.secondLegend, false, options.datasource ?? PROMETHEUS));
 
   if (options.description) {
     panel.description(options.description);
@@ -410,8 +456,8 @@ function addOverviewPanels(builder: DashboardBuilder): void {
       dualMetricPanel(
         3,
         "5xx and 429 rate",
-        `sum(rate(http_server_requests_seconds_count{${HTTP_SELECTOR},status=~"5.."}[$__rate_interval]))`,
-        `sum(rate(http_server_requests_seconds_count{${HTTP_SELECTOR},status="429"}[$__rate_interval]))`,
+        `sum(rate(http_server_requests_seconds_count{${HTTP_SELECTOR},status=~"5.."}[$__rate_interval])) or 0 * sum(rate(http_server_requests_seconds_count{${HTTP_SELECTOR}}[$__rate_interval]))`,
+        `sum(rate(http_server_requests_seconds_count{${HTTP_SELECTOR},status="429"}[$__rate_interval])) or 0 * sum(rate(http_server_requests_seconds_count{${HTTP_SELECTOR}}[$__rate_interval]))`,
         {
           unit: "reqps",
           firstLegend: "5xx",
@@ -602,7 +648,7 @@ function jvmAndHikari(): DashboardBuilder {
       }),
     )
     .withPanel(
-      metricPanel(3, "Allocation rate", `sum by (instance, color) (rate(jvm_memory_allocated_bytes_total{${SERVICE_SELECTOR}}[$__rate_interval]))`, {
+      metricPanel(3, "Allocation rate", `sum by (instance, color) (rate(jvm_gc_memory_allocated_bytes_total{${SERVICE_SELECTOR}}[$__rate_interval]))`, {
         unit: "Bps",
         legendFormat: "{{instance}} {{color}}",
       }),
@@ -643,6 +689,24 @@ function jvmAndHikari(): DashboardBuilder {
 
 const sharedRdsDescription =
   "SHARED RDS — dev load can affect prod. CloudWatch and MySQL exporter cannot separate beatDev and beatProd schemas at the instance level.";
+
+function cadvisorMetric(
+  sample: (selector: string) => string,
+): string {
+  const labeledSeries = (label: string, selector: string): string =>
+    `sum by (container) (label_replace(${sample(selector)}, "container", "$1", "${label}", "(.+)"))`;
+
+  return [
+    labeledSeries(
+      "container_label_com_docker_compose_service",
+      'env=~"$env",container_label_com_docker_compose_service!=""',
+    ),
+    labeledSeries(
+      "name",
+      'env=~"$env",container_label_com_docker_compose_service="",name!=""',
+    ),
+  ].join(" or ");
+}
 
 function sharedRds(): DashboardBuilder {
   const builder = baseDashboard(
@@ -747,18 +811,36 @@ function infrastructure(): DashboardBuilder {
       ),
     )
     .withPanel(
-      metricPanel(5, "Container CPU (prod only)", `sum by (name) (rate(container_cpu_usage_seconds_total{env=~"$env",name!=""}[$__rate_interval]))`, {
+      metricPanel(
+        5,
+        "Container CPU (prod only)",
+        cadvisorMetric(
+          (selector) =>
+            `rate(container_cpu_usage_seconds_total{${selector}}[$__rate_interval])`,
+        ),
+        {
         unit: "percentunit",
-        legendFormat: "{{name}}",
-        description: "cAdvisor is enabled for prod only; an empty dev panel is expected and documented by the dashboard description.",
-      }),
+          legendFormat: "{{container}}",
+          description:
+            "cAdvisor is enabled for prod only; compose service is preferred, with a name fallback for exporter label compatibility.",
+        },
+      ),
     )
     .withPanel(
-      metricPanel(6, "Container memory (prod only)", `sum by (name) (container_memory_working_set_bytes{env=~"$env",name!=""})`, {
-        unit: "bytes",
-        legendFormat: "{{name}}",
-        description: "cAdvisor is enabled for prod only; an empty dev panel is expected and documented by the dashboard description.",
-      }),
+      metricPanel(
+        6,
+        "Container memory (prod only)",
+        cadvisorMetric(
+          (selector) =>
+            `container_memory_working_set_bytes{${selector}}`,
+        ),
+        {
+          unit: "bytes",
+          legendFormat: "{{container}}",
+          description:
+            "cAdvisor is enabled for prod only; compose service is preferred, with a name fallback for exporter label compatibility.",
+        },
+      ),
     )
     .withPanel(
       metricPanel(7, "Redis up", `redis_up{env=~"$env"}`, {
@@ -797,7 +879,7 @@ function pipeline(): DashboardBuilder {
     "05 Observability Pipeline",
     "beat-observability-pipeline",
     "Alloy self-monitoring, scrape health, and remote-write pipeline pressure. Cloud usage is tracked against the Free plan outside the data plane.",
-    { defaultEnvironment: "prod" },
+    { defaultEnvironment: "prod", cloudUsage: true },
   );
 
   return builder
@@ -852,13 +934,27 @@ function pipeline(): DashboardBuilder {
       }),
     )
     .withPanel(
-      textPanel(
+      metricPanel(
         9,
+        "Grafana Cloud active series",
+        "sum(grafanacloud_instance_active_series)",
+        {
+          datasource: CLOUD_USAGE,
+          span: 24,
+          unit: "short",
+          stat: true,
+          thresholds: FREE_PLAN_ACTIVE_SERIES_THRESHOLDS,
+          description:
+            "Grafana Cloud Free plan allows 10,000 active series. This sums grafanacloud_instance_active_series across the usage datasource's id labels; keep below the 70% target (7,000).",
+        },
+      ),
+    )
+    .withPanel(
+      textPanel(
+        10,
         "Free plan guardrail",
         `
-The first 14-day operating window targets **<70% of the Grafana Cloud Free plan limits** before adding more signals. Check Cloud Usage in the Grafana Cloud portal for the authoritative active-series and logs/traces usage numbers.
-
-This dashboard deliberately does not invent a Cloud Usage metric name or datasource UID.
+The first 14-day operating window targets **<70% of the Grafana Cloud Free plan limits** before adding more signals. The active-series stat uses the selected Grafana Cloud usage datasource and marks the 7,000 target and 10,000 Free plan limit.
 `,
       ),
     );

--- a/support/observability/src/main/resources/application-observability.yml
+++ b/support/observability/src/main/resources/application-observability.yml
@@ -31,9 +31,12 @@ management:
       env: ${spring.profiles.active:unknown}
     distribution:
       percentiles-histogram:
-        http.server.requests: true
+        # Keep aggregatable Prometheus p95/p99 through explicit SLO buckets only;
+        # disabling percentile histograms avoids Micrometer's default ~73 buckets.
+        http.server.requests: false
       slo:
-        http.server.requests: 100ms, 200ms, 500ms, 1s, 2s
+        # Existing API SLOs plus contention-test tail boundaries through the 35s timeout.
+        http.server.requests: 100ms, 200ms, 500ms, 1s, 2s, 5s, 10s, 20s, 30s, 35s
 
   tracing:
     export:


### PR DESCRIPTION
## Related issue 🛠

- closes #604

## Work Description ✏️

- Micrometer의 기본 percentile histogram을 비활성화하고 명시적 SLO bucket 10개로 HTTP histogram cardinality를 제한했습니다.
- Alloy가 의도한 10s/20s/30s/35s tail bucket을 보존하도록 relabel rule을 맞췄습니다.
- Grafana Cloud Logs datasource만 선택하도록 Loki variable을 제한했습니다.
- 5xx/429를 base request telemetry에 고정해 정상적인 0과 수집 부재를 구분했습니다.
- JVM allocation metric과 cAdvisor container label fallback을 현재 metric 계약에 맞췄습니다.
- Observability Pipeline에 Grafana Cloud active series와 Free plan 70%/100% threshold를 추가했습니다.
- Foundation SDK 원본에서 dashboard JSON을 결정적으로 재생성했습니다.

## Trouble Shooting ⚽️

- 단순 `or vector(0)`는 telemetry 자체가 없을 때도 정상 0으로 보이므로 base request rate에 0을 곱해 fallback을 고정했습니다.
- cAdvisor `id` fallback은 root/system cgroup을 container로 오인할 수 있어 compose service와 name만 사용합니다.
- 기존 Alloy relabel rule이 10s/30s bucket을 제거하던 문제를 Micrometer SLO bucket과 함께 정합화했습니다.

## Related ScreenShot 📷

- N/A — Git Sync 반영 후 Grafana Cloud에서 live panel을 검증합니다.

## Uncompleted Tasks 😅

- merge/deploy 후 active series가 7,000 이하인지 Grafana Cloud에서 확인
- 실제 datasource에서 Loki, container, active-series panel 확인
- Docker daemon을 사용할 수 있는 환경에서 최종 `alloy validate` 실행

## To Reviewers 📢

검증 완료:

- `npm run typecheck`
- `npm run check:generated`
- `./gradlew --no-daemon :support:observability:check`
- `SKIP_ALLOY_IMAGE_VALIDATION=1 ./scripts/verify-alloy-config.sh`
- `git diff --check`

Sol Medium 재리뷰에서 Critical/Major/Minor 없이 승인됐으며, 최종 root 리뷰도 완료했습니다.