### PR TITLE
fix: Grafana recording rule SOPS 경로 수정

### DIFF
--- a/.github/workflows/grafana-as-code.yml
+++ b/.github/workflows/grafana-as-code.yml
@@ -117,8 +117,8 @@ jobs:
             exit 1
           }
           secrets_file="ops/ansible/inventories/prod/group_vars/all/secrets.sops.yml"
-          remote_write_url="$(sops --decrypt --extract '[\"gc_prom_url\"]' "$secrets_file")"
-          mimir_user="$(sops --decrypt --extract '[\"gc_prom_user\"]' "$secrets_file")"
+          remote_write_url="$(sops --decrypt --extract '["gc_prom_url"]' "$secrets_file")"
+          mimir_user="$(sops --decrypt --extract '["gc_prom_user"]' "$secrets_file")"
           {
             echo "MIMIR_ADDRESS=${remote_write_url%/api/prom/push}"
             echo "MIMIR_API_USER=$mimir_user"


### PR DESCRIPTION
## Related issue 🛠

- closes #612
- relates to #608

## Work Description ✏️

- Grafana as code workflow의 SOPS `--extract` 경로에서 불필요한 역슬래시를 제거했습니다.
- `gc_prom_url`, `gc_prom_user`를 실제 prod SOPS 파일에서 추출해 성공 여부를 검증했습니다.

## Trouble Shooting ⚽️

- 실패 job의 토큰은 정상 주입됐습니다.
- `sops`가 `[^"gc_prom_url"]` 형태의 이스케이프된 경로를 문자열 키가 아닌 숫자 인덱스로 해석해 종료 코드 91이 발생했습니다.

## Related ScreenShot 📷

- N/A

## Uncompleted Tasks 😅

- develop 머지 후 `grafana-as-code` workflow 성공 및 recording rule 반영 확인

## To Reviewers 📢

- workflow 변경은 SOPS extract 경로 2줄로 제한했습니다.