### PR TITLE
fix: Alloy metric cardinality budget 축소

### DIFF
--- a/ops/ansible/roles/observability_alloy/templates/config.alloy.j2
+++ b/ops/ansible/roles/observability_alloy/templates/config.alloy.j2
@@ -92,10 +92,22 @@ prometheus.exporter.cadvisor "containers" {
   allowlisted_container_labels = ["com.docker.compose.service"]
 }
 
+// 부하 실험에는 컨테이너별 CPU·메모리와 scrape 상태만 필요하다.
+// 다른 scrape job에 영향을 주지 않도록 cAdvisor 전용 allowlist로 제한한다.
+prometheus.relabel "cadvisor_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex         = "^(up|container_cpu_usage_seconds_total|container_memory_working_set_bytes)$"
+    action        = "keep"
+  }
+
+  forward_to = [prometheus.relabel.cleanup.receiver]
+}
+
 prometheus.scrape "containers" {
   targets         = prometheus.exporter.cadvisor.containers.targets
   scrape_interval = "{{ observability_alloy_scrape_interval }}"
-  forward_to      = [prometheus.relabel.cleanup.receiver]
+  forward_to      = [prometheus.relabel.cadvisor_metrics.receiver]
 }
 {% endif %}
 
@@ -126,9 +138,6 @@ prometheus.exporter.mysql "shared_rds" {
   data_source_name = local.file.shared_mysql_dsn.content
   set_collectors = [
     "global_status",
-    "global_variables",
-    "info_schema.innodb_metrics",
-    "engine_innodb_status",
   ]
   lock_wait_timeout = 2
 }

--- a/scripts/verify-alloy-config.sh
+++ b/scripts/verify-alloy-config.sh
@@ -61,9 +61,11 @@ for environment in dev prod; do
   if [[ "$environment" == "dev" ]]; then
     enable_cadvisor=true
     enable_k6=true
+    enable_shared_mysql=false
   else
     enable_cadvisor=true
     enable_k6=false
+    enable_shared_mysql=true
   fi
 
   ansible-playbook -i 'localhost,' "$render_playbook" \
@@ -74,12 +76,16 @@ for environment in dev prod; do
     -e "observability_alloy_enable_logs=true" \
     -e "observability_alloy_enable_traces=true" \
     -e "observability_alloy_enable_cadvisor=$enable_cadvisor" \
+    -e "observability_alloy_shared_mysql_enabled=$enable_shared_mysql" \
     -e "observability_alloy_enable_k6_metrics=$enable_k6"
 
   grep -q 'prometheus.exporter.self "alloy"' "$output_path"
   grep -q 'prometheus.exporter.redis "redis"' "$output_path"
   grep -q 'prometheus.exporter.cadvisor "containers"' "$output_path"
   grep -Fq 'allowlisted_container_labels = ["com.docker.compose.service"]' "$output_path"
+  grep -q 'prometheus.relabel "cadvisor_metrics"' "$output_path"
+  grep -Fq 'regex         = "^(up|container_cpu_usage_seconds_total|container_memory_working_set_bytes)$"' "$output_path"
+  grep -Fq 'forward_to      = [prometheus.relabel.cadvisor_metrics.receiver]' "$output_path"
   grep -q 'otelcol.processor.memory_limiter "apps"' "$output_path"
   if [[ "$environment" == "dev" ]] && ! grep -q 'otelcol.processor.memory_limiter "k6"' "$output_path"; then
     echo "dev config is missing the k6 memory limiter" >&2
@@ -116,6 +122,17 @@ for environment in dev prod; do
     echo "prod config unexpectedly enables the k6 OTLP receiver" >&2
     exit 1
   fi
+  if [[ "$environment" == "prod" ]]; then
+    grep -q 'prometheus.exporter.mysql "shared_rds"' "$output_path"
+    grep -Fq '    "global_status",' "$output_path"
+    if grep -Eq 'global_variables|info_schema\.innodb_metrics|engine_innodb_status' "$output_path"; then
+      echo "prod config enables an unexpected MySQL collector" >&2
+      exit 1
+    fi
+  elif grep -q 'prometheus.exporter.mysql "shared_rds"' "$output_path"; then
+    echo "dev config unexpectedly enables the shared MySQL exporter" >&2
+    exit 1
+  fi
 done
 
 if [[ "$skip_image_validation" == "1" ]]; then
@@ -126,7 +143,7 @@ fi
 for environment in dev prod; do
   secret_dir="$work_dir/secrets-$environment"
   mkdir -m 700 "$secret_dir"
-  for secret_name in gc_token gc_prom_user gc_loki_user gc_tempo_user redis_password; do
+  for secret_name in gc_token gc_prom_user gc_loki_user gc_tempo_user redis_password shared_mysql_dsn; do
     printf '%s\n' "synthetic-$secret_name" >"$secret_dir/$secret_name"
     chmod 600 "$secret_dir/$secret_name"
   done


### PR DESCRIPTION
## 변경
- dev/prod cAdvisor remote-write를 `up`, container CPU, working-set memory로 제한
- shared RDS MySQL collector를 대시보드/부하실험에 필요한 `global_status`로 제한
- dev/prod 렌더 검증에 cAdvisor relabel 체인과 prod MySQL collector 회귀 검사 추가

## 관측 계약
- 유지: 컨테이너 CPU/메모리, scrape up, JVM/Hikari, k6, node exporter, CloudWatch RDS, MySQL global status
- 제외: 현재 대시보드와 부하실험이 사용하지 않는 cAdvisor filesystem/network/task 계열 및 MySQL variables/innodb collector
- WAL 파일은 변경하거나 삭제하지 않음

## 검증
- `SKIP_ALLOY_IMAGE_VALIDATION=1 bash scripts/verify-alloy-config.sh`
- `cd ops/ansible && ansible-lint playbooks/observability.yml`
- `bash -n scripts/verify-alloy-config.sh`

## 배포 순서
CI 통과 후 dev Alloy → 지표 확인 → prod Alloy → 15~30분 drain/stale 관찰