### PR TITLE
feat: 선착순 예매 부하 실험 관측 고도화

### DIFF
--- a/application/frontoffice/src/main/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentService.kt
+++ b/application/frontoffice/src/main/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentService.kt
@@ -79,13 +79,14 @@ class StockContentionExperimentService(
         validateBookerContact(command.bookerName, command.bookerPhoneNumber)
         validatePurchaseTicketCount(command.purchaseTicketCount)
 
+        val prepared = prepareBooking(memberId, command)
         val selectedStrategy = strategyRegistry.get(strategy)
         return try {
             selectedStrategy.executeWithReservationLock(command.scheduleId) {
                 if (strategy == StockContentionStrategy.OPTIMISTIC) {
-                    createWithOptimisticRetry(memberId, command, selectedStrategy)
+                    createWithOptimisticRetry(prepared, command, selectedStrategy)
                 } else {
-                    executeAttempt(memberId, command, selectedStrategy, 1)
+                    executeReservationAttempt(prepared, command, selectedStrategy, 1)
                 }
             }
         } catch (_: StockContentionLockTimeout) {
@@ -103,14 +104,46 @@ class StockContentionExperimentService(
         }
     }
 
-    private fun createWithOptimisticRetry(
+    private fun prepareBooking(
         memberId: Long,
+        command: StockContentionBookingCommand,
+    ): PreparedStockContentionBooking {
+        val member =
+            memberRepository.findById(memberId)
+                ?: throw FrontofficeApplicationException(
+                    BookingApplicationErrorCode.MEMBER_NOT_FOUND
+                )
+        val scheduleMetadata =
+            scheduleStore.findBookingMetadataById(command.scheduleId)
+                ?: throw FrontofficeApplicationException(
+                    BookingApplicationErrorCode.SCHEDULE_NOT_FOUND
+                )
+        if (!scheduleMetadata.bookingOpen) {
+            throw FrontofficeApplicationException(BookingApplicationErrorCode.BOOKING_CLOSED)
+        }
+        val performance =
+            // Common validation must not serialize requests on the performance row. The selected
+            // schedule strategy is the only contention mechanism in this experiment.
+            performanceRepository.findById(scheduleMetadata.performanceId)
+                ?: throw FrontofficeApplicationException(
+                    BookingApplicationErrorCode.PERFORMANCE_NOT_FOUND
+                )
+        return PreparedStockContentionBooking(
+            userId = member.userId,
+            performanceId = scheduleMetadata.performanceId,
+            totalPaymentAmount =
+                calculatePaymentAmount(performance.ticketPrice, command.purchaseTicketCount),
+        )
+    }
+
+    private fun createWithOptimisticRetry(
+        prepared: PreparedStockContentionBooking,
         command: StockContentionBookingCommand,
         strategy: StockContentionReservationStrategy,
     ): StockContentionExperimentResponse {
         for (attempt in 1..optimisticAttemptLimit) {
             try {
-                return executeAttempt(memberId, command, strategy, attempt)
+                return executeReservationAttempt(prepared, command, strategy, attempt)
             } catch (_: OptimisticReservationConflict) {
                 if (attempt == optimisticAttemptLimit) {
                     return StockContentionExperimentResponse(
@@ -132,43 +165,19 @@ class StockContentionExperimentService(
         error("Optimistic retry loop did not execute")
     }
 
-    private fun executeAttempt(
-        memberId: Long,
+    private fun executeReservationAttempt(
+        prepared: PreparedStockContentionBooking,
         command: StockContentionBookingCommand,
         strategy: StockContentionReservationStrategy,
         attempt: Int,
     ): StockContentionExperimentResponse =
         checkNotNull(
             transactionTemplate.execute {
-                val member =
-                    memberRepository.findById(memberId)
-                        ?: throw FrontofficeApplicationException(
-                            BookingApplicationErrorCode.MEMBER_NOT_FOUND
-                        )
-                val scheduleMetadata =
-                    scheduleStore.findBookingMetadataById(command.scheduleId)
-                        ?: throw FrontofficeApplicationException(
-                            BookingApplicationErrorCode.SCHEDULE_NOT_FOUND
-                        )
-                if (!scheduleMetadata.bookingOpen) {
-                    throw FrontofficeApplicationException(
-                        BookingApplicationErrorCode.BOOKING_CLOSED
-                    )
-                }
-                val performanceId = scheduleMetadata.performanceId
-                val performance =
-                    // Common validation must not serialize requests on the performance row. The
-                    // selected schedule strategy is the only contention mechanism in this
-                    // experiment.
-                    performanceRepository.findById(performanceId)
-                        ?: throw FrontofficeApplicationException(
-                            BookingApplicationErrorCode.PERFORMANCE_NOT_FOUND
-                        )
                 val reservation =
                     strategy.reserve(
                         StockReservationRequest(
                             scheduleId = command.scheduleId,
-                            performanceId = performanceId,
+                            performanceId = prepared.performanceId,
                             purchaseTicketCount = command.purchaseTicketCount,
                         )
                     )
@@ -179,9 +188,6 @@ class StockContentionExperimentService(
                         attemptCount = attempt,
                     )
                 }
-
-                val totalPaymentAmount =
-                    calculatePaymentAmount(performance.ticketPrice, command.purchaseTicketCount)
                 val booking =
                     Booking.create(
                         purchaseTicketCount = command.purchaseTicketCount,
@@ -190,9 +196,9 @@ class StockContentionExperimentService(
                         birthDate = null,
                         password = null,
                         scheduleId = command.scheduleId,
-                        userId = member.userId,
+                        userId = prepared.userId,
                         createdAt = LocalDateTime.now(clock),
-                        totalPaymentAmount = totalPaymentAmount,
+                        totalPaymentAmount = prepared.totalPaymentAmount,
                     )
                 val savedBooking = bookingRepository.save(booking)
                 StockContentionExperimentResponse(
@@ -210,6 +216,12 @@ class StockContentionExperimentService(
             )
         }
     }
+
+    private data class PreparedStockContentionBooking(
+        val userId: Long,
+        val performanceId: Long,
+        val totalPaymentAmount: Int,
+    )
 
     private fun validatePurchaseTicketCount(ticketCount: Int) {
         if (ticketCount !in MIN_PURCHASE_TICKET_COUNT..MAX_PURCHASE_TICKET_COUNT) {

--- a/application/frontoffice/src/test/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentServiceSpec.kt
+++ b/application/frontoffice/src/test/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentServiceSpec.kt
@@ -82,22 +82,7 @@ class StockContentionExperimentServiceSpec : FunSpec() {
                     bookingOpen = true,
                     version = null,
                 )
-            val savedBooking =
-                Booking.rehydrate(
-                    id = 99L,
-                    purchaseTicketCount = 1,
-                    bookerName = "홍길동",
-                    bookerPhoneNumber = "010-1234-5678",
-                    bookingStatus = com.beat.domain.booking.model.BookingStatus.CHECKING_PAYMENT,
-                    createdAt = LocalDateTime.of(2026, 8, 23, 9, 0),
-                    cancellationDate = null,
-                    birthDate = null,
-                    password = null,
-                    refundAccount = null,
-                    scheduleId = 10L,
-                    userId = 30L,
-                    totalPaymentAmount = 100,
-                )
+            val savedBooking = savedBooking()
             val reservationStrategy = AcceptingReservationStrategy()
 
             every { transactionManager.getTransaction(any()) } returns transactionStatus
@@ -198,6 +183,112 @@ class StockContentionExperimentServiceSpec : FunSpec() {
             verify(exactly = 0) { performanceRepository.findById(any()) }
             verify(exactly = 0) { scheduleStore.find(any(), any(), any()) }
         }
+
+        test("Redis lock은 공통 조회가 끝난 뒤 transaction과 reservation을 감싼다") {
+            val strategyRegistry = mockk<StockContentionStrategyRegistry>()
+            val memberRepository = mockk<MemberRepository>()
+            val performanceRepository = mockk<PerformanceRepository>()
+            val bookingRepository = mockk<BookingRepository>()
+            val scheduleStore = mockk<StockContentionScheduleStore>()
+            val transactionManager = mockk<PlatformTransactionManager>(relaxed = true)
+            val transactionStatus = mockk<TransactionStatus>(relaxed = true)
+            val member = mockk<Member>()
+            val performance = mockk<com.beat.domain.performance.model.Performance>()
+            var lockEntered = false
+            var reservationInsideLock = false
+            var commitCompletedBeforeUnlock = false
+            val reservationStrategy =
+                RecordingReservationStrategy(
+                    strategy = StockContentionStrategy.REDIS,
+                    onLock = {
+                        verify(exactly = 1) { memberRepository.findById(1L) }
+                        verify(exactly = 1) { scheduleStore.findBookingMetadataById(10L) }
+                        verify(exactly = 1) { performanceRepository.findById(20L) }
+                        verify(exactly = 0) { transactionManager.getTransaction(any()) }
+                        lockEntered = true
+                    },
+                    onReserve = { reservationInsideLock = lockEntered },
+                    onUnlock = {
+                        verify(exactly = 1) { transactionManager.commit(transactionStatus) }
+                        commitCompletedBeforeUnlock = true
+                    },
+                )
+
+            every { member.userId } returns 30L
+            every { performance.ticketPrice } returns 100
+            every { transactionManager.getTransaction(any()) } returns transactionStatus
+            every { strategyRegistry.get(StockContentionStrategy.REDIS) } returns
+                reservationStrategy
+            every { memberRepository.findById(1L) } returns member
+            every { scheduleStore.findBookingMetadataById(10L) } returns
+                ScheduleBookingMetadata(performanceId = 20L, bookingOpen = true)
+            every { performanceRepository.findById(20L) } returns performance
+            every { bookingRepository.save(any()) } returns savedBooking()
+
+            experimentService(
+                    strategyRegistry,
+                    memberRepository,
+                    performanceRepository,
+                    bookingRepository,
+                    scheduleStore,
+                    transactionManager,
+                )
+                .createMemberBooking(1L, StockContentionStrategy.REDIS, bookingCommand())
+
+            reservationInsideLock shouldBe true
+            commitCompletedBeforeUnlock shouldBe true
+            verify(exactly = 1) { transactionManager.commit(transactionStatus) }
+            verify(exactly = 1) { bookingRepository.save(any()) }
+        }
+
+        test("Optimistic conflict retry는 공통 조회를 반복하지 않고 reservation transaction만 재시도한다") {
+            val strategyRegistry = mockk<StockContentionStrategyRegistry>()
+            val memberRepository = mockk<MemberRepository>()
+            val performanceRepository = mockk<PerformanceRepository>()
+            val bookingRepository = mockk<BookingRepository>()
+            val scheduleStore = mockk<StockContentionScheduleStore>()
+            val transactionManager = mockk<PlatformTransactionManager>(relaxed = true)
+            val transactionStatus = mockk<TransactionStatus>(relaxed = true)
+            val member = mockk<Member>()
+            val performance = mockk<com.beat.domain.performance.model.Performance>()
+            val reservationStrategy =
+                RecordingReservationStrategy(
+                    strategy = StockContentionStrategy.OPTIMISTIC,
+                    conflictsBeforeAcceptance = 2,
+                )
+
+            every { member.userId } returns 30L
+            every { performance.ticketPrice } returns 100
+            every { transactionManager.getTransaction(any()) } returns transactionStatus
+            every { strategyRegistry.get(StockContentionStrategy.OPTIMISTIC) } returns
+                reservationStrategy
+            every { memberRepository.findById(1L) } returns member
+            every { scheduleStore.findBookingMetadataById(10L) } returns
+                ScheduleBookingMetadata(performanceId = 20L, bookingOpen = true)
+            every { performanceRepository.findById(20L) } returns performance
+            every { bookingRepository.save(any()) } returns savedBooking()
+
+            val response =
+                experimentService(
+                        strategyRegistry,
+                        memberRepository,
+                        performanceRepository,
+                        bookingRepository,
+                        scheduleStore,
+                        transactionManager,
+                    )
+                    .createMemberBooking(1L, StockContentionStrategy.OPTIMISTIC, bookingCommand())
+
+            response.attemptCount shouldBe 3
+            response.outcome shouldBe StockContentionOutcome.ACCEPTED
+            verify(exactly = 1) { memberRepository.findById(1L) }
+            verify(exactly = 1) { scheduleStore.findBookingMetadataById(10L) }
+            verify(exactly = 1) { performanceRepository.findById(20L) }
+            verify(exactly = 3) { transactionManager.getTransaction(any()) }
+            verify(exactly = 2) { transactionManager.rollback(transactionStatus) }
+            verify(exactly = 1) { transactionManager.commit(transactionStatus) }
+            verify(exactly = 1) { bookingRepository.save(any()) }
+        }
     }
 }
 
@@ -207,3 +298,77 @@ private class AcceptingReservationStrategy : StockContentionReservationStrategy 
     override fun reserve(request: StockReservationRequest): StockReservationDecision =
         StockReservationDecision(StockContentionOutcome.ACCEPTED)
 }
+
+private class RecordingReservationStrategy(
+    override val strategy: StockContentionStrategy,
+    private val onLock: () -> Unit = {},
+    private val onReserve: () -> Unit = {},
+    private val onUnlock: () -> Unit = {},
+    private var conflictsBeforeAcceptance: Int = 0,
+) : StockContentionReservationStrategy {
+    override fun reserve(request: StockReservationRequest): StockReservationDecision {
+        onReserve()
+        if (conflictsBeforeAcceptance > 0) {
+            conflictsBeforeAcceptance--
+            throw OptimisticReservationConflict()
+        }
+        return StockReservationDecision(StockContentionOutcome.ACCEPTED)
+    }
+
+    override fun <T> executeWithReservationLock(scheduleId: Long, operation: () -> T): T {
+        onLock()
+        return try {
+            operation()
+        } finally {
+            onUnlock()
+        }
+    }
+}
+
+private fun experimentService(
+    strategyRegistry: StockContentionStrategyRegistry,
+    memberRepository: MemberRepository,
+    performanceRepository: PerformanceRepository,
+    bookingRepository: BookingRepository,
+    scheduleStore: StockContentionScheduleStore,
+    transactionManager: PlatformTransactionManager,
+): StockContentionExperimentService =
+    StockContentionExperimentService(
+        strategyRegistry = strategyRegistry,
+        memberRepository = memberRepository,
+        performanceRepository = performanceRepository,
+        bookingRepository = bookingRepository,
+        scheduleStore = scheduleStore,
+        transactionManager = transactionManager,
+        clock =
+            Clock.fixed(
+                Instant.parse("2026-08-23T00:00:00Z"),
+                ZoneId.of("Asia/Seoul"),
+            ),
+        properties = StockContentionExperimentProperties().apply { optimisticBackoffMillis = 0 },
+    )
+
+private fun bookingCommand(): StockContentionBookingCommand =
+    StockContentionBookingCommand(
+        scheduleId = 10L,
+        purchaseTicketCount = 1,
+        bookerName = "홍길동",
+        bookerPhoneNumber = "010-1234-5678",
+    )
+
+private fun savedBooking(): Booking =
+    Booking.rehydrate(
+        id = 99L,
+        purchaseTicketCount = 1,
+        bookerName = "홍길동",
+        bookerPhoneNumber = "010-1234-5678",
+        bookingStatus = com.beat.domain.booking.model.BookingStatus.CHECKING_PAYMENT,
+        createdAt = LocalDateTime.of(2026, 8, 23, 9, 0),
+        cancellationDate = null,
+        birthDate = null,
+        password = null,
+        refundAccount = null,
+        scheduleId = 10L,
+        userId = 30L,
+        totalPaymentAmount = 100,
+    )

--- a/docs/testing/first-come-booking-concurrency-experiment.md
+++ b/docs/testing/first-come-booking-concurrency-experiment.md
@@ -17,11 +17,13 @@
 | 전략 | 재고 경쟁 방식 | 고정 파라미터 |
 | --- | --- | --- |
 | `PESSIMISTIC` | Schedule row `FOR UPDATE` 후 조건부 차감 | 공통 transaction timeout 30초 |
-| `OPTIMISTIC` | `schedule.version` CAS 실패 시 전체 transaction 재시도 | 최대 50회, backoff 1ms |
+| `OPTIMISTIC` | `schedule.version` CAS 실패 시 reservation transaction 재시도 | 최대 50회, backoff 1ms |
 | `REDIS` | Redis token lock을 획득한 뒤 DB 조건부 차감 | acquire 30초, lease 60초, poll 10ms |
 | `ATOMIC` | 재고 조건을 포함한 단일 `UPDATE` | 사전 재고 read 없음 |
 
-공통 경로는 member 조회, schedule/performance 메타데이터 검증, 예매 가능 시간 확인, 가격 계산, Booking INSERT다. 전략마다 재고 경쟁 부분 외의 비즈니스 동작을 바꾸지 않는다.
+공통 준비 경로는 member 조회, schedule/performance 메타데이터 검증, 예매 가능 시간 확인과 가격
+계산이며 lock/retry 전에 요청당 한 번 실행한다. 이후 네 전략 모두 재고 확보와 Booking INSERT를
+하나의 DB transaction으로 실행한다. Redis lock은 이 transaction 직전에 획득하고 commit 뒤 해제한다.
 
 ## 2. 실행 경로와 안전 경계
 
@@ -179,13 +181,19 @@ RDS의 CloudWatch는 60초 해상도이므로 1초 flash의 원인을 단독으�
 | --- | --- | --- |
 | 정합성/oversell/중복 | DB read-only invariant query | k6 outcome counter |
 | accepted TPS, exact outcome, p50/p95/p99, drain | local k6 JSON summary | 90 Load Test k6 panels |
-| 서버 HTTP RPS | Spring actuator metric | 90 Load Test panel 5 |
-| JVM, Hikari | `02 JVM & Hikari`, 90 panels 6~8 | app metric raw series |
-| dev container CPU/memory | `04 Infrastructure` cAdvisor panels | node CPU/memory |
-| RDS CPU/memory/connection/I/O | `03 Shared RDS / MySQL`, 90 panels 9~13 | CloudWatch 60s points |
+| run identity와 workload 동일성 | `test_id`, `git_sha`, `dataset_hash`, `budget_version` | 90 Load Test selector/identity panel |
+| 서버 HTTP RPS/latency | stock-contention endpoint 전용 Spring actuator metric | 90 Load Test server panels |
+| JVM, GC, process CPU, Hikari | `90 Load Test`와 `02 JVM & Hikari` | app metric raw series |
+| dev node/container CPU·memory | `90 Load Test`와 `04 Infrastructure` | node/cAdvisor raw series |
+| RDS CPU/memory/swap/connection/latency/IOPS/queue | `90 Load Test`와 `03 Shared RDS / MySQL` | CloudWatch 60s points |
+| MySQL QPS/thread/buffer-pool/row-lock | `90 Load Test`와 `03 Shared RDS / MySQL` | shared exporter pre/post delta |
 | Redis 상태 | `04 Infrastructure` Redis panels | experiment response lock timeout |
+| 관측 파이프라인 무결성 | Alloy pending/failed, Cloud discarded samples | `05 Observability Pipeline` |
 
-MySQL exporter는 아직 별도 read-only DSN 설정이 없으므로 buffer-pool physical-read/read-request 패널은 `No data`가 정상이다. RDS IOPS/latency/queue는 CloudWatch로 확인한다. paging을 핵심 결론으로 쓰려면 MySQL exporter를 먼저 구축해야 한다.
+MySQL exporter는 shared RDS를 prod Alloy 한 곳에서만 scrape하며 `env=shared`,
+`scope=beat-shared-rds`로 노출한다. buffer-pool과 row-lock counter는 run 전후 delta를
+기록하되 공유 instance의 외부 접근이 섞일 수 있으므로 단독으로 전략에 귀속하지 않는다.
+RDS IOPS/latency/queue는 CloudWatch 60초 지표로 함께 확인한다.
 
 ## 9. artifact와 결과 보고
 

--- a/load-tests/k6/scenarios/stock-contention/README.md
+++ b/load-tests/k6/scenarios/stock-contention/README.md
@@ -73,57 +73,30 @@ flash는 k6 open arrival-rate 모델이므로 200 VU가 DB transaction 200개와
 ## 실행
 
 dev 서버를 한 번 배포한 뒤, 각 strategy마다 합성 warmup/flash schedule을 같은 초기 상태로
-복원하고 아래 두 profile을 순서대로 실행합니다. reset API는 추가하지 않으므로 fixture 복원은
-실험 운영 절차에서 수행합니다. 각 warmup 뒤 flash 전, 그리고 strategy 사이에는 60초 quiet
-period를 둡니다. 다섯 repetition block은 서로 다른 strategy 순서를 사용합니다.
+복원하고 아래 runner로 profile 하나씩 실행합니다. 이 runner는 macOS 기본 shell이 zsh여도 Bash로
+동작하며 workload 값은 받지 않습니다. reset API는 추가하지 않으므로 fixture 복원과 DB invariant
+검증은 실행자가 별도로 수행해야 합니다.
 
 ```bash
 cd load-tests/k6/scenarios/stock-contention
-set -euo pipefail
-
-GIT_SHA="$(git rev-parse HEAD)"
-DATASET_HASH="$(sha256sum cases.json | awk '{print $1}')"
-
-run_profile() {
-  local strategy="$1"
-  local profile="$2"
-  TARGET_ENV="dev" \
-  BASE_URL="https://api-dev.beatlive.kr" \
-  STRATEGY="${strategy}" \
-  DATA_FILE="./cases.json" \
-  TEST_ID="${TEST_ID}" \
-  GIT_SHA="${GIT_SHA}" \
-  DATASET_HASH="${DATASET_HASH}" \
-  LOAD_PROFILE="${profile}" \
-  K6_OTEL_SERVICE_NAME="beat-k6" \
-  K6_OTEL_METRIC_PREFIX="k6_" \
-  K6_OTEL_SINGLE_COUNTER_FOR_RATE="true" \
-  K6_OTEL_GRPC_EXPORTER_ENDPOINT="127.0.0.1:4327" \
-  K6_OTEL_GRPC_EXPORTER_INSECURE="true" \
-  k6 run --out opentelemetry stock-contention.js
-}
-
-STRATEGY_ORDERS=(
-  "PESSIMISTIC OPTIMISTIC REDIS ATOMIC"
-  "OPTIMISTIC REDIS ATOMIC PESSIMISTIC"
-  "REDIS ATOMIC PESSIMISTIC OPTIMISTIC"
-  "ATOMIC PESSIMISTIC OPTIMISTIC REDIS"
-  "PESSIMISTIC REDIS ATOMIC OPTIMISTIC"
-)
-
-for REPETITION in 1 2 3 4 5; do
-  read -r -a STRATEGIES <<< "${STRATEGY_ORDERS[$((REPETITION - 1))]}"
-  for STRATEGY in "${STRATEGIES[@]}"; do
-    # 매 repetition/strategy마다 동일한 fixture와 dataset을 복원한다.
-    TEST_ID="stock-contention-${STRATEGY}-r${REPETITION}-$(date +%Y%m%d-%H%M%S)"
-    run_profile "${STRATEGY}" warmup
-    sleep 60
-    # flash schedule을 stock 100으로 복원한 뒤 flash를 제공한다.
-    run_profile "${STRATEGY}" flash
-    sleep 60
-  done
-done
+TEST_ID="stock-contention-PESSIMISTIC-r1-$(date +%Y%m%d-%H%M%S)"
+./run-stock-contention.sh PESSIMISTIC warmup "$TEST_ID"
+# 60초 quiet period와 flash fixture read-back 후 실행
+./run-stock-contention.sh PESSIMISTIC flash "$TEST_ID"
 ```
+
+Grafana로 OTLP metric도 보낼 때만 tunnel을 연 뒤 다음 환경변수를 추가합니다.
+
+```bash
+K6_OUTPUT=opentelemetry \
+K6_OTEL_GRPC_EXPORTER_ENDPOINT=127.0.0.1:4327 \
+K6_OTEL_GRPC_EXPORTER_INSECURE=true \
+./run-stock-contention.sh PESSIMISTIC flash "$TEST_ID"
+```
+
+다섯 repetition의 strategy 순서는 아래 rotation 계약을 따르되 자동 반복하지 않습니다. 각
+strategy 앞의 선택적 cleanup/reset/read-back과 종료 뒤 invariant/cooldown 확인이 성공한 뒤에만
+다음 run을 시작해야 하기 때문입니다.
 
 기본 결과 파일은 다음처럼 profile별로 생성됩니다.
 
@@ -134,7 +107,7 @@ summary-<test_id>-flash.json
 
 summary에는 strategy, profile, budget version, case count, accepted/sold_out/
 conflict_exhausted/lock_timeout/unexpected 수, accepted TPS, accepted latency p50/p95/p99,
-attempts, timeouts, dropped, drain time 추정값이 포함됩니다. 최종 schedule stock,
+attempts, optimistic retry 총수와 요청당 평균, timeouts, dropped, drain time 추정값이 포함됩니다. 최종 schedule stock,
 overselling, duplicate booking, negative stock은 DB read-only query로 별도 검증해야 합니다.
 
 ## 판정 지표와 중단
@@ -156,6 +129,7 @@ stock_contention_request_start_elapsed_ms
 stock_contention_completion_elapsed_ms
 stock_contention_drain_time_ms
 stock_contention_attempt_count
+stock_contention_optimistic_retries
 ```
 
 각 custom metric에는 `test_id`, `git_sha`, `strategy`, `phase`가 붙고, 공통 k6

--- a/load-tests/k6/scenarios/stock-contention/run-stock-contention.sh
+++ b/load-tests/k6/scenarios/stock-contention/run-stock-contention.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <PESSIMISTIC|OPTIMISTIC|REDIS|ATOMIC> <warmup|flash> <test-id>" >&2
+}
+
+if [[ $# -ne 3 ]]; then
+  usage
+  exit 64
+fi
+
+strategy="$1"
+profile="$2"
+test_id="$3"
+
+case "$strategy" in
+  PESSIMISTIC | OPTIMISTIC | REDIS | ATOMIC) ;;
+  *)
+    usage
+    exit 64
+    ;;
+esac
+
+case "$profile" in
+  warmup | flash) ;;
+  *)
+    usage
+    exit 64
+    ;;
+esac
+
+if [[ -z "$test_id" || "$test_id" =~ [[:space:]] ]]; then
+  echo "test-id must be non-empty and contain no whitespace." >&2
+  exit 64
+fi
+
+command -v k6 >/dev/null || {
+  echo "k6 is required." >&2
+  exit 69
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+data_file="${DATA_FILE:-$script_dir/cases.json}"
+base_url="${BASE_URL:-https://api-dev.beatlive.kr}"
+git_sha="${GIT_SHA:-$(git -C "$repo_root" rev-parse HEAD)}"
+
+if [[ ! -r "$data_file" ]]; then
+  echo "Dataset is not readable: $data_file" >&2
+  exit 66
+fi
+
+k6_output_args=()
+if [[ -n "${K6_OUTPUT:-}" ]]; then
+  k6_output_args=(--out "$K6_OUTPUT")
+fi
+
+cd "$script_dir"
+TARGET_ENV=dev \
+BASE_URL="$base_url" \
+STRATEGY="$strategy" \
+DATA_FILE="$data_file" \
+TEST_ID="$test_id" \
+GIT_SHA="$git_sha" \
+LOAD_PROFILE="$profile" \
+K6_OTEL_SERVICE_NAME="${K6_OTEL_SERVICE_NAME:-beat-k6}" \
+K6_OTEL_METRIC_PREFIX="${K6_OTEL_METRIC_PREFIX:-k6_}" \
+K6_OTEL_SINGLE_COUNTER_FOR_RATE="${K6_OTEL_SINGLE_COUNTER_FOR_RATE:-true}" \
+k6 run "${k6_output_args[@]}" stock-contention.js

--- a/load-tests/k6/scenarios/stock-contention/stock-contention.js
+++ b/load-tests/k6/scenarios/stock-contention/stock-contention.js
@@ -74,6 +74,7 @@ const REQUEST_START_ELAPSED_METRIC = 'stock_contention_request_start_elapsed_ms'
 const COMPLETION_ELAPSED_METRIC = 'stock_contention_completion_elapsed_ms';
 const DRAIN_TIME_METRIC = 'stock_contention_drain_time_ms';
 const ATTEMPT_COUNT_METRIC = 'stock_contention_attempt_count';
+const OPTIMISTIC_RETRY_METRIC = 'stock_contention_optimistic_retries';
 
 const requestsSubmitted = new Counter(REQUESTS_SUBMITTED_METRIC);
 const bookingsAccepted = new Counter(BOOKINGS_ACCEPTED_METRIC);
@@ -89,6 +90,7 @@ const requestStartElapsed = new Trend(REQUEST_START_ELAPSED_METRIC);
 const completionElapsed = new Trend(COMPLETION_ELAPSED_METRIC);
 const drainTime = new Trend(DRAIN_TIME_METRIC);
 const attemptCount = new Trend(ATTEMPT_COUNT_METRIC);
+const optimisticRetries = new Counter(OPTIMISTIC_RETRY_METRIC);
 
 const exactThresholds = exactOutcomeThresholds(phase);
 const thresholds = {
@@ -106,6 +108,7 @@ addOptionalP95Threshold(thresholds, ACCEPTED_LATENCY_METRIC, config.maxP95Ms);
 export const options = {
   // The response body carries the outcome and attemptCount contract.
   discardResponseBodies: false,
+  summaryTrendStats: ['med', 'p(95)', 'p(99)', 'avg', 'min', 'max', 'count'],
   tags: { ...config.tags, strategy },
   systemTags: ['status', 'method', 'name', 'scenario', 'expected_response', 'error_code'],
   scenarios: {
@@ -178,6 +181,7 @@ export function handleSummary(data) {
   const unexpected = metricCount(data, UNEXPECTED_RESPONSES_METRIC);
   const submitted = metricCount(data, REQUESTS_SUBMITTED_METRIC);
   const timeoutCount = metricCount(data, TIMEOUTS_METRIC);
+  const optimisticRetryCount = metricCount(data, OPTIMISTIC_RETRY_METRIC);
   const droppedValues = metricValues(data, 'dropped_iterations');
   const droppedCount = counterMetricCount(droppedValues);
   const acceptedLatencyValues = metricValues(data, ACCEPTED_LATENCY_METRIC);
@@ -247,6 +251,10 @@ export function handleSummary(data) {
     terminal_latency_ms: latencySummary(terminalLatencyValues, recognized),
     drain_time_metric_ms: latencySummary(drainTimeValues, submitted),
     attempts: attemptsSummary(metricValues(data, ATTEMPT_COUNT_METRIC), submitted),
+    optimistic_retries: {
+      count: optimisticRetryCount,
+      average_per_request: submitted > 0 ? optimisticRetryCount / submitted : null,
+    },
     timeouts: timeoutSummary,
     dropped: {
       ...(droppedValues || {}),
@@ -307,6 +315,10 @@ export default function (runContext) {
   requestTimedOut.add(timedOut, outcomeTags);
   timeouts.add(timedOut ? 1 : 0, outcomeTags);
   attemptCount.add(result?.attemptCount ?? 0, outcomeTags);
+  optimisticRetries.add(
+    strategy === 'OPTIMISTIC' && result ? Math.max(0, result.attemptCount - 1) : 0,
+    outcomeTags,
+  );
   completionElapsed.add(elapsedMs, metricTags);
   drainTime.add(drainElapsedMs, metricTags);
   if (outcome !== 'unexpected') {

--- a/load-tests/k6/tests/stock-contention.test.mjs
+++ b/load-tests/k6/tests/stock-contention.test.mjs
@@ -358,6 +358,19 @@ test('stock contention booking request does not follow redirects', () => {
   assert.match(stockContentionScenarioSource, /redirects:\s*0/);
 });
 
+test('stock contention summary explicitly collects p99 and optimistic retry cost', () => {
+  assert.match(
+    stockContentionScenarioSource,
+    /summaryTrendStats:\s*\['med', 'p\(95\)', 'p\(99\)', 'avg', 'min', 'max', 'count'\]/,
+  );
+  assert.match(
+    stockContentionScenarioSource,
+    /const OPTIMISTIC_RETRY_METRIC = 'stock_contention_optimistic_retries';/,
+  );
+  assert.match(stockContentionScenarioSource, /Math\.max\(0, result\.attemptCount - 1\)/);
+  assert.match(stockContentionScenarioSource, /average_per_request:/);
+});
+
 test('stock contention strategy is restricted to the four comparison strategies', () => {
   assert.equal(validateStrategy('ATOMIC'), 'ATOMIC');
   assert.throws(() => validateStrategy('atomic_update'), /STRATEGY must be/);

--- a/ops/grafana/SOURCES.md
+++ b/ops/grafana/SOURCES.md
@@ -60,10 +60,13 @@ names:
 `mysql_global_status_innodb_buffer_pool_reads` and
 `mysql_global_status_innodb_buffer_pool_read_requests`; it is intentionally
 empty when the shared read-only MySQL exporter is disabled. RDS panels use the
-AWS/RDS `CPUUtilization`, `FreeableMemory`, `DatabaseConnections`,
-`ReadLatency`, and `WriteLatency` metrics with a 60-second period during the
-experiment. The optional EC2 panel uses the AWS/EC2 `CPUCreditBalance` metric,
-an exact `InstanceId` textbox, and its 300-second basic-monitoring period.
+AWS/RDS `CPUUtilization`, `FreeableMemory`, `SwapUsage`,
+`DatabaseConnections`, `ReadLatency`, `WriteLatency`, `ReadIOPS`, `WriteIOPS`,
+`DiskQueueDepth`, and `BurstBalance` metrics with a 60-second period during the
+experiment. `BurstBalance` can be absent for storage configurations where AWS
+does not publish it and must not be interpreted as zero. The optional EC2 panel
+uses the AWS/EC2 `CPUCreditBalance` metric, an exact `InstanceId` textbox, and
+its 300-second basic-monitoring period.
 The names and monitoring-period constraints are from the [Amazon RDS
 metrics](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-metrics.html)
 and [Amazon EC2 CloudWatch metrics](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html)

--- a/ops/grafana/generated/90-load-test.json
+++ b/ops/grafana/generated/90-load-test.json
@@ -45,9 +45,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(rate(k6_http_reqs{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile) (rate(k6_http_reqs{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}}",
+          "legendFormat": "{{test_id}} {{strategy}} {{load_profile}}",
           "range": true,
           "refId": "A"
         }
@@ -96,9 +96,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "100 * sum(rate(k6_http_req_failed_total{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",condition=\"nonzero\"}[$__rate_interval])) / sum(rate(k6_http_reqs{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval]))",
+          "expr": "100 * sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile) (rate(k6_http_req_failed_total{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",condition=\"nonzero\"}[$__rate_interval])) / sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile) (rate(k6_http_reqs{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "failed",
+          "legendFormat": "{{test_id}} {{strategy}} failed",
           "range": true,
           "refId": "A"
         }
@@ -147,9 +147,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (le, strategy, load_profile) (rate(k6_http_req_duration_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile) (rate(k6_http_req_duration_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p95",
+          "legendFormat": "{{test_id}} {{strategy}} p95",
           "range": true,
           "refId": "A"
         },
@@ -159,9 +159,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by (le, strategy, load_profile) (rate(k6_http_req_duration_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile) (rate(k6_http_req_duration_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p99",
+          "legendFormat": "{{test_id}} {{strategy}} p99",
           "range": true,
           "refId": "B"
         }
@@ -210,9 +210,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max(k6_vus{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"})",
+          "expr": "max by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile) (k6_vus{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"})",
           "instant": false,
-          "legendFormat": "VUs",
+          "legendFormat": "{{test_id}} VUs",
           "range": true,
           "refId": "A"
         },
@@ -222,9 +222,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(rate(k6_dropped_iterations{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile) (rate(k6_dropped_iterations{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "dropped iterations",
+          "legendFormat": "{{test_id}} dropped",
           "range": true,
           "refId": "B"
         }
@@ -238,7 +238,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "The business /api selector includes /api/internal/experiments/stock-contention/{strategy}/bookings; compare this server-side RPS with k6 request rate as separate signals.",
+      "description": "Only beat-apis stock-contention requests are included. Server metrics have no k6 test_id, so correlate them with the retained UTC run window.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -273,14 +273,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(rate(http_server_requests_seconds_count{env=~\"$env\",application=~\"$application\",uri=~\"^/api(/.*)?$\",uri!~\"^/(actuator|health|metrics|v3/api-docs|swagger-ui)(/.*)?$|^(UNKNOWN|NOT_FOUND)$\"}[$__rate_interval]))",
+          "expr": "sum by (instance, color, uri) (rate(http_server_requests_seconds_count{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\",uri=~\"^/api/internal/experiments/stock-contention/[^/]+/bookings$\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{application}}",
+          "legendFormat": "{{instance}} {{color}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Server-side RPS",
+      "title": "Experiment endpoint — server-side RPS",
       "transparent": false,
       "type": "timeseries"
     },
@@ -339,7 +339,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max by (application, instance, color, pool) (hikaricp_connections_active{env=~\"$env\",application=~\"$application\",instance=~\"$instance\",color=~\"$color\"} / hikaricp_connections_max{env=~\"$env\",application=~\"$application\",instance=~\"$instance\",color=~\"$color\"})",
+          "expr": "max by (application, instance, color, pool) (hikaricp_connections_active{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"} / hikaricp_connections_max{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"})",
           "instant": false,
           "legendFormat": "{{application}} {{instance}} {{color}} {{pool}}",
           "range": true,
@@ -390,7 +390,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max by (application, instance, color, pool) (hikaricp_connections_pending{env=~\"$env\",application=~\"$application\",instance=~\"$instance\",color=~\"$color\"})",
+          "expr": "max by (application, instance, color, pool) (hikaricp_connections_pending{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"})",
           "instant": false,
           "legendFormat": "{{application}} {{instance}} {{color}} {{pool}}",
           "range": true,
@@ -440,7 +440,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "100 * sum by (application, instance, color) (jvm_memory_used_bytes{area=\"heap\",env=~\"$env\",application=~\"$application\",instance=~\"$instance\",color=~\"$color\"}) / sum by (application, instance, color) (jvm_memory_max_bytes{area=\"heap\",env=~\"$env\",application=~\"$application\",instance=~\"$instance\",color=~\"$color\"})",
+          "expr": "100 * sum by (application, instance, color) (jvm_memory_used_bytes{area=\"heap\",env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"}) / sum by (application, instance, color) (jvm_memory_max_bytes{area=\"heap\",env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"})",
           "instant": false,
           "legendFormat": "{{application}} {{instance}} {{color}}",
           "range": true,
@@ -809,9 +809,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_bookings_accepted{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_bookings_accepted{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} accepted",
+          "legendFormat": "{{test_id}} {{strategy}} accepted",
           "range": true,
           "refId": "A"
         },
@@ -821,9 +821,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_bookings_sold_out{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_bookings_sold_out{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} sold_out",
+          "legendFormat": "{{test_id}} {{strategy}} sold_out",
           "range": true,
           "refId": "B"
         }
@@ -872,9 +872,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_conflict_exhausted{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_conflict_exhausted{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} conflict",
+          "legendFormat": "{{test_id}} {{strategy}} conflict",
           "range": true,
           "refId": "A"
         },
@@ -884,9 +884,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_lock_timeout{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_lock_timeout{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} lock timeout",
+          "legendFormat": "{{test_id}} {{strategy}} lock timeout",
           "range": true,
           "refId": "B"
         }
@@ -935,9 +935,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_unexpected_response{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_unexpected_response{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} unexpected",
+          "legendFormat": "{{test_id}} {{strategy}} unexpected",
           "range": true,
           "refId": "A"
         },
@@ -947,9 +947,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_timeouts{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_timeouts{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} timeout",
+          "legendFormat": "{{test_id}} {{strategy}} timeout",
           "range": true,
           "refId": "B"
         }
@@ -998,9 +998,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_request_timeout_total{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\",condition=\"nonzero\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_request_timeout_total{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\",condition=\"nonzero\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} request timeout rate",
+          "legendFormat": "{{test_id}} {{strategy}} request timeout",
           "range": true,
           "refId": "A"
         },
@@ -1010,9 +1010,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum by (strategy, load_profile, phase) (rate(k6_stock_contention_requests_submitted{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_requests_submitted{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
           "instant": false,
-          "legendFormat": "{{strategy}} submitted",
+          "legendFormat": "{{test_id}} {{strategy}} submitted",
           "range": true,
           "refId": "B"
         }
@@ -1061,9 +1061,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_accepted_latency_ms_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_accepted_latency_ms_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p95",
+          "legendFormat": "{{test_id}} {{strategy}} p95",
           "range": true,
           "refId": "A"
         },
@@ -1073,9 +1073,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_accepted_latency_ms_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_accepted_latency_ms_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p99",
+          "legendFormat": "{{test_id}} {{strategy}} p99",
           "range": true,
           "refId": "B"
         }
@@ -1124,9 +1124,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.5, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_attempt_count_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.5, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_attempt_count_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p50",
+          "legendFormat": "{{test_id}} {{strategy}} p50",
           "range": true,
           "refId": "A"
         },
@@ -1136,9 +1136,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_attempt_count_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_attempt_count_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p99",
+          "legendFormat": "{{test_id}} {{strategy}} p99",
           "range": true,
           "refId": "B"
         }
@@ -1187,9 +1187,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_completion_elapsed_ms_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_completion_elapsed_ms_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p95",
+          "legendFormat": "{{test_id}} {{strategy}} p95",
           "range": true,
           "refId": "A"
         },
@@ -1199,9 +1199,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_completion_elapsed_ms_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_completion_elapsed_ms_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p99",
+          "legendFormat": "{{test_id}} {{strategy}} p99",
           "range": true,
           "refId": "B"
         }
@@ -1250,9 +1250,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_drain_time_ms_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_drain_time_ms_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p95",
+          "legendFormat": "{{test_id}} {{strategy}} p95",
           "range": true,
           "refId": "A"
         },
@@ -1262,9 +1262,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum by (le, strategy, load_profile, phase) (rate(k6_stock_contention_drain_time_ms_bucket{test_id=~\"$test_id\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_drain_time_ms_bucket{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "{{strategy}} {{load_profile}} p99",
+          "legendFormat": "{{test_id}} {{strategy}} p99",
           "range": true,
           "refId": "B"
         }
@@ -1390,15 +1390,1302 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Server-side histogram for only the stock-contention endpoint. The 30s scrape interval makes this supporting evidence; local k6 JSON remains authoritative for the 1s flash.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le, instance, color) (rate(http_server_requests_seconds_bucket{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\",uri=~\"^/api/internal/experiments/stock-contention/[^/]+/bookings$\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "{{instance}} {{color}} p95",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum by (le, instance, color) (rate(http_server_requests_seconds_bucket{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\",uri=~\"^/api/internal/experiments/stock-contention/[^/]+/bookings$\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "{{instance}} {{color}} p99",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Experiment endpoint — server latency p95 / p99",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 96
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "max by (instance, color) (process_cpu_usage{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"})",
+          "instant": false,
+          "legendFormat": "{{instance}} {{color}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "beat-apis process CPU",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Seconds spent in GC per second, summed across cause/action series for the active beat-apis process.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 104
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (instance, color) (rate(jvm_gc_pause_seconds_sum{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{instance}} {{color}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "beat-apis GC pause time rate",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 104
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (instance, color) (rate(jvm_gc_memory_allocated_bytes_total{env=~\"$env\",application=\"beat-apis\",instance=~\"$instance\",color=~\"$color\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{instance}} {{color}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "beat-apis allocation rate",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Node-wide CPU detects noisy-neighbor or host saturation that cannot be attributed to the application strategy.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 112
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\",env=~\"$env\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Selected environment — node CPU",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 112
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "100 * (1 - node_memory_MemAvailable_bytes{env=~\"$env\"} / node_memory_MemTotal_bytes{env=~\"$env\"})",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Selected environment — node memory used",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "All dev containers remain visible so application pressure can be distinguished from Redis, Alloy, nginx or another container.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 120
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (container) (label_replace(rate(container_cpu_usage_seconds_total{env=~\"$env\",container_label_com_docker_compose_service!=\"\"}[$__rate_interval]), \"container\", \"$1\", \"container_label_com_docker_compose_service\", \"(.+)\")) or sum by (container) (label_replace(rate(container_cpu_usage_seconds_total{env=~\"$env\",container_label_com_docker_compose_service=\"\",name!=\"\"}[$__rate_interval]), \"container\", \"$1\", \"name\", \"(.+)\"))",
+          "instant": false,
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Container CPU",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 120
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (container) (label_replace(container_memory_working_set_bytes{env=~\"$env\",container_label_com_docker_compose_service!=\"\"}, \"container\", \"$1\", \"container_label_com_docker_compose_service\", \"(.+)\")) or sum by (container) (label_replace(container_memory_working_set_bytes{env=~\"$env\",container_label_com_docker_compose_service=\"\",name!=\"\"}, \"container\", \"$1\", \"name\", \"(.+)\"))",
+          "instant": false,
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Container memory",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${DS_CLOUDWATCH}"
+      },
+      "description": "AWS/RDS SEARCH is constrained to the entered DBInstanceIdentifier and uses a 60s period for the experiment. Shared RDS is still in scope when the selected target environment is dev.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 128
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${DS_CLOUDWATCH}"
+          },
+          "expression": "SEARCH('{AWS/RDS,DBInstanceIdentifier} MetricName=\"ReadIOPS\" DBInstanceIdentifier=\"$rds_instance_identifier\"', 'Average', 60)",
+          "id": "rds_readiops",
+          "metricEditorMode": 1,
+          "metricQueryType": 0,
+          "namespace": "AWS/RDS",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "ap-northeast-2"
+        }
+      ],
+      "title": "Shared RDS — read IOPS",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${DS_CLOUDWATCH}"
+      },
+      "description": "AWS/RDS SEARCH is constrained to the entered DBInstanceIdentifier and uses a 60s period for the experiment. Shared RDS is still in scope when the selected target environment is dev.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 128
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${DS_CLOUDWATCH}"
+          },
+          "expression": "SEARCH('{AWS/RDS,DBInstanceIdentifier} MetricName=\"WriteIOPS\" DBInstanceIdentifier=\"$rds_instance_identifier\"', 'Average', 60)",
+          "id": "rds_writeiops",
+          "metricEditorMode": 1,
+          "metricQueryType": 0,
+          "namespace": "AWS/RDS",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "ap-northeast-2"
+        }
+      ],
+      "title": "Shared RDS — write IOPS",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${DS_CLOUDWATCH}"
+      },
+      "description": "AWS/RDS SEARCH is constrained to the entered DBInstanceIdentifier and uses a 60s period for the experiment. Shared RDS is still in scope when the selected target environment is dev.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 136
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${DS_CLOUDWATCH}"
+          },
+          "expression": "SEARCH('{AWS/RDS,DBInstanceIdentifier} MetricName=\"DiskQueueDepth\" DBInstanceIdentifier=\"$rds_instance_identifier\"', 'Average', 60)",
+          "id": "rds_diskqueuedepth",
+          "metricEditorMode": 1,
+          "metricQueryType": 0,
+          "namespace": "AWS/RDS",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "ap-northeast-2"
+        }
+      ],
+      "title": "Shared RDS — disk queue",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${DS_CLOUDWATCH}"
+      },
+      "description": "Relevant only when the RDS storage type exposes BurstBalance; otherwise No data is expected.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 136
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${DS_CLOUDWATCH}"
+          },
+          "expression": "SEARCH('{AWS/RDS,DBInstanceIdentifier} MetricName=\"BurstBalance\" DBInstanceIdentifier=\"$rds_instance_identifier\"', 'Minimum', 60)",
+          "id": "rds_burstbalance",
+          "metricEditorMode": 1,
+          "metricQueryType": 0,
+          "namespace": "AWS/RDS",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "ap-northeast-2"
+        }
+      ],
+      "title": "Shared RDS — burst balance",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Shared-instance signal. Compare pre/run/post windows and do not attribute unrelated traffic to a strategy.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 144
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "rate(mysql_global_status_questions{env=\"shared\",scope=\"beat-shared-rds\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "questions",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL queries per second",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 144
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "mysql_global_status_threads_connected{env=\"shared\",scope=\"beat-shared-rds\"}",
+          "instant": false,
+          "legendFormat": "connected",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "mysql_global_status_threads_running{env=\"shared\",scope=\"beat-shared-rds\"}",
+          "instant": false,
+          "legendFormat": "running",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "MySQL connected / running threads",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Shared-RDS cumulative counter converted to waits per second. Compare the same UTC run windows and retain pre/post deltas.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 152
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "rate(mysql_global_status_innodb_row_lock_waits{env=\"shared\",scope=\"beat-shared-rds\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "waits/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "InnoDB row-lock waits",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Milliseconds added to the cumulative InnoDB row-lock wait-time counter per second. This is shared-instance supporting evidence, not request latency.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 152
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "rate(mysql_global_status_innodb_row_lock_time{env=\"shared\",scope=\"beat-shared-rds\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "wait ms/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "InnoDB row-lock wait time rate",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Confirms that REDIS strategy activity reaches the environment-local Redis; it does not measure lock ownership correctness.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 160
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "rate(redis_commands_processed_total{env=~\"$env\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis commands per second",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A sustained pending increase or any failed-sample rate invalidates the observability window even when the application result is correct.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 160
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (remote_name) (prometheus_remote_storage_samples_pending{env=~\"$env\"})",
+          "instant": false,
+          "legendFormat": "{{remote_name}} pending",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (remote_name) (rate(prometheus_remote_storage_samples_failed_total{env=~\"$env\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{remote_name}} failed/s",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Alloy remote-write pending / failed",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANA_CLOUD_USAGE}"
+      },
+      "description": "Keep below the 7,000 operating target and investigate before the tenant limit can cause ingestion loss.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 7000
+              },
+              {
+                "color": "red",
+                "value": 10000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 168
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": []
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANA_CLOUD_USAGE}"
+          },
+          "exemplar": true,
+          "expr": "sum(grafanacloud_instance_active_series)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Grafana Cloud active series",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANA_CLOUD_USAGE}"
+      },
+      "description": "Must remain zero for a valid run; otherwise application, host and RDS correlations may have missing samples.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 168
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANA_CLOUD_USAGE}"
+          },
+          "exemplar": true,
+          "expr": "sum by (reason) (grafanacloud_instance_samples_discarded_per_second{reason=~\"per_user.*|rate_limited\"})",
+          "instant": false,
+          "legendFormat": "{{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Grafana Cloud discarded samples",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "All selected-environment application/cAdvisor/Redis targets and the single shared MySQL target must be present. Blue/Green application color health remains visible in 04/05 for detailed diagnosis.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 176
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "max by (env, job) (up{env=~\"$env\",job=~\"apis|integrations/cadvisor|integrations/redis\"}) or max by (env, job) (up{env=\"shared\",job=\"integrations/mysql\"})",
+          "instant": false,
+          "legendFormat": "{{env}} {{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Required scrape targets",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Must stay close to the configured scrape interval. A rising value means the DB panels are stale even if historical lines remain visible.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 176
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "time() - timestamp(mysql_global_status_uptime{env=\"shared\",scope=\"beat-shared-rds\"})",
+          "instant": false,
+          "legendFormat": "shared MySQL age",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL exporter sample age",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Only OPTIMISTIC should be non-zero. Exact total retries and average per request remain authoritative in the local JSON summary.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 184
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_optimistic_retries{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{test_id}} retries/s",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_optimistic_retries{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval])) / sum by (test_id, git_sha, dataset_hash, budget_version, strategy, load_profile, phase) (rate(k6_stock_contention_requests_submitted{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\",target_env=~\"$env\",scenario=~\"$test_scenario\",strategy=~\"$strategy\",load_profile=~\"$load_profile\",phase=~\"$phase\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{test_id}} retries/request",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Optimistic retry cost",
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 12,
+        "y": 184
+      },
+      "id": 45,
+      "options": {
+        "content": "\n**test_id:** `$test_id`<br>\n**git_sha:** `$git_sha`<br>\n**dataset_hash:** `$dataset_hash`<br>\n**budget_version:** `$budget_version`<br>\n**strategy/profile/phase:** `$strategy / $load_profile / $phase`\n\nMultiple test IDs may be selected for an overlay. Every k6 aggregation retains the full run identity, so different code, fixture or budget versions are never silently merged.\n",
+        "mode": "markdown"
+      },
+      "repeatDirection": "h",
+      "title": "Selected run identity",
+      "transparent": false,
+      "type": "text"
+    },
+    {
       "gridPos": {
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 96
+        "y": 192
       },
       "id": 24,
       "options": {
-        "content": "\n- Select `test_id` first, then strategy, load_profile and phase. User ID, access token and booking ID are never metric tags.\n- k6 OTLP naming assumes Alloy `otelcol.exporter.prometheus.k6 { add_metric_suffixes = false }`: Counter names are unsuffixed, Rate `.total` names become `_total`, and Trend histograms expose `_bucket/_sum/_count` in milliseconds.\n- Grafana histogram p95/p99 values are estimates from exported buckets. Exact outcome counts, TPS, overselling/duplicate checks and exact local percentiles come from the retained JSON summary plus read-only DB invariant query.\n- The /api HTTP selector includes the stock-contention endpoint, so server-side RPS includes this experiment while remaining independent from k6 RPS.\n- CloudWatch RDS panels use a 60s period and require the exact shared DBInstanceIdentifier. EC2 CPUCreditBalance uses the exact InstanceId above and a 300s basic-monitoring period; a blank selector intentionally yields no series.\n- The warm-cache panel is supporting evidence only: shared MySQL exporter collection must be enabled and the physical/read-request comparison does not replace the local/DB verdict.\n- The run must be preflighted against the environment allowlist and workload budget before traffic starts.\n- Shared RDS is always in scope, including when the selected target environment is `dev`.\n- Keep the local JSON summary/artifact after the 14-day metrics window expires.\n",
+        "content": "\n- Select one or more `test_id` values, then confirm git_sha, dataset_hash and budget_version before comparing strategy, load_profile and phase. User ID, access token and booking ID are never metric tags.\n- k6 OTLP naming assumes Alloy `otelcol.exporter.prometheus.k6 { add_metric_suffixes = false }`: Counter names are unsuffixed, Rate `.total` names become `_total`, and Trend histograms expose `_bucket/_sum/_count` in milliseconds.\n- Grafana histogram p95/p99 values are estimates from exported buckets. Exact outcome counts, TPS, overselling/duplicate checks and exact local percentiles come from the retained JSON summary plus read-only DB invariant query.\n- Server HTTP panels select only beat-apis stock-contention routes. Server/JVM/Hikari/container/RDS/MySQL metrics do not carry k6 test_id, so correlate them with the retained UTC run window.\n- CloudWatch RDS panels use a 60s period and require the exact shared DBInstanceIdentifier. EC2 CPUCreditBalance uses the exact InstanceId above and a 300s basic-monitoring period; a blank selector intentionally yields no series.\n- MySQL and CloudWatch are shared-RDS supporting evidence. Buffer-pool, row-lock, IOPS and queue signals do not replace the local/DB verdict and cannot exclusively attribute unrelated shared traffic to one strategy.\n- The run must be preflighted against the environment allowlist and workload budget before traffic starts.\n- Shared RDS is always in scope, including when the selected target environment is `dev`.\n- Keep the local JSON summary/artifact after the 14-day metrics window expires.\n",
         "mode": "markdown"
       },
       "repeatDirection": "h",
@@ -1553,6 +2840,39 @@
       },
       {
         "allowCustomValue": true,
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "description": "Grafana Cloud usage is selected at dashboard load; its UID is never committed.",
+        "includeAll": false,
+        "label": "Grafana Cloud usage",
+        "multi": false,
+        "name": "DS_GRAFANA_CLOUD_USAGE",
+        "query": "prometheus",
+        "regex": "/^grafanacloud-usage$/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allowCustomValue": true,
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "includeAll": false,
+        "label": "Load test",
+        "multi": true,
+        "name": "test_id",
+        "query": "label_values(k6_stock_contention_requests_submitted{target_env=~\"$env\"}, test_id)",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": true,
         "allValue": ".*",
         "auto": false,
         "auto_count": 30,
@@ -1562,11 +2882,49 @@
           "uid": "${DS_PROMETHEUS}"
         },
         "includeAll": true,
-        "label": "Load test",
+        "label": "Deployed Git SHA",
         "multi": false,
-        "name": "test_id",
-        "query": "label_values(k6_http_reqs, test_id)",
-        "refresh": 1,
+        "name": "git_sha",
+        "query": "label_values(k6_stock_contention_requests_submitted{test_id=~\"$test_id\"}, git_sha)",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": true,
+        "allValue": ".*",
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "includeAll": true,
+        "label": "Dataset SHA-256",
+        "multi": false,
+        "name": "dataset_hash",
+        "query": "label_values(k6_stock_contention_requests_submitted{test_id=~\"$test_id\",git_sha=~\"$git_sha\"}, dataset_hash)",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": true,
+        "allValue": ".*",
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "includeAll": true,
+        "label": "Workload budget",
+        "multi": false,
+        "name": "budget_version",
+        "query": "label_values(k6_stock_contention_requests_submitted{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\"}, budget_version)",
+        "refresh": 2,
         "skipUrlSync": false,
         "type": "query"
       },
@@ -1584,8 +2942,8 @@
         "label": "Strategy",
         "multi": false,
         "name": "strategy",
-        "query": "label_values(k6_http_reqs{test_id=~\"$test_id\"}, strategy)",
-        "refresh": 1,
+        "query": "label_values(k6_stock_contention_requests_submitted{test_id=~\"$test_id\",git_sha=~\"$git_sha\",dataset_hash=~\"$dataset_hash\",budget_version=~\"$budget_version\"}, strategy)",
+        "refresh": 2,
         "skipUrlSync": false,
         "type": "query"
       },
@@ -1603,8 +2961,8 @@
         "label": "Load profile",
         "multi": false,
         "name": "load_profile",
-        "query": "label_values(k6_http_reqs{test_id=~\"$test_id\"}, load_profile)",
-        "refresh": 1,
+        "query": "label_values(k6_stock_contention_requests_submitted{test_id=~\"$test_id\",strategy=~\"$strategy\"}, load_profile)",
+        "refresh": 2,
         "skipUrlSync": false,
         "type": "query"
       },
@@ -1623,7 +2981,7 @@
         "multi": false,
         "name": "phase",
         "query": "label_values(k6_stock_contention_requests_submitted{test_id=~\"$test_id\"}, phase)",
-        "refresh": 1,
+        "refresh": 2,
         "skipUrlSync": false,
         "type": "query"
       },

--- a/ops/grafana/src/index.ts
+++ b/ops/grafana/src/index.ts
@@ -123,6 +123,28 @@ function queryVariable(
   return builder;
 }
 
+function loadTestVariable(
+  name: string,
+  label: string,
+  query: string,
+  options: { multi?: boolean; includeAll?: boolean } = {},
+): Builder<VariableModel> {
+  const includeAll = options.includeAll ?? true;
+  const builder = new QueryVariableBuilder(name)
+    .label(label)
+    .query(query)
+    .datasource(PROMETHEUS)
+    .refresh(VariableRefresh.OnTimeRangeChanged)
+    .multi(options.multi ?? false)
+    .includeAll(includeAll);
+
+  if (includeAll) {
+    builder.allValue(".*");
+  }
+
+  return builder;
+}
+
 function dashboardVariables(options: {
   defaultEnvironment: "dev" | "prod";
   logs?: boolean;
@@ -228,29 +250,41 @@ function dashboardVariables(options: {
 
   if (options.loadTest) {
     variables.push(
-      queryVariable(
+      loadTestVariable(
         "test_id",
         "Load test",
-        "label_values(k6_http_reqs, test_id)",
-        PROMETHEUS,
+        'label_values(k6_stock_contention_requests_submitted{target_env=~"$env"}, test_id)',
+        { multi: true, includeAll: false },
       ),
-      queryVariable(
+      loadTestVariable(
+        "git_sha",
+        "Deployed Git SHA",
+        'label_values(k6_stock_contention_requests_submitted{test_id=~"$test_id"}, git_sha)',
+      ),
+      loadTestVariable(
+        "dataset_hash",
+        "Dataset SHA-256",
+        'label_values(k6_stock_contention_requests_submitted{test_id=~"$test_id",git_sha=~"$git_sha"}, dataset_hash)',
+      ),
+      loadTestVariable(
+        "budget_version",
+        "Workload budget",
+        'label_values(k6_stock_contention_requests_submitted{test_id=~"$test_id",git_sha=~"$git_sha",dataset_hash=~"$dataset_hash"}, budget_version)',
+      ),
+      loadTestVariable(
         "strategy",
         "Strategy",
-        'label_values(k6_http_reqs{test_id=~"$test_id"}, strategy)',
-        PROMETHEUS,
+        'label_values(k6_stock_contention_requests_submitted{test_id=~"$test_id",git_sha=~"$git_sha",dataset_hash=~"$dataset_hash",budget_version=~"$budget_version"}, strategy)',
       ),
-      queryVariable(
+      loadTestVariable(
         "load_profile",
         "Load profile",
-        'label_values(k6_http_reqs{test_id=~"$test_id"}, load_profile)',
-        PROMETHEUS,
+        'label_values(k6_stock_contention_requests_submitted{test_id=~"$test_id",strategy=~"$strategy"}, load_profile)',
       ),
-      queryVariable(
+      loadTestVariable(
         "phase",
         "Experiment phase",
         'label_values(k6_stock_contention_requests_submitted{test_id=~"$test_id"}, phase)',
-        PROMETHEUS,
       ),
       new TextBoxVariableBuilder("test_scenario")
         .label("Scenario (optional)")
@@ -1043,21 +1077,23 @@ function loadTest(): DashboardBuilder {
     "90 Load Test",
     "beat-load-test",
     "k6 stock-contention test_id correlation with outcome counters, latency histograms, completion/drain timing, server RPS, JVM/Hikari saturation, shared RDS and an optional burstable load-generator signal. Default environment is dev; prod remains selectable with an explicit shared-RDS warning.",
-    { defaultEnvironment: "dev", cloudwatch: true, loadTest: true, ec2Instance: true },
+    { defaultEnvironment: "dev", cloudwatch: true, cloudUsage: true, loadTest: true, ec2Instance: true },
   );
 
-  const k6Selector = 'test_id=~"$test_id",scenario=~"$test_scenario",strategy=~"$strategy",load_profile=~"$load_profile"';
+  const runIdentitySelector = 'test_id=~"$test_id",git_sha=~"$git_sha",dataset_hash=~"$dataset_hash",budget_version=~"$budget_version",target_env=~"$env"';
+  const k6Selector = `${runIdentitySelector},scenario=~"$test_scenario",strategy=~"$strategy",load_profile=~"$load_profile"`;
   const experimentSelector = `${k6Selector},phase=~"$phase"`;
-  const experimentGroup = "strategy, load_profile, phase";
+  const runGroup = "test_id, git_sha, dataset_hash, budget_version, strategy, load_profile";
+  const experimentGroup = `${runGroup}, phase`;
   const k6Metric = (metric: string) => `k6_${metric}`;
   const experimentRate = (metric: string, extraSelector = "") =>
     `sum by (${experimentGroup}) (rate(${k6Metric(metric)}{${experimentSelector}${extraSelector}}[$__rate_interval]))`;
   const experimentQuantile = (metric: string, quantile: number) =>
     `histogram_quantile(${quantile}, sum by (le, ${experimentGroup}) (rate(${k6Metric(metric)}_bucket{${experimentSelector}}[$__rate_interval])))`;
-  // k6 test_id is emitted by the external runner, not by Spring server metrics.
-  // The server selector intentionally includes every /api route, including the
-  // stock-contention endpoint after its /api prefix was added.
-  const serverSelector = HTTP_SELECTOR;
+  // Server metrics cannot carry the external k6 test_id. Restrict them to the
+  // experiment route and correlate by the retained UTC run window.
+  const loadServiceSelector = 'env=~"$env",application="beat-apis",instance=~"$instance",color=~"$color"';
+  const serverSelector = `${loadServiceSelector},uri=~"^/api/internal/experiments/stock-contention/[^/]+/bookings$"`;
   const rdsExperimentDescription =
     "AWS/RDS SEARCH is constrained to the entered DBInstanceIdentifier and uses a 60s period for the experiment. Shared RDS is still in scope when the selected target environment is dev.";
   const rdsMemoryGuardrail =
@@ -1065,17 +1101,17 @@ function loadTest(): DashboardBuilder {
 
   return builder
     .withPanel(
-      metricPanel(1, "k6 request rate", `sum(rate(k6_http_reqs{${k6Selector}}[$__rate_interval]))`, {
+      metricPanel(1, "k6 request rate", `sum by (${runGroup}) (rate(k6_http_reqs{${k6Selector}}[$__rate_interval]))`, {
         unit: "reqps",
-        legendFormat: "{{strategy}} {{load_profile}}",
+        legendFormat: "{{test_id}} {{strategy}} {{load_profile}}",
         description:
           "k6 Counter http_reqs is exported as k6_http_reqs by Alloy with add_metric_suffixes=false; select test_id, strategy and load profile before comparing runs.",
       }),
     )
     .withPanel(
-      metricPanel(2, "k6 failed request rate", `100 * sum(rate(k6_http_req_failed_total{${k6Selector},condition="nonzero"}[$__rate_interval])) / sum(rate(k6_http_reqs{${k6Selector}}[$__rate_interval]))`, {
+      metricPanel(2, "k6 failed request rate", `100 * sum by (${runGroup}) (rate(k6_http_req_failed_total{${k6Selector},condition="nonzero"}[$__rate_interval])) / sum by (${runGroup}) (rate(k6_http_reqs{${k6Selector}}[$__rate_interval]))`, {
         unit: "percent",
-        legendFormat: "failed",
+        legendFormat: "{{test_id}} {{strategy}} failed",
         description:
           "k6 Rate http_req_failed is exported as k6_http_req_failed_total with condition=nonzero; this is transport/status failure visibility, not the stock outcome verdict.",
       }),
@@ -1084,12 +1120,12 @@ function loadTest(): DashboardBuilder {
       dualMetricPanel(
         3,
         "k6 latency p95 / p99",
-        `histogram_quantile(0.95, sum by (le, strategy, load_profile) (rate(k6_http_req_duration_bucket{${k6Selector}}[$__rate_interval])))`,
-        `histogram_quantile(0.99, sum by (le, strategy, load_profile) (rate(k6_http_req_duration_bucket{${k6Selector}}[$__rate_interval])))`,
+        `histogram_quantile(0.95, sum by (le, ${runGroup}) (rate(k6_http_req_duration_bucket{${k6Selector}}[$__rate_interval])))`,
+        `histogram_quantile(0.99, sum by (le, ${runGroup}) (rate(k6_http_req_duration_bucket{${k6Selector}}[$__rate_interval])))`,
         {
           unit: "ms",
-          firstLegend: "{{strategy}} {{load_profile}} p95",
-          secondLegend: "{{strategy}} {{load_profile}} p99",
+          firstLegend: "{{test_id}} {{strategy}} p95",
+          secondLegend: "{{test_id}} {{strategy}} p99",
           description:
             "k6 Trend http_req_duration is an OTLP histogram in milliseconds; with Alloy add_metric_suffixes=false its classic bucket series is k6_http_req_duration_bucket. Prometheus quantiles are estimates; the local k6 summary remains authoritative.",
         },
@@ -1099,11 +1135,11 @@ function loadTest(): DashboardBuilder {
       dualMetricPanel(
         4,
         "k6 VUs / dropped iterations",
-        `max(k6_vus{${k6Selector}})`,
-        `sum(rate(k6_dropped_iterations{${k6Selector}}[$__rate_interval]))`,
+        `max by (${runGroup}) (k6_vus{${k6Selector}})`,
+        `sum by (${runGroup}) (rate(k6_dropped_iterations{${k6Selector}}[$__rate_interval]))`,
         {
-          firstLegend: "VUs",
-          secondLegend: "dropped iterations",
+          firstLegend: "{{test_id}} VUs",
+          secondLegend: "{{test_id}} dropped",
           unit: "short",
           description:
             "k6 dropped_iterations is a Counter and is exported without an added _total suffix. Any non-zero local dropped count invalidates the stock-contention run.",
@@ -1111,28 +1147,28 @@ function loadTest(): DashboardBuilder {
       ),
     )
     .withPanel(
-      metricPanel(5, "Server-side RPS", `sum(rate(http_server_requests_seconds_count{${serverSelector}}[$__rate_interval]))`, {
+      metricPanel(5, "Experiment endpoint — server-side RPS", `sum by (instance, color, uri) (rate(http_server_requests_seconds_count{${serverSelector}}[$__rate_interval]))`, {
         unit: "reqps",
-        legendFormat: "{{application}}",
-        description: "The business /api selector includes /api/internal/experiments/stock-contention/{strategy}/bookings; compare this server-side RPS with k6 request rate as separate signals.",
+        legendFormat: "{{instance}} {{color}}",
+        description: "Only beat-apis stock-contention requests are included. Server metrics have no k6 test_id, so correlate them with the retained UTC run window.",
       }),
     )
     .withPanel(
-      metricPanel(6, "Server Hikari utilization", `max by (application, instance, color, pool) (hikaricp_connections_active{${HIKARI_SELECTOR}} / hikaricp_connections_max{${HIKARI_SELECTOR}})`, {
+      metricPanel(6, "Server Hikari utilization", `max by (application, instance, color, pool) (hikaricp_connections_active{${loadServiceSelector}} / hikaricp_connections_max{${loadServiceSelector}})`, {
         unit: "percentunit",
         legendFormat: "{{application}} {{instance}} {{color}} {{pool}}",
         description: "Blue/Green pools are evaluated independently; sum(active)/sum(max) is intentionally not used.",
       }),
     )
     .withPanel(
-      metricPanel(7, "Server Hikari pending connections", `max by (application, instance, color, pool) (hikaricp_connections_pending{${HIKARI_SELECTOR}})`, {
+      metricPanel(7, "Server Hikari pending connections", `max by (application, instance, color, pool) (hikaricp_connections_pending{${loadServiceSelector}})`, {
         unit: "short",
         legendFormat: "{{application}} {{instance}} {{color}} {{pool}}",
         description: "Pending waiters indicate pool pressure even when active/max utilization has not reached 100%.",
       }),
     )
     .withPanel(
-      metricPanel(8, "Server JVM heap", `100 * sum by (application, instance, color) (jvm_memory_used_bytes{area="heap",${SERVICE_SELECTOR}}) / sum by (application, instance, color) (jvm_memory_max_bytes{area="heap",${SERVICE_SELECTOR}})`, {
+      metricPanel(8, "Server JVM heap", `100 * sum by (application, instance, color) (jvm_memory_used_bytes{area="heap",${loadServiceSelector}}) / sum by (application, instance, color) (jvm_memory_max_bytes{area="heap",${loadServiceSelector}})`, {
         unit: "percent",
         legendFormat: "{{application}} {{instance}} {{color}}",
       }),
@@ -1211,8 +1247,8 @@ function loadTest(): DashboardBuilder {
         experimentRate("stock_contention_bookings_sold_out"),
         {
           unit: "reqps",
-          firstLegend: "{{strategy}} {{load_profile}} accepted",
-          secondLegend: "{{strategy}} {{load_profile}} sold_out",
+          firstLegend: "{{test_id}} {{strategy}} accepted",
+          secondLegend: "{{test_id}} {{strategy}} sold_out",
           description:
             "Custom k6 Counters are correlated by test_id, git_sha, strategy, phase and load_profile. The local JSON summary and read-only DB invariant decide exact accepted/sold_out counts.",
         },
@@ -1226,8 +1262,8 @@ function loadTest(): DashboardBuilder {
         experimentRate("stock_contention_lock_timeout"),
         {
           unit: "reqps",
-          firstLegend: "{{strategy}} {{load_profile}} conflict",
-          secondLegend: "{{strategy}} {{load_profile}} lock timeout",
+          firstLegend: "{{test_id}} {{strategy}} conflict",
+          secondLegend: "{{test_id}} {{strategy}} lock timeout",
           description:
             "Any conflict_exhausted or lock_timeout sample is a failed experiment outcome, even if the HTTP status is 200.",
         },
@@ -1241,8 +1277,8 @@ function loadTest(): DashboardBuilder {
         experimentRate("stock_contention_timeouts"),
         {
           unit: "reqps",
-          firstLegend: "{{strategy}} unexpected",
-          secondLegend: "{{strategy}} timeout",
+          firstLegend: "{{test_id}} {{strategy}} unexpected",
+          secondLegend: "{{test_id}} {{strategy}} timeout",
           description:
             "The timeout Counter is a terminal request timeout count. For the Rate-based request-timeout signal, see the next panel; both remain separate from local exact counts.",
         },
@@ -1256,8 +1292,8 @@ function loadTest(): DashboardBuilder {
         experimentRate("stock_contention_requests_submitted"),
         {
           unit: "reqps",
-          firstLegend: "{{strategy}} request timeout rate",
-          secondLegend: "{{strategy}} submitted",
+          firstLegend: "{{test_id}} {{strategy}} request timeout",
+          secondLegend: "{{test_id}} {{strategy}} submitted",
           description:
             "Rate metrics retain k6's condition label; condition=nonzero selects timed-out requests. The submitted Counter is shown as a rate to make timeout volume comparable with the planned request stream.",
         },
@@ -1271,8 +1307,8 @@ function loadTest(): DashboardBuilder {
         experimentQuantile("stock_contention_accepted_latency_ms", 0.99),
         {
           unit: "ms",
-          firstLegend: "{{strategy}} {{load_profile}} p95",
-          secondLegend: "{{strategy}} {{load_profile}} p99",
+          firstLegend: "{{test_id}} {{strategy}} p95",
+          secondLegend: "{{test_id}} {{strategy}} p99",
           description:
             "Accepted-only k6 Trend histogram. The Prometheus p95/p99 are histogram_quantile estimates; exact accepted latency percentiles are preserved in the local JSON summary.",
         },
@@ -1286,8 +1322,8 @@ function loadTest(): DashboardBuilder {
         experimentQuantile("stock_contention_attempt_count", 0.99),
         {
           unit: "short",
-          firstLegend: "{{strategy}} {{load_profile}} p50",
-          secondLegend: "{{strategy}} {{load_profile}} p99",
+          firstLegend: "{{test_id}} {{strategy}} p50",
+          secondLegend: "{{test_id}} {{strategy}} p99",
           description:
             "Response attemptCount Trend; values above one expose retry work. The local JSON summary is authoritative for exact samples and maxima.",
         },
@@ -1301,8 +1337,8 @@ function loadTest(): DashboardBuilder {
         experimentQuantile("stock_contention_completion_elapsed_ms", 0.99),
         {
           unit: "ms",
-          firstLegend: "{{strategy}} {{load_profile}} p95",
-          secondLegend: "{{strategy}} {{load_profile}} p99",
+          firstLegend: "{{test_id}} {{strategy}} p95",
+          secondLegend: "{{test_id}} {{strategy}} p99",
           description:
             "Elapsed milliseconds from k6 setup start until each response completed; this makes tail work after the arrival window visible.",
         },
@@ -1316,8 +1352,8 @@ function loadTest(): DashboardBuilder {
         experimentQuantile("stock_contention_drain_time_ms", 0.99),
         {
           unit: "ms",
-          firstLegend: "{{strategy}} {{load_profile}} p95",
-          secondLegend: "{{strategy}} {{load_profile}} p99",
+          firstLegend: "{{test_id}} {{strategy}} p95",
+          secondLegend: "{{test_id}} {{strategy}} p99",
           description:
             "max(0, completion elapsed - planned profile duration). Zero means the response completed inside the planned window; positive values show completion/drain tail. Exact max drain_time_ms remains in local JSON.",
         },
@@ -1342,16 +1378,200 @@ function loadTest(): DashboardBuilder {
       ec2CpuCreditPanel(23),
     )
     .withPanel(
+      dualMetricPanel(
+        26,
+        "Experiment endpoint — server latency p95 / p99",
+        `histogram_quantile(0.95, sum by (le, instance, color) (rate(http_server_requests_seconds_bucket{${serverSelector}}[$__rate_interval])))`,
+        `histogram_quantile(0.99, sum by (le, instance, color) (rate(http_server_requests_seconds_bucket{${serverSelector}}[$__rate_interval])))`,
+        {
+          unit: "s",
+          firstLegend: "{{instance}} {{color}} p95",
+          secondLegend: "{{instance}} {{color}} p99",
+          description: "Server-side histogram for only the stock-contention endpoint. The 30s scrape interval makes this supporting evidence; local k6 JSON remains authoritative for the 1s flash.",
+        },
+      ),
+    )
+    .withPanel(
+      metricPanel(27, "beat-apis process CPU", `max by (instance, color) (process_cpu_usage{${loadServiceSelector}})`, {
+        unit: "percentunit",
+        legendFormat: "{{instance}} {{color}}",
+      }),
+    )
+    .withPanel(
+      metricPanel(28, "beat-apis GC pause time rate", `sum by (instance, color) (rate(jvm_gc_pause_seconds_sum{${loadServiceSelector}}[$__rate_interval]))`, {
+        unit: "s",
+        legendFormat: "{{instance}} {{color}}",
+        description: "Seconds spent in GC per second, summed across cause/action series for the active beat-apis process.",
+      }),
+    )
+    .withPanel(
+      metricPanel(29, "beat-apis allocation rate", `sum by (instance, color) (rate(jvm_gc_memory_allocated_bytes_total{${loadServiceSelector}}[$__rate_interval]))`, {
+        unit: "Bps",
+        legendFormat: "{{instance}} {{color}}",
+      }),
+    )
+    .withPanel(
+      metricPanel(30, "Selected environment — node CPU", `100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle",env=~"$env"}[$__rate_interval])))`, {
+        unit: "percent",
+        legendFormat: "{{instance}}",
+        description: "Node-wide CPU detects noisy-neighbor or host saturation that cannot be attributed to the application strategy.",
+      }),
+    )
+    .withPanel(
+      metricPanel(31, "Selected environment — node memory used", `100 * (1 - node_memory_MemAvailable_bytes{env=~"$env"} / node_memory_MemTotal_bytes{env=~"$env"})`, {
+        unit: "percent",
+        legendFormat: "{{instance}}",
+      }),
+    )
+    .withPanel(
+      metricPanel(32, "Container CPU", cadvisorMetric(
+        (selector) => `rate(container_cpu_usage_seconds_total{${selector}}[$__rate_interval])`,
+      ), {
+        unit: "percentunit",
+        legendFormat: "{{container}}",
+        description: "All dev containers remain visible so application pressure can be distinguished from Redis, Alloy, nginx or another container.",
+      }),
+    )
+    .withPanel(
+      metricPanel(33, "Container memory", cadvisorMetric(
+        (selector) => `container_memory_working_set_bytes{${selector}}`,
+      ), {
+        unit: "bytes",
+        legendFormat: "{{container}}",
+      }),
+    )
+    .withPanel(cloudWatchSearchPanel(34, "Shared RDS — read IOPS", "ReadIOPS", "Average", "short", rdsExperimentDescription, 60))
+    .withPanel(cloudWatchSearchPanel(46, "Shared RDS — write IOPS", "WriteIOPS", "Average", "short", rdsExperimentDescription, 60))
+    .withPanel(cloudWatchSearchPanel(35, "Shared RDS — disk queue", "DiskQueueDepth", "Average", "short", rdsExperimentDescription, 60))
+    .withPanel(cloudWatchSearchPanel(36, "Shared RDS — burst balance", "BurstBalance", "Minimum", "percent", "Relevant only when the RDS storage type exposes BurstBalance; otherwise No data is expected.", 60))
+    .withPanel(
+      metricPanel(37, "MySQL queries per second", `rate(mysql_global_status_questions{${MYSQL_SELECTOR}}[$__rate_interval])`, {
+        unit: "reqps",
+        legendFormat: "questions",
+        description: "Shared-instance signal. Compare pre/run/post windows and do not attribute unrelated traffic to a strategy.",
+      }),
+    )
+    .withPanel(
+      dualMetricPanel(
+        38,
+        "MySQL connected / running threads",
+        `mysql_global_status_threads_connected{${MYSQL_SELECTOR}}`,
+        `mysql_global_status_threads_running{${MYSQL_SELECTOR}}`,
+        { unit: "short", firstLegend: "connected", secondLegend: "running" },
+      ),
+    )
+    .withPanel(
+      metricPanel(
+        39,
+        "InnoDB row-lock waits",
+        `rate(mysql_global_status_innodb_row_lock_waits{${MYSQL_SELECTOR}}[$__rate_interval])`,
+        {
+          unit: "reqps",
+          legendFormat: "waits/s",
+          description: "Shared-RDS cumulative counter converted to waits per second. Compare the same UTC run windows and retain pre/post deltas.",
+        },
+      ),
+    )
+    .withPanel(
+      metricPanel(47, "InnoDB row-lock wait time rate", `rate(mysql_global_status_innodb_row_lock_time{${MYSQL_SELECTOR}}[$__rate_interval])`, {
+        unit: "short",
+        legendFormat: "wait ms/s",
+        description: "Milliseconds added to the cumulative InnoDB row-lock wait-time counter per second. This is shared-instance supporting evidence, not request latency.",
+      }),
+    )
+    .withPanel(
+      metricPanel(40, "Redis commands per second", `rate(redis_commands_processed_total{env=~"$env"}[$__rate_interval])`, {
+        unit: "reqps",
+        legendFormat: "{{instance}}",
+        description: "Confirms that REDIS strategy activity reaches the environment-local Redis; it does not measure lock ownership correctness.",
+      }),
+    )
+    .withPanel(
+      dualMetricPanel(
+        41,
+        "Alloy remote-write pending / failed",
+        `sum by (remote_name) (prometheus_remote_storage_samples_pending{env=~"$env"})`,
+        `sum by (remote_name) (rate(prometheus_remote_storage_samples_failed_total{env=~"$env"}[$__rate_interval]))`,
+        {
+          unit: "short",
+          firstLegend: "{{remote_name}} pending",
+          secondLegend: "{{remote_name}} failed/s",
+          description: "A sustained pending increase or any failed-sample rate invalidates the observability window even when the application result is correct.",
+        },
+      ),
+    )
+    .withPanel(
+      metricPanel(42, "Grafana Cloud active series", "sum(grafanacloud_instance_active_series)", {
+        datasource: CLOUD_USAGE,
+        span: 12,
+        unit: "short",
+        stat: true,
+        thresholds: FREE_PLAN_ACTIVE_SERIES_THRESHOLDS,
+        description: "Keep below the 7,000 operating target and investigate before the tenant limit can cause ingestion loss.",
+      }),
+    )
+    .withPanel(
+      metricPanel(43, "Grafana Cloud discarded samples", 'sum by (reason) (grafanacloud_instance_samples_discarded_per_second{reason=~"per_user.*|rate_limited"})', {
+        datasource: CLOUD_USAGE,
+        unit: "reqps",
+        legendFormat: "{{reason}}",
+        description: "Must remain zero for a valid run; otherwise application, host and RDS correlations may have missing samples.",
+      }),
+    )
+    .withPanel(
+      metricPanel(48, "Required scrape targets", `max by (env, job) (up{env=~"$env",job=~"apis|integrations/cadvisor|integrations/redis"}) or max by (env, job) (up{env="shared",job="integrations/mysql"})`, {
+        unit: "short",
+        legendFormat: "{{env}} {{job}}",
+        description: "All selected-environment application/cAdvisor/Redis targets and the single shared MySQL target must be present. Blue/Green application color health remains visible in 04/05 for detailed diagnosis.",
+      }),
+    )
+    .withPanel(
+      metricPanel(49, "MySQL exporter sample age", `time() - timestamp(mysql_global_status_uptime{${MYSQL_SELECTOR}})`, {
+        unit: "s",
+        legendFormat: "shared MySQL age",
+        description: "Must stay close to the configured scrape interval. A rising value means the DB panels are stale even if historical lines remain visible.",
+      }),
+    )
+    .withPanel(
+      dualMetricPanel(
+        44,
+        "Optimistic retry cost",
+        `sum by (${experimentGroup}) (rate(${k6Metric("stock_contention_optimistic_retries")}{${experimentSelector}}[$__rate_interval]))`,
+        `sum by (${experimentGroup}) (rate(${k6Metric("stock_contention_optimistic_retries")}{${experimentSelector}}[$__rate_interval])) / sum by (${experimentGroup}) (rate(${k6Metric("stock_contention_requests_submitted")}{${experimentSelector}}[$__rate_interval]))`,
+        {
+          unit: "short",
+          firstLegend: "{{test_id}} retries/s",
+          secondLegend: "{{test_id}} retries/request",
+          description: "Only OPTIMISTIC should be non-zero. Exact total retries and average per request remain authoritative in the local JSON summary.",
+        },
+      ),
+    )
+    .withPanel(
+      textPanel(
+        45,
+        "Selected run identity",
+        `
+**test_id:** \`$test_id\`<br>
+**git_sha:** \`$git_sha\`<br>
+**dataset_hash:** \`$dataset_hash\`<br>
+**budget_version:** \`$budget_version\`<br>
+**strategy/profile/phase:** \`$strategy / $load_profile / $phase\`
+
+Multiple test IDs may be selected for an overlay. Every k6 aggregation retains the full run identity, so different code, fixture or budget versions are never silently merged.
+`,
+      ),
+    )
+    .withPanel(
       textPanel(
         24,
         "Load-test observability and safety contract",
         `
-- Select \`test_id\` first, then strategy, load_profile and phase. User ID, access token and booking ID are never metric tags.
+- Select one or more \`test_id\` values, then confirm git_sha, dataset_hash and budget_version before comparing strategy, load_profile and phase. User ID, access token and booking ID are never metric tags.
 - k6 OTLP naming assumes Alloy \`otelcol.exporter.prometheus.k6 { add_metric_suffixes = false }\`: Counter names are unsuffixed, Rate \`.total\` names become \`_total\`, and Trend histograms expose \`_bucket/_sum/_count\` in milliseconds.
 - Grafana histogram p95/p99 values are estimates from exported buckets. Exact outcome counts, TPS, overselling/duplicate checks and exact local percentiles come from the retained JSON summary plus read-only DB invariant query.
-- The /api HTTP selector includes the stock-contention endpoint, so server-side RPS includes this experiment while remaining independent from k6 RPS.
+- Server HTTP panels select only beat-apis stock-contention routes. Server/JVM/Hikari/container/RDS/MySQL metrics do not carry k6 test_id, so correlate them with the retained UTC run window.
 - CloudWatch RDS panels use a 60s period and require the exact shared DBInstanceIdentifier. EC2 CPUCreditBalance uses the exact InstanceId above and a 300s basic-monitoring period; a blank selector intentionally yields no series.
-- The warm-cache panel is supporting evidence only: shared MySQL exporter collection must be enabled and the physical/read-request comparison does not replace the local/DB verdict.
+- MySQL and CloudWatch are shared-RDS supporting evidence. Buffer-pool, row-lock, IOPS and queue signals do not replace the local/DB verdict and cannot exclusively attribute unrelated shared traffic to one strategy.
 - The run must be preflighted against the environment allowlist and workload budget before traffic starts.
 - Shared RDS is always in scope, including when the selected target environment is \`dev\`.
 - Keep the local JSON summary/artifact after the 14-day metrics window expires.


### PR DESCRIPTION
## Related issue 🛠

- N/A

## Work Description ✏️

- 네 가지 재고 경쟁 전략이 공통 준비 조회를 요청당 한 번만 수행하고, 재고 확보와 Booking INSERT만 transaction 경계에서 비교하도록 정리했습니다.
- k6 결과에 optimistic retry 비용과 p99를 기록하고, 고정 실행 명령을 제공했습니다.
- 90 Load Test 대시보드에 test_id, git_sha, dataset_hash, budget_version 기반 실행 격리와 JVM·Hikari·host/container·RDS/MySQL·Redis·remote-write 지표를 추가했습니다.
- 실험 절차와 datasource 근거 문서를 실제 구성에 맞게 갱신했습니다.

## Trouble Shooting ⚽️

- k6 실행 간 시계열이 합쳐지지 않도록 workload identity label을 모든 k6 쿼리에 유지했습니다.
- 서버 지표는 stock-contention endpoint로 제한하고, test_id를 가질 수 없는 인프라 지표는 선택한 UTC 시간 범위로 상관 분석하도록 명시했습니다.
- 정확한 TPS·outcome·percentile은 local k6 JSON, 정합성은 DB invariant를 최종 판정 기준으로 유지합니다.

## Related ScreenShot 📷

- Grafana Git Sync 반영 및 최초 smoke run 이후 첨부 예정

## Uncompleted Tasks 😅

- dev 반영 후 experiment URI label과 stock_contention_optimistic_retries 시계열을 최초 smoke run으로 확인해야 합니다.

## To Reviewers 📢

- 공통 준비 조회가 Redis lock 및 optimistic retry 바깥에 위치하고, 모든 전략의 reservation과 Booking INSERT는 동일 transaction 경계를 유지하는지 확인 부탁드립니다.
- Grafana 패널은 원인 상관관계용이며 local JSON/DB invariant를 대체하지 않습니다.

## Verification ✅

- StockContentionExperimentServiceSpec 통과
- k6 Node tests 26/26 통과
- Grafana typecheck, generate, generated check 통과
- dashboard panel ID 및 CloudWatch datasource assertion 통과
- bash syntax 및 git diff check 통과