### PR TITLE
feat: shared RDS MySQL exporter 활성화

### DIFF
--- a/ops/ansible/inventories/prod/group_vars/all/main.yml
+++ b/ops/ansible/inventories/prod/group_vars/all/main.yml
@@ -92,6 +92,8 @@ observability_alloy_wal_truncate: "12h"
 observability_alloy_enable_logs: true
 observability_alloy_enable_traces: true
 observability_alloy_enable_cadvisor: true
+observability_alloy_shared_mysql_enabled: true
+observability_alloy_shared_mysql_read_only: true
 observability_alloy_published_ports:
   - "127.0.0.1:12345:12345"
   - "127.0.0.1:4317:4317"

--- a/ops/ansible/inventories/prod/group_vars/all/secrets.sops.yml
+++ b/ops/ansible/inventories/prod/group_vars/all/secrets.sops.yml
@@ -25,6 +25,7 @@ image_cdn_acm_cert_arn: ENC[AES256_GCM,data:vEU3obHtEGw6hnm4Tywsskzf14oydGRNoqaH
 image_cdn_source_bucket: ENC[AES256_GCM,data:vc+oTWq3wxTxzKXy87rT3VLveTMEF+RPYJ+U3IfnDBChIOa0QYu87mbN4C8uguwc,iv:HLxNFCdCU0sy6CokzRIxlhn3UwcvtYSpR8bVpwKf0lU=,tag:aAjQW4OqXHl3bGMcIIj3jA==,type:str]
 image_cdn_lambda_code_bucket: ENC[AES256_GCM,data:IV2yv9l0myycrPy6FOQN+Ygh7o1Fg1TuCmgbs0JacDKFw67AhOYiXt0pVpYTXNA0DA==,iv:Og8cRX5z+FcMocpjCJv9nHJy4J+HzQRw10Kgs3bF9aw=,tag:K8Cvk6AUyQZbncAjgZ37xA==,type:str]
 image_cdn_transformed_bucket_name: ENC[AES256_GCM,data:82qLvSSBE1fmIn1CYe2Aa4z9JVXIhCvjjtd6HVxtQQ==,iv:gNKzFmvCP5qoxfEts8xKkpyOrP+2LtMO0+Zb0uQ37BE=,tag:aBFuX2TZshjnwGNyb2n5BA==,type:str]
+observability_alloy_shared_mysql_dsn: ENC[AES256_GCM,data:e2r8nZLyaWXEqhevUAXcs3SjFJ0SgngumG/sZfrzAXAJx9kCK+kr4J93ackp22yApZx5YNLkmLB30NAg0xbwI7fmFaK88glfI4kdvWMy8B/vp0h6zZh1pEKNvgdI/IbdUvvP9w7bq8L6y6d/f3aqvimll+T6CJh91jNNltjhLtXPcS53D5WNYk0=,iv:7y5ycp8bI99NYfVTeb+IEeuHqi3PXuFOeOtmoCNy28A=,tag:4omiSAkl8yotUZV+UkLcIg==,type:str]
 sops:
     age:
         - recipient: age10ku4fy9jalda7pkqwmgnywjnmeqdknv0fkt5a7dgs5egk9xf7atsa6vnpa
@@ -54,7 +55,7 @@ sops:
             aU5yYWsxbmJNVGhqWk4wTllaUWE4M2sKacdVvsLDjkl2c8TxIp7XileSS2EiGh2t
             FPl1QzCI3WlhI/CVJARSZXdEvJo4mxEJXH44vW/cIXB2f2lc1tss6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-08-30T12:56:41Z"
-    mac: ENC[AES256_GCM,data:GA4BS2NYAApl4wSE1xNMjPDRis9fXshSVqwOdF/aiaBLa4KUj/Kl3sJfE9QM4ZaSh+9CLQ8h0oMwTJ/QoAL7t6WK39v4XzcJhgYCYbUFzOH10oh4fjL6TBVZYTrKGPwg363ZbkLTopcLJVUnAHv33mwd4T+vvBXQbbgUrXHPm0w=,iv:h0j+r+ApmX8pw8yGNGwAcaYS60mR08++tYNWCKprxtM=,tag:uOtv4XpQGb9MtMO0dA6cFQ==,type:str]
+    lastmodified: "2026-09-08T15:35:53Z"
+    mac: ENC[AES256_GCM,data:6nEmGZ34hlwZPSouvcYob9koasC7kJllBvD04R9Ak5V44Vwy23Fe/sEv6taMYgiJtbsZ+Oyrx+UYayri7SiwS0imDia42yRubiXMNnTovdN0os4Q82PuMeJAdzT6JcsFK/6BNpwYmyLovS29+nXSnzcUqmfjTqBex1/D5zU7Vos=,iv:i5XIl0k6EEa1Qe7v2tVPTZiIox8KSrTqZrMfZOcgvXE=,tag:PxIRcyRwlfP9x8OiERgwDA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Related issue 🛠

- relates to #606

## Work Description ✏️

- shared RDS 전용 beat_monitor DSN을 prod SOPS inventory에 암호화해 추가했습니다.
- prod에서 shared MySQL exporter와 read-only 검증 게이트를 활성화했습니다.
- 기존 exporter 설정의 env=shared, scope=beat-shared-rds 라벨 및 제한된 collector 구성을 사용합니다.

## Trouble Shooting ⚽️

- 기본 AWS CLI 계정에서 대상 RDS를 찾을 수 없어, prod SOPS의 기존 JDBC URL에서 동일 RDS endpoint를 안전하게 추출해 DSN을 구성했습니다.
- 로컬 Alloy Docker validate는 Docker 엔진이 컨테이너 시작 단계에서 멈춰 완료하지 못했습니다. Ansible 렌더링·inventory·syntax-check·lint는 통과했으며, alloy-config CI로 최종 파싱을 확인합니다.

## Related ScreenShot 📷

- 해당 없음

## Uncompleted Tasks 😅

- develop 반영 후 main 릴리즈 및 deploy-observability-prod 실행
- 배포 후 mysql_up == 1, MySQL 지표 수신, 03·90 대시보드 확인

## To Reviewers 📢

- DSN 평문은 저장소와 PR 본문에 노출되지 않으며 SOPS 암호문만 커밋했습니다.
- 이 PR은 #606의 MySQL exporter 활성화 부분이며, 운영 배포 검증 전까지 이슈를 자동 종료하지 않습니다.