### PR TITLE
ci: bootstrap main dependency snapshot

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,33 @@
+name: dependency-submission
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+          dependency-graph: generate-and-submit
+          dependency-graph-include-configurations: "^runtimeClasspath$"


### PR DESCRIPTION
## 목적

현재 `main`에는 `dependency-submission` workflow 자체가 없어 build-time resolved dependency snapshot이 없습니다. 이 때문에 release PR #630의 Dependency Review가 기준 graph 없이 develop 전체를 신규 의존성으로 비교합니다.

## 변경

- main에 `dependency-submission` workflow를 추가
- `main` push와 수동 실행에서 Gradle `runtimeClasspath` graph 제출
- 병합 push가 현재 main SHA의 기준 snapshot을 자동 생성

## 영향

- 애플리케이션, Alloy, DB, Lambda 배포 변경 없음
- GitHub Dependency Graph 기준선만 생성

병합 후 #630 CI를 재실행합니다.