### PR TITLE
fix: 부하 실험 측정 계약 보강

### DIFF
--- a/load-tests/k6/scenarios/stock-contention/README.md
+++ b/load-tests/k6/scenarios/stock-contention/README.md
@@ -145,15 +145,20 @@ Grafana Cloud MCP로 run 전 10분 baseline과 실행·cooldown 구간에서 다
 
 현재 k6 발생기는 Mac이므로 발생기에는 AWS CPU credit가 없습니다. 반면 dev application EC2와
 shared `db.t3.micro` RDS는 burstable 계열입니다. RDS db.t3는 AWS가 Unlimited mode로 운영하며,
-EC2는 실제 instance의 credit specification을 실험 전에 AWS Console/CLI로 확인합니다.
+EC2는 실제 instance의 credit specification을 실험 전에 AWS Console/CLI로 확인합니다. runner는
+SOPS의 dev `ansible_host`를 복호화하고 그 public IP에 연결된 running EC2를 AWS에서 역조회하므로,
+다른 계정·instance를 가리키거나 두 instance가 조회되면 실행을 중단합니다. 올바른 AWS profile과
+SOPS key가 준비되어 있어야 합니다.
 
 ```bash
-read -r -p "Dev EC2 InstanceId (i-...): " EC2_INSTANCE_ID
-export EC2_INSTANCE_ID
-export EC2_CPU_CREDITS="$(aws ec2 describe-instance-credit-specifications \
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DEV_HOST="$(sops --decrypt --extract '["ansible_host"]' \
+  "$REPO_ROOT/ops/ansible/inventories/dev/group_vars/all/secrets.sops.yml")"
+EC2_INSTANCE_ID="$(aws ec2 describe-instances \
   --region ap-northeast-2 \
-  --instance-ids "$EC2_INSTANCE_ID" \
-  --query 'InstanceCreditSpecifications[0].CpuCredits' \
+  --filters "Name=network-interface.association.public-ip,Values=$DEV_HOST" \
+            "Name=instance-state-name,Values=running" \
+  --query 'Reservations[].Instances[].InstanceId' \
   --output text)"
 
 aws ec2 describe-instance-credit-specifications \
@@ -161,8 +166,8 @@ aws ec2 describe-instance-credit-specifications \
   --instance-ids "$EC2_INSTANCE_ID"
 ```
 
-runner는 실제 `EC2_INSTANCE_ID`와 조회된 `EC2_CPU_CREDITS`(`standard` 또는 `unlimited`)가
-없으면 실행을 거부하며 두 값을 warmup/flash summary metadata에 저장합니다.
+runner는 이 경로에서 검증한 실제 `EC2_INSTANCE_ID`와 조회된 `EC2_CPU_CREDITS`(`standard` 또는
+`unlimited`)를 warmup/flash summary metadata에 저장합니다.
 
 각 block의 baseline 시작 전 bucket부터 cooldown 종료 뒤 bucket까지 동일 instance의
 `CPUCreditBalance`, `CPUCreditUsage`, `CPUSurplusCreditBalance`,
@@ -196,9 +201,6 @@ dev 서버를 한 번 배포한 뒤, 각 strategy마다 합성 warmup/flash sche
 
 ```bash
 cd load-tests/k6/scenarios/stock-contention
-# 위 AWS 조회를 실행한 동일 shell에서 실제 두 값이 유지되어야 합니다.
-: "${EC2_INSTANCE_ID:?AWS burst credit 절차를 먼저 실행하세요}"
-: "${EC2_CPU_CREDITS:?AWS burst credit 절차를 먼저 실행하세요}"
 TEST_ID="stock-contention-PESSIMISTIC-r1-$(date +%Y%m%d-%H%M%S)"
 ./run-stock-contention.sh PESSIMISTIC warmup "$TEST_ID"
 # 60초 quiet period, S1 snapshot과 flash fixture read-back 후 실행

--- a/load-tests/k6/scenarios/stock-contention/README.md
+++ b/load-tests/k6/scenarios/stock-contention/README.md
@@ -100,10 +100,12 @@ RDS 재시작, cache flush, `drop_caches`, `TRUNCATE`와 광범위한 `DELETE`�
 운영 환경과 다른 상태를 만들거나 다른 서비스에 영향을 줍니다. 대신 모든 strategy에서 동일하게
 warmup한 뒤 60초 quiet period를 두고, 종료 후 최소 90초 동안 baseline 복귀를 확인합니다.
 
-### run 전후 필수 snapshot
+### run 경계별 필수 snapshot
 
-DB에서는 동일 connection으로 flash 직전과 drain 직후 아래 누적값을 같은 순서로 기록하고
-`post - pre` delta를 결과에 남깁니다.
+DB에서는 매 run마다 같은 쿼리 순서로 세 경계를 기록합니다. `S0`는 fixture reset/read-back과
+최초 quiet period 뒤, `S1`은 warmup과 두 번째 quiet period 뒤이자 flash 직전, `S2`는 flash
+drain 직후입니다. 전 구간에 걸쳐 transaction을 열어 두지 않고 각 경계에서 짧은 read-only
+session으로 조회합니다.
 
 ```sql
 SHOW GLOBAL STATUS WHERE Variable_name IN (
@@ -119,6 +121,13 @@ SHOW GLOBAL STATUS WHERE Variable_name IN (
   'Questions'
 );
 ```
+
+누적 counter인 `Innodb_buffer_pool_read_requests`, `Innodb_buffer_pool_reads`,
+`Innodb_buffer_pool_read_ahead`, `Innodb_buffer_pool_read_ahead_evicted`,
+`Innodb_row_lock_waits`, `Innodb_row_lock_time`, `Questions`만 `S1-S0`(warmup)와
+`S2-S1`(flash) delta를 계산합니다. `Innodb_buffer_pool_pages_dirty`, `Threads_connected`,
+`Threads_running`은 gauge이므로 S0/S1/S2 원값과 Grafana 구간 max/average를 기록하고 delta를
+누적량처럼 해석하지 않습니다.
 
 `Innodb_buffer_pool_reads`는 storage까지 간 physical read이고
 `Innodb_buffer_pool_read_requests`는 logical read입니다. `SwapUsage`는 별개의 RDS OS memory
@@ -139,20 +148,35 @@ shared `db.t3.micro` RDS는 burstable 계열입니다. RDS db.t3는 AWS가 Unlim
 EC2는 실제 instance의 credit specification을 실험 전에 AWS Console/CLI로 확인합니다.
 
 ```bash
+read -r -p "Dev EC2 InstanceId (i-...): " EC2_INSTANCE_ID
+export EC2_INSTANCE_ID
+export EC2_CPU_CREDITS="$(aws ec2 describe-instance-credit-specifications \
+  --region ap-northeast-2 \
+  --instance-ids "$EC2_INSTANCE_ID" \
+  --query 'InstanceCreditSpecifications[0].CpuCredits' \
+  --output text)"
+
 aws ec2 describe-instance-credit-specifications \
   --region ap-northeast-2 \
-  --instance-ids <DEV_EC2_INSTANCE_ID>
+  --instance-ids "$EC2_INSTANCE_ID"
 ```
 
-각 block 전후 동일 instance의 `CPUCreditBalance`, `CPUCreditUsage`,
-`CPUSurplusCreditBalance`, `CPUSurplusCreditsCharged`를 CloudWatch/Grafana MCP로 기록합니다.
-EC2 또는 RDS credit balance가 run 중 0에 도달하거나 surplus balance/charged가 새로 증가하면
-다른 CPU credit regime에서 실행된 것이므로 해당 run을 성능 비교에서 제외합니다. Unlimited는
+runner는 실제 `EC2_INSTANCE_ID`와 조회된 `EC2_CPU_CREDITS`(`standard` 또는 `unlimited`)가
+없으면 실행을 거부하며 두 값을 warmup/flash summary metadata에 저장합니다.
+
+각 block의 baseline 시작 전 bucket부터 cooldown 종료 뒤 bucket까지 동일 instance의
+`CPUCreditBalance`, `CPUCreditUsage`, `CPUSurplusCreditBalance`,
+`CPUSurplusCreditsCharged`를 CloudWatch/Grafana MCP에서 5분 해상도로 기록합니다. 관측된 5분
+bucket에서 EC2 또는 RDS credit balance가 0이거나 surplus balance/charged가 직전 bucket보다
+증가하면 해당 run을 제외합니다. 이 지표로 1초 flash 안의 일시적 credit 전환까지 증명할 수는
+없으므로 credit 지표는 block의 실행 regime을 판별하는 정황 근거로만 사용합니다. Unlimited는
 credit 소진 뒤에도 실행을 허용하는 과금 방식이지, 실험 변인이 사라진다는 뜻이 아닙니다.
 
 ### run 무효화 조건
 
+- preflight·fixture read-back 실패 또는 실제 EC2 instance/credit metadata 누락
 - `dropped_iterations`, unexpected response, timeout, lock timeout 또는 DB invariant 실패
+- warmup 900 accepted 또는 flash 100 accepted/100 sold-out 불일치
 - 실행 중 배포·batch·RDS backup·network interruption 발생
 - CPU credit regime 변경 또는 cooldown 뒤 CPU/JVM/Hikari가 baseline으로 복귀하지 않음
 - Hikari acquire timeout이나 지속 pending 발생
@@ -172,9 +196,12 @@ dev 서버를 한 번 배포한 뒤, 각 strategy마다 합성 warmup/flash sche
 
 ```bash
 cd load-tests/k6/scenarios/stock-contention
+# 위 AWS 조회를 실행한 동일 shell에서 실제 두 값이 유지되어야 합니다.
+: "${EC2_INSTANCE_ID:?AWS burst credit 절차를 먼저 실행하세요}"
+: "${EC2_CPU_CREDITS:?AWS burst credit 절차를 먼저 실행하세요}"
 TEST_ID="stock-contention-PESSIMISTIC-r1-$(date +%Y%m%d-%H%M%S)"
 ./run-stock-contention.sh PESSIMISTIC warmup "$TEST_ID"
-# 60초 quiet period와 flash fixture read-back 후 실행
+# 60초 quiet period, S1 snapshot과 flash fixture read-back 후 실행
 ./run-stock-contention.sh PESSIMISTIC flash "$TEST_ID"
 ```
 
@@ -191,6 +218,14 @@ K6_OTEL_GRPC_EXPORTER_INSECURE=true \
 strategy 앞의 선택적 cleanup/reset/read-back과 종료 뒤 invariant/cooldown 확인이 성공한 뒤에만
 다음 run을 시작해야 하기 때문입니다.
 
+| repetition | 실행 순서 |
+| --- | --- |
+| r1 | PESSIMISTIC → OPTIMISTIC → REDIS → ATOMIC |
+| r2 | OPTIMISTIC → REDIS → ATOMIC → PESSIMISTIC |
+| r3 | REDIS → ATOMIC → PESSIMISTIC → OPTIMISTIC |
+| r4 | ATOMIC → PESSIMISTIC → OPTIMISTIC → REDIS |
+| r5 | PESSIMISTIC → REDIS → ATOMIC → OPTIMISTIC |
+
 기본 결과 파일은 다음처럼 profile별로 생성됩니다.
 
 ```text
@@ -198,7 +233,7 @@ summary-<test_id>-warmup.json
 summary-<test_id>-flash.json
 ```
 
-summary에는 strategy, profile, budget version, case count, accepted/sold_out/
+summary에는 strategy, profile, budget version, 실제 EC2 instance ID와 CPU credit mode, case count, accepted/sold_out/
 conflict_exhausted/lock_timeout/unexpected 수, accepted TPS, accepted latency p50/p95/p99,
 attempts, optimistic retry 총수와 요청당 평균, timeouts, dropped, drain time 추정값이 포함됩니다. 최종 schedule stock,
 overselling, duplicate booking, negative stock은 DB read-only query로 별도 검증해야 합니다.
@@ -242,14 +277,8 @@ timeout, dropped iteration threshold를 사용합니다. warmup은 accepted/sold
 정확히 900/0/0으로, flash는 100/100/0으로 검증하고 conflict/lock-timeout과 timeout rate도
 0이어야 합니다.
 
-다음 중 하나라도 발생하면 실행을 폐기합니다.
-
-- preflight 실패
-- fixture data exhausted
-- `dropped_iterations > 0`
-- unexpected response, conflict/lock-timeout 또는 timeout이 1건 이상
-- flash 결과가 accepted 100, sold_out 100이 아님
-- DB invariant 검증 실패
+실행 폐기 여부는 위의 단일 canonical `run 무효화 조건`을 그대로 적용합니다. 이 목록을 모두
+통과하지 않은 run은 summary가 생성됐더라도 strategy 비교에 포함하지 않습니다.
 
 실험 전후 RDS, Hikari, JVM, Redis와 shared DB의 영향을 별도로 기록합니다. 200건 flash의
 p50/p95/p99는 summary에 저장하되, 작은 표본의 대표 latency는 p95로 보고하고 절대 TPS는

--- a/load-tests/k6/scenarios/stock-contention/contract.js
+++ b/load-tests/k6/scenarios/stock-contention/contract.js
@@ -34,6 +34,9 @@ export const STOCK_CONTENTION_EXPERIMENT_PATH = '/api/internal/experiments/stock
 
 export const STOCK_CONTENTION_REQUEST_TIMEOUT = '35s';
 
+const EC2_INSTANCE_ID_PATTERN = /^i-[0-9a-f]{8,17}$/;
+const EC2_CPU_CREDIT_MODES = new Set(['standard', 'unlimited']);
+
 export const STOCK_CONTENTION_RESPONSE_OUTCOMES = Object.freeze([
   'ACCEPTED',
   'SOLD_OUT',
@@ -150,6 +153,18 @@ export function validateStrategy(strategy) {
     throw new Error('STRATEGY must be PESSIMISTIC, OPTIMISTIC, REDIS, or ATOMIC.');
   }
   return strategy;
+}
+
+export function validateExperimentHostMetadata(env) {
+  const ec2InstanceId = String(env.EC2_INSTANCE_ID || '').trim();
+  const ec2CpuCredits = String(env.EC2_CPU_CREDITS || '').trim().toLowerCase();
+  if (!EC2_INSTANCE_ID_PATTERN.test(ec2InstanceId)) {
+    throw new Error('EC2_INSTANCE_ID must be the actual dev EC2 instance ID.');
+  }
+  if (!EC2_CPU_CREDIT_MODES.has(ec2CpuCredits)) {
+    throw new Error('EC2_CPU_CREDITS must be exactly standard or unlimited.');
+  }
+  return Object.freeze({ ec2InstanceId, ec2CpuCredits });
 }
 
 export function stockContentionBookingPath(strategy) {

--- a/load-tests/k6/scenarios/stock-contention/run-stock-contention.sh
+++ b/load-tests/k6/scenarios/stock-contention/run-stock-contention.sh
@@ -36,29 +36,63 @@ if [[ -z "$test_id" || "$test_id" =~ [[:space:]] ]]; then
   exit 64
 fi
 
-command -v k6 >/dev/null || {
-  echo "k6 is required." >&2
-  exit 69
-}
-
-if [[ ! "${EC2_INSTANCE_ID:-}" =~ ^i-[0-9a-f]{8,17}$ ]]; then
-  echo "EC2_INSTANCE_ID must be the actual dev EC2 instance ID." >&2
-  exit 64
-fi
-
-case "${EC2_CPU_CREDITS:-}" in
-  standard | unlimited) ;;
-  *)
-    echo "EC2_CPU_CREDITS must be exactly standard or unlimited." >&2
-    exit 64
-    ;;
-esac
+for required_command in k6 sops aws; do
+  command -v "$required_command" >/dev/null || {
+    echo "$required_command is required." >&2
+    exit 69
+  }
+done
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
 data_file="${DATA_FILE:-$script_dir/cases.json}"
 base_url="${BASE_URL:-https://api-dev.beatlive.kr}"
 git_sha="${GIT_SHA:-$(git -C "$repo_root" rev-parse HEAD)}"
+dev_inventory_secrets="$repo_root/ops/ansible/inventories/dev/group_vars/all/secrets.sops.yml"
+aws_region="ap-northeast-2"
+
+dev_host="$(sops --decrypt --extract '["ansible_host"]' "$dev_inventory_secrets")" || {
+  echo "Unable to decrypt the dev deployment host from SOPS." >&2
+  exit 78
+}
+if [[ ! "$dev_host" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+  echo "The dev deployment host must be an IPv4 address." >&2
+  exit 78
+fi
+
+resolved_instance_id="$(aws ec2 describe-instances \
+  --region "$aws_region" \
+  --filters \
+    "Name=network-interface.association.public-ip,Values=$dev_host" \
+    "Name=instance-state-name,Values=running" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text)" || {
+  echo "Unable to resolve the dev deployment host through AWS." >&2
+  exit 78
+}
+if [[ ! "$resolved_instance_id" =~ ^i-[0-9a-f]{8,17}$ ]]; then
+  echo "The dev deployment host must resolve to exactly one running EC2 instance." >&2
+  exit 78
+fi
+
+resolved_cpu_credits="$(aws ec2 describe-instance-credit-specifications \
+  --region "$aws_region" \
+  --instance-ids "$resolved_instance_id" \
+  --query 'InstanceCreditSpecifications[0].CpuCredits' \
+  --output text)" || {
+  echo "Unable to resolve the dev EC2 CPU credit mode through AWS." >&2
+  exit 78
+}
+case "$resolved_cpu_credits" in
+  standard | unlimited) ;;
+  *)
+    echo "The dev EC2 CPU credit mode must be standard or unlimited." >&2
+    exit 78
+    ;;
+esac
+
+printf 'Verified dev EC2 instance %s with CPU credit mode %s.\n' \
+  "$resolved_instance_id" "$resolved_cpu_credits"
 
 if [[ ! -r "$data_file" ]]; then
   echo "Dataset is not readable: $data_file" >&2
@@ -77,8 +111,8 @@ STRATEGY="$strategy" \
 DATA_FILE="$data_file" \
 TEST_ID="$test_id" \
 GIT_SHA="$git_sha" \
-EC2_INSTANCE_ID="$EC2_INSTANCE_ID" \
-EC2_CPU_CREDITS="$EC2_CPU_CREDITS" \
+EC2_INSTANCE_ID="$resolved_instance_id" \
+EC2_CPU_CREDITS="$resolved_cpu_credits" \
 LOAD_PROFILE="$profile" \
 K6_OTEL_SERVICE_NAME="${K6_OTEL_SERVICE_NAME:-beat-k6}" \
 K6_OTEL_METRIC_PREFIX="${K6_OTEL_METRIC_PREFIX:-k6_}" \

--- a/load-tests/k6/scenarios/stock-contention/run-stock-contention.sh
+++ b/load-tests/k6/scenarios/stock-contention/run-stock-contention.sh
@@ -41,6 +41,19 @@ command -v k6 >/dev/null || {
   exit 69
 }
 
+if [[ ! "${EC2_INSTANCE_ID:-}" =~ ^i-[0-9a-f]{8,17}$ ]]; then
+  echo "EC2_INSTANCE_ID must be the actual dev EC2 instance ID." >&2
+  exit 64
+fi
+
+case "${EC2_CPU_CREDITS:-}" in
+  standard | unlimited) ;;
+  *)
+    echo "EC2_CPU_CREDITS must be exactly standard or unlimited." >&2
+    exit 64
+    ;;
+esac
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
 data_file="${DATA_FILE:-$script_dir/cases.json}"
@@ -64,6 +77,8 @@ STRATEGY="$strategy" \
 DATA_FILE="$data_file" \
 TEST_ID="$test_id" \
 GIT_SHA="$git_sha" \
+EC2_INSTANCE_ID="$EC2_INSTANCE_ID" \
+EC2_CPU_CREDITS="$EC2_CPU_CREDITS" \
 LOAD_PROFILE="$profile" \
 K6_OTEL_SERVICE_NAME="${K6_OTEL_SERVICE_NAME:-beat-k6}" \
 K6_OTEL_METRIC_PREFIX="${K6_OTEL_METRIC_PREFIX:-k6_}" \

--- a/load-tests/k6/scenarios/stock-contention/stock-contention.js
+++ b/load-tests/k6/scenarios/stock-contention/stock-contention.js
@@ -21,6 +21,7 @@ import {
   parseBookingResult,
   stockContentionBookingPath,
   STOCK_CONTENTION_REQUEST_TIMEOUT,
+  validateExperimentHostMetadata,
   validateStrategy,
 } from './contract.js';
 import {
@@ -43,6 +44,7 @@ if (initialConfig.accessToken) {
 }
 
 const strategy = validateStrategy(__ENV.STRATEGY);
+const experimentHost = validateExperimentHostMetadata(__ENV);
 const bookingPath = stockContentionBookingPath(strategy);
 const loadedCases = loadCases(__ENV, initialConfig);
 const { accessToken, request, phaseCaseCount } = loadedCases;
@@ -225,6 +227,8 @@ export function handleSummary(data) {
     total_case_count: loadedCases.totalCases,
     expected_accepted: expected.accepted,
     expected_sold_out: expected.sold_out,
+    ec2_instance_id: experimentHost.ec2InstanceId,
+    ec2_cpu_credits: experimentHost.ec2CpuCredits,
   });
   const summary = JSON.parse(summaryOutput[config.summaryFile]);
   summary.results = {

--- a/load-tests/k6/tests/stock-contention.test.mjs
+++ b/load-tests/k6/tests/stock-contention.test.mjs
@@ -23,6 +23,7 @@ import {
   STOCK_CONTENTION_TOTAL_CASE_COUNT,
   stockContentionBookingPath,
   validateStockCases,
+  validateExperimentHostMetadata,
   validateStrategy,
 } from '../scenarios/stock-contention/contract.js';
 
@@ -67,6 +68,24 @@ function validDataset() {
 test('stock contention target accepts only dev', () => {
   assert.doesNotThrow(() => assertDevOnlyTarget('dev'));
   assert.throws(() => assertDevOnlyTarget('prod'), /dev-only/);
+});
+
+test('stock contention run은 실제 EC2 instance와 CPU credit mode를 요구한다', () => {
+  assert.deepEqual(
+    validateExperimentHostMetadata({
+      EC2_INSTANCE_ID: 'i-0123456789abcdef0',
+      EC2_CPU_CREDITS: 'unlimited',
+    }),
+    { ec2InstanceId: 'i-0123456789abcdef0', ec2CpuCredits: 'unlimited' },
+  );
+  assert.throws(
+    () => validateExperimentHostMetadata({ EC2_CPU_CREDITS: 'unlimited' }),
+    /EC2_INSTANCE_ID/,
+  );
+  assert.throws(
+    () => validateExperimentHostMetadata({ EC2_INSTANCE_ID: 'i-0123456789abcdef0' }),
+    /EC2_CPU_CREDITS/,
+  );
 });
 
 test('stock contention dataset keeps the fixed iteration counts and exact six-field config', () => {
@@ -426,9 +445,13 @@ test('stock contention summary metadata keeps strategy and endpoint in the JSON 
       strategy: 'ATOMIC',
       phase: 'flash',
       endpoint: 'POST /api/internal/experiments/stock-contention/ATOMIC/bookings',
+      ec2_instance_id: 'i-0123456789abcdef0',
+      ec2_cpu_credits: 'unlimited',
     },
   );
   const summary = JSON.parse(output['summary.json']);
   assert.equal(summary.metadata.strategy, 'ATOMIC');
   assert.equal(summary.metadata.endpoint, 'POST /api/internal/experiments/stock-contention/ATOMIC/bookings');
+  assert.equal(summary.metadata.ec2_instance_id, 'i-0123456789abcdef0');
+  assert.equal(summary.metadata.ec2_cpu_credits, 'unlimited');
 });

--- a/scripts/apply-local-dev-booking-migration.sh
+++ b/scripts/apply-local-dev-booking-migration.sh
@@ -10,7 +10,9 @@ set -euo pipefail
 #
 # 1. Shared RDS / InnoDB buffer pool
 #    - Read back performance and schedules 16/17 in the same order every time.
-#    - Capture these global counters immediately before warmup and after flash:
+#    - Capture S0 after reset/read-back and the initial quiet period, S1 after
+#      warmup and the next quiet period (immediately before flash), and S2 after
+#      flash drain. Use the same query and boundary order for every run:
 #        SHOW GLOBAL STATUS WHERE Variable_name IN (
 #          'Innodb_buffer_pool_read_requests',
 #          'Innodb_buffer_pool_reads',
@@ -18,11 +20,14 @@ set -euo pipefail
 #          'Innodb_buffer_pool_read_ahead_evicted',
 #          'Innodb_buffer_pool_pages_dirty'
 #        );
-#    - Treat counter deltas only as shared-RDS context, never as a strategy-
-#      attributable result. SELECT * of three fixture rows does not normalize
-#      the buffer pool and must not be described as cache pre-touch.
-#    - Fixed order: fixture reset/read-back -> quiet >=60s -> pre snapshot ->
-#      warmup -> quiet >=60s -> flash -> post snapshot -> cleanup.
+#    - Use S1-S0 for warmup counter deltas and S2-S1 for flash counter deltas.
+#      Record Innodb_buffer_pool_pages_dirty as boundary snapshots, not a
+#      cumulative delta. Treat all values only as shared-RDS context, never as
+#      a strategy-attributable result. SELECT * of three fixture rows does not
+#      normalize the buffer pool and must not be described as cache pre-touch.
+#    - Fixed order: fixture reset/read-back -> quiet >=60s -> S0 -> warmup ->
+#      quiet >=60s -> S1 -> flash -> drain -> S2 -> cleanup. Do not hold a DB
+#      transaction open across these phases.
 #      Keep warmup bookings until flash completes; cleanup between warmup and
 #      flash would erase part of the cache/table-state control.
 #    - Never restart shared RDS, FLUSH TABLES, drop caches, TRUNCATE, or issue a

--- a/scripts/apply-local-dev-booking-migration.sh
+++ b/scripts/apply-local-dev-booking-migration.sh
@@ -18,7 +18,12 @@ set -euo pipefail
 #          'Innodb_buffer_pool_reads',
 #          'Innodb_buffer_pool_read_ahead',
 #          'Innodb_buffer_pool_read_ahead_evicted',
-#          'Innodb_buffer_pool_pages_dirty'
+#          'Innodb_buffer_pool_pages_dirty',
+#          'Innodb_row_lock_waits',
+#          'Innodb_row_lock_time',
+#          'Threads_connected',
+#          'Threads_running',
+#          'Questions'
 #        );
 #    - Use S1-S0 for warmup counter deltas and S2-S1 for flash counter deltas.
 #      Record Innodb_buffer_pool_pages_dirty as boundary snapshots, not a


### PR DESCRIPTION
## Related issue 🛠

- N/A

## Work Description ✏️

- shared dev/RDS 환경의 변인 통제와 run 무효화 기준을 하나의 canonical 계약으로 정리했습니다.
- DB snapshot을 S0(예열 전), S1(flash 직전), S2(flash 직후)로 통일하고 counter delta와 gauge snapshot을 구분했습니다.
- 실제 dev EC2 InstanceId와 CPU credit mode를 runner에서 필수 검증하고 warmup/flash summary metadata에 저장합니다.
- CloudWatch CPU credit의 5분 해상도 한계와 5회 strategy rotation 순서를 명시했습니다.

## Trouble Shooting ⚽️

- 최신 develop(#639)을 rebase해 동일 README 영역의 충돌을 해소했습니다.
- RDS cache 재시작·강제 flush 대신 동일 warmup, quiet period, cooldown과 경계 snapshot을 사용합니다.

## Related ScreenShot 📷

- 문서·실험 runner 변경으로 해당 없음

## Uncompleted Tasks 😅

- 없음

## To Reviewers 📢

- shared RDS에 영향을 주는 destructive cache reset은 계속 금지합니다.
- EC2 metadata 누락 또는 유효하지 않은 값이면 부하 실행 자체가 중단됩니다.

## Verification ✅

- `node --test load-tests/k6/tests/*.test.mjs` — 27/27 통과
- `bash -n` — runner/migration script 통과
- `shellcheck` — runner/migration script 통과
- `git diff --check` 통과