### PR TITLE
ci: main dependency snapshot bootstrap 지원

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+  workflow_dispatch:
 
 jobs:
   dependency-submission:


### PR DESCRIPTION
## 목적

`main`의 resolved dependency snapshot을 수동 제출할 수 있게 합니다. release PR의 Dependency Review가 base graph 없이 전체 의존성을 신규로 판정하는 bootstrap 문제를 해소합니다.

## 변경

- `dependency-submission`에 `workflow_dispatch` trigger 추가
- 기존 push 기반 develop/main graph 제출 동작은 유지
- 애플리케이션·Alloy runtime 변경 없음

## 후속

병합 후 `main` ref로 workflow를 한 번 실행해 기준 snapshot을 생성하고, #630 CI를 재실행합니다.