### PR TITLE
fix: percentunit 패널 y축 0-1 고정

### DIFF
--- a/ops/grafana/generated/00-system-overview.json
+++ b/ops/grafana/generated/00-system-overview.json
@@ -240,6 +240,8 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/ops/grafana/generated/02-jvm-hikari.json
+++ b/ops/grafana/generated/02-jvm-hikari.json
@@ -264,6 +264,8 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/ops/grafana/generated/03-shared-rds-mysql.json
+++ b/ops/grafana/generated/03-shared-rds-mysql.json
@@ -550,6 +550,8 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/ops/grafana/generated/04-infrastructure.json
+++ b/ops/grafana/generated/04-infrastructure.json
@@ -226,6 +226,8 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/ops/grafana/generated/90-load-test.json
+++ b/ops/grafana/generated/90-load-test.json
@@ -293,6 +293,8 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/ops/grafana/src/index.ts
+++ b/ops/grafana/src/index.ts
@@ -354,6 +354,10 @@ function metricPanel(
     panel.thresholds(options.thresholds);
   } else if (options.unit === "percentunit") {
     panel.thresholds(PERCENT_UNIT_THRESHOLDS);
+    // Ratios cannot exceed 1. This also pins the y-axis to 0-100% when the
+    // series are all zero, where autoscale would otherwise fall back to a
+    // default raw max (rendered as 10000%).
+    panel.min(0).max(1);
   }
 
   return panel;


### PR DESCRIPTION
값이 전부 0이면 autoscale이 raw 기본 max로 폴백되어 10000%로 렌더링됨 (Hikari dev). 비율 패널은 min 0, max 1로 고정. threshold 0.8 유지.