### PR TITLE
fix: 의존성 보안 자동화 및 이미지 스캔 게이트 보완

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -245,12 +245,31 @@ jobs:
           trivy-config: .trivy-image.yaml
 
   verify:
-    needs: [openapi, gradle-check, sonar]
+    if: ${{ !cancelled() }}
+    needs: [openapi, gradle-check, sonar, scan-images]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
 
     steps:
       - name: Confirm required checks passed
-        run: echo "Required CI checks passed"
+        env:
+          OPENAPI_RESULT: ${{ needs.openapi.result }}
+          GRADLE_CHECK_RESULT: ${{ needs.gradle-check.result }}
+          SONAR_RESULT: ${{ needs.sonar.result }}
+          SCAN_IMAGES_RESULT: ${{ needs.scan-images.result }}
+        run: |
+          results=(
+            "openapi=${OPENAPI_RESULT}"
+            "gradle-check=${GRADLE_CHECK_RESULT}"
+            "sonar=${SONAR_RESULT}"
+            "scan-images=${SCAN_IMAGES_RESULT}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "${result#*=}" != "success" ]]; then
+              echo "Required CI check did not pass: ${result}" >&2
+              exit 1
+            fi
+          done
+          echo "Required CI checks passed"
         shell: bash

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -148,6 +148,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    outputs:
+      analysis-result: ${{ steps.sonar-analysis.outcome }}
     # secrets는 if: 조건식에서 직접 참조할 수 없다(GitHub 공식 문서).
     # job-level env로 승격 후 env 컨텍스트로 검사한다.
     env:
@@ -184,6 +186,7 @@ jobs:
           path: .
 
       - name: SonarQube Cloud Analysis (Kover coverage, JDK 25)
+        id: sonar-analysis
         if: ${{ env.SONAR_TOKEN != '' }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -257,6 +260,7 @@ jobs:
           OPENAPI_RESULT: ${{ needs.openapi.result }}
           GRADLE_CHECK_RESULT: ${{ needs.gradle-check.result }}
           SONAR_RESULT: ${{ needs.sonar.result }}
+          SONAR_ANALYSIS_RESULT: ${{ needs.sonar.outputs.analysis-result }}
           SCAN_IMAGES_RESULT: ${{ needs.scan-images.result }}
         run: |
           results=(
@@ -271,5 +275,17 @@ jobs:
               exit 1
             fi
           done
+
+          case "${SONAR_ANALYSIS_RESULT}" in
+            success)
+              ;;
+            skipped)
+              echo "Sonar analysis skipped because SONAR_TOKEN is unavailable"
+              ;;
+            *)
+              echo "Sonar analysis did not complete: ${SONAR_ANALYSIS_RESULT}" >&2
+              exit 1
+              ;;
+          esac
           echo "Required CI checks passed"
         shell: bash

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 25
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "25"
           distribution: "temurin"
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 25
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "25"
           distribution: "temurin"
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 25
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "25"
           distribution: "temurin"
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "25"
           distribution: "temurin"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - main
-  workflow_dispatch:
 
 jobs:
   dependency-submission:
@@ -16,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 25
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 25
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "25"
           distribution: "temurin"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,30 @@
+name: dependency-submission
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+          dependency-graph: generate-and-submit

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -190,7 +190,7 @@ jobs:
         with:
           ref: ${{ needs.resolve-ref.outputs.commit_sha }}
 
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "25"
           distribution: "temurin"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           ref: ${{ needs.resolve-release.outputs.commit_sha }}
 
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "25"
           distribution: "temurin"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=768m
 
 org.gradle.parallel=true
 org.gradle.caching=true
+
+# Spring Boot 4.0.8 manages Tomcat 11.0.24; use the security-fixed 11.0.25 patch.
+tomcat.version=11.0.25

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["dockerfile"],
+  "enabledManagers": ["gradle", "gradle-wrapper", "dockerfile", "github-actions"],
   "vulnerabilityAlerts": {
     "enabled": false
   },


### PR DESCRIPTION
## Related issue 🛠

- closes #617

## Work Description ✏️

- Renovate 일반 업데이트 범위를 Gradle, Gradle Wrapper, Dockerfile, GitHub Actions로 확장했습니다.
- Renovate 보안 PR은 계속 비활성화하여 Dependabot Security Updates와 역할 중복을 막았습니다.
- develop/main의 Gradle 직접·전이 의존성을 GitHub Dependency Graph에 제출하는 workflow를 추가했습니다.
- Spring Boot 4.0.8의 Tomcat 11.0.24를 보안 수정 버전 11.0.25로 override했습니다.
- ci-pr의 최종 verify가 apis/admin/batch Trivy image scan 성공을 필수로 요구하도록 변경했습니다.
- actions/setup-java 7개 사용처를 v6.0.0 immutable SHA로 통일했습니다.

## Trouble Shooting ⚽️

- Gradle 전이 의존성은 manifest 정적 분석만으로 Dependabot 가시성이 부족해 build-time dependency submission을 사용했습니다.
- scan-images 실패 뒤 verify가 skip되어 성공 체크처럼 오해되지 않도록, 취소가 아닌 경우 항상 실행하고 모든 needs 결과를 명시적으로 검사합니다.

## Related ScreenShot 📷

- 해당 없음

## Uncompleted Tasks 😅

- Dependency Graph 제출 및 Dependabot의 Gradle 전이 의존성 인식은 이 workflow가 develop에 병합되어 최초 실행된 뒤 확인합니다.
- branch protection의 required check 지정은 저장소 설정에서 별도로 확인합니다.

## To Reviewers 📢

- Tomcat core/websocket의 api/admin/batch runtime classpath 및 bootJar가 모두 11.0.25임을 확인했습니다.
- setup-java v6.0.0이 적용된 PR CI에서 Gradle check, OpenAPI, Sonar, apis/admin/batch Trivy scan, 최종 verify가 모두 통과했습니다.
- actionlint, Renovate config validator, git diff check를 통과했습니다.
