### PR TITLE
fix: Dependabot 보안 업데이트 책임 복원

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "enabledManagers": ["gradle", "gradle-wrapper", "dockerfile", "github-actions"],
   "vulnerabilityAlerts": {
-    "enabled": true
+    "enabled": false
   },
   "packageRules": [
     {


### PR DESCRIPTION
## 변경 사항
- Renovate vulnerability alert remediation을 비활성화
- Dependabot Security Updates를 GitHub 설정에서 다시 활성화

## 책임 분리
- Dependabot: Alerts + 보안 수정 PR
- Renovate: 일반 의존성 업데이트

#621은 sharp high alert를 해결하는 Dependabot 보안 PR이며 이 구성을 검증하는 정상 사례입니다.

## 검증
- `jq empty renovate.json`
- `git diff --check`