### PR TITLE
fix: 선착순 예매 실험의 커넥션 경계 보정

### DIFF
--- a/application/frontoffice/src/main/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentService.kt
+++ b/application/frontoffice/src/main/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentService.kt
@@ -65,7 +65,13 @@ class StockContentionExperimentService(
     private val optimisticBackoffNanos =
         properties.optimisticBackoffMillis.coerceIn(0L, MAX_OPTIMISTIC_BACKOFF_MILLIS) *
             NANOS_PER_MILLISECOND
-    private val transactionTemplate =
+    private val preparationTransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
+            isReadOnly = true
+            timeout =
+                properties.transactionTimeoutSeconds.coerceIn(1, MAX_TRANSACTION_TIMEOUT_SECONDS)
+        }
+    private val reservationTransactionTemplate =
         TransactionTemplate(transactionManager).apply {
             timeout =
                 properties.transactionTimeoutSeconds.coerceIn(1, MAX_TRANSACTION_TIMEOUT_SECONDS)
@@ -79,13 +85,17 @@ class StockContentionExperimentService(
         validateBookerContact(command.bookerName, command.bookerPhoneNumber)
         validatePurchaseTicketCount(command.purchaseTicketCount)
 
+        val prepared =
+            checkNotNull(
+                preparationTransactionTemplate.execute { prepareBooking(memberId, command) }
+            )
         val selectedStrategy = strategyRegistry.get(strategy)
         return try {
             selectedStrategy.executeWithReservationLock(command.scheduleId) {
                 if (strategy == StockContentionStrategy.OPTIMISTIC) {
-                    createWithOptimisticRetry(memberId, command, selectedStrategy)
+                    createWithOptimisticRetry(prepared, command, selectedStrategy)
                 } else {
-                    executeReservationAttempt(memberId, command, selectedStrategy, 1)
+                    executeReservationAttempt(prepared, command, selectedStrategy, 1)
                 }
             }
         } catch (_: StockContentionLockTimeout) {
@@ -136,13 +146,13 @@ class StockContentionExperimentService(
     }
 
     private fun createWithOptimisticRetry(
-        memberId: Long,
+        prepared: PreparedStockContentionBooking,
         command: StockContentionBookingCommand,
         strategy: StockContentionReservationStrategy,
     ): StockContentionExperimentResponse {
         for (attempt in 1..optimisticAttemptLimit) {
             try {
-                return executeReservationAttempt(memberId, command, strategy, attempt)
+                return executeReservationAttempt(prepared, command, strategy, attempt)
             } catch (_: OptimisticReservationConflict) {
                 if (attempt == optimisticAttemptLimit) {
                     return StockContentionExperimentResponse(
@@ -165,17 +175,13 @@ class StockContentionExperimentService(
     }
 
     private fun executeReservationAttempt(
-        memberId: Long,
+        prepared: PreparedStockContentionBooking,
         command: StockContentionBookingCommand,
         strategy: StockContentionReservationStrategy,
         attempt: Int,
     ): StockContentionExperimentResponse =
         checkNotNull(
-            transactionTemplate.execute {
-                // Every reservation attempt owns one transaction. Common reads and the stock
-                // mutation therefore share the transaction-bound JPA/JDBC connection, and a
-                // booking can never commit without its corresponding stock reservation.
-                val prepared = prepareBooking(memberId, command)
+            reservationTransactionTemplate.execute {
                 val reservation =
                     strategy.reserve(
                         StockReservationRequest(

--- a/application/frontoffice/src/main/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentService.kt
+++ b/application/frontoffice/src/main/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentService.kt
@@ -79,14 +79,13 @@ class StockContentionExperimentService(
         validateBookerContact(command.bookerName, command.bookerPhoneNumber)
         validatePurchaseTicketCount(command.purchaseTicketCount)
 
-        val prepared = prepareBooking(memberId, command)
         val selectedStrategy = strategyRegistry.get(strategy)
         return try {
             selectedStrategy.executeWithReservationLock(command.scheduleId) {
                 if (strategy == StockContentionStrategy.OPTIMISTIC) {
-                    createWithOptimisticRetry(prepared, command, selectedStrategy)
+                    createWithOptimisticRetry(memberId, command, selectedStrategy)
                 } else {
-                    executeReservationAttempt(prepared, command, selectedStrategy, 1)
+                    executeReservationAttempt(memberId, command, selectedStrategy, 1)
                 }
             }
         } catch (_: StockContentionLockTimeout) {
@@ -137,13 +136,13 @@ class StockContentionExperimentService(
     }
 
     private fun createWithOptimisticRetry(
-        prepared: PreparedStockContentionBooking,
+        memberId: Long,
         command: StockContentionBookingCommand,
         strategy: StockContentionReservationStrategy,
     ): StockContentionExperimentResponse {
         for (attempt in 1..optimisticAttemptLimit) {
             try {
-                return executeReservationAttempt(prepared, command, strategy, attempt)
+                return executeReservationAttempt(memberId, command, strategy, attempt)
             } catch (_: OptimisticReservationConflict) {
                 if (attempt == optimisticAttemptLimit) {
                     return StockContentionExperimentResponse(
@@ -166,13 +165,17 @@ class StockContentionExperimentService(
     }
 
     private fun executeReservationAttempt(
-        prepared: PreparedStockContentionBooking,
+        memberId: Long,
         command: StockContentionBookingCommand,
         strategy: StockContentionReservationStrategy,
         attempt: Int,
     ): StockContentionExperimentResponse =
         checkNotNull(
             transactionTemplate.execute {
+                // Every reservation attempt owns one transaction. Common reads and the stock
+                // mutation therefore share the transaction-bound JPA/JDBC connection, and a
+                // booking can never commit without its corresponding stock reservation.
+                val prepared = prepareBooking(memberId, command)
                 val reservation =
                     strategy.reserve(
                         StockReservationRequest(

--- a/application/frontoffice/src/test/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentServiceSpec.kt
+++ b/application/frontoffice/src/test/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentServiceSpec.kt
@@ -24,6 +24,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionStatus
 
 class StockContentionExperimentServiceSpec : FunSpec() {
@@ -36,6 +37,7 @@ class StockContentionExperimentServiceSpec : FunSpec() {
             val scheduleStore = mockk<StockContentionScheduleStore>()
             val transactionManager = mockk<PlatformTransactionManager>(relaxed = true)
             val transactionStatus = mockk<TransactionStatus>(relaxed = true)
+            val transactionDefinitions = mutableListOf<TransactionDefinition>()
             val clock =
                 Clock.fixed(
                     Instant.parse("2026-08-23T00:00:00Z"),
@@ -85,7 +87,8 @@ class StockContentionExperimentServiceSpec : FunSpec() {
             val savedBooking = savedBooking()
             val reservationStrategy = AcceptingReservationStrategy()
 
-            every { transactionManager.getTransaction(any()) } returns transactionStatus
+            every { transactionManager.getTransaction(capture(transactionDefinitions)) } returns
+                transactionStatus
             every { strategyRegistry.get(StockContentionStrategy.PESSIMISTIC) } returns
                 reservationStrategy
             every { memberRepository.findById(1L) } returns member
@@ -127,6 +130,7 @@ class StockContentionExperimentServiceSpec : FunSpec() {
 
             verify(exactly = 1) { performanceRepository.findById(20L) }
             verify(exactly = 0) { performanceRepository.lockById(20L) }
+            transactionDefinitions.map { it.isReadOnly } shouldBe listOf(true, false)
         }
 
         test("공통 metadata가 닫힌 schedule이면 전략 실행 전에 BOOKING_CLOSED를 반환한다") {
@@ -184,7 +188,7 @@ class StockContentionExperimentServiceSpec : FunSpec() {
             verify(exactly = 0) { scheduleStore.find(any(), any(), any()) }
         }
 
-        test("Redis lock 안에서 공통 조회와 reservation transaction이 함께 실행된다") {
+        test("Redis lock은 공통 read transaction 종료 후 reservation transaction을 감싼다") {
             val strategyRegistry = mockk<StockContentionStrategyRegistry>()
             val memberRepository = mockk<MemberRepository>()
             val performanceRepository = mockk<PerformanceRepository>()
@@ -201,18 +205,19 @@ class StockContentionExperimentServiceSpec : FunSpec() {
                 RecordingReservationStrategy(
                     strategy = StockContentionStrategy.REDIS,
                     onLock = {
-                        verify(exactly = 0) { transactionManager.getTransaction(any()) }
-                        lockEntered = true
-                    },
-                    onReserve = {
-                        reservationInsideLock = lockEntered
                         verify(exactly = 1) { memberRepository.findById(1L) }
                         verify(exactly = 1) { scheduleStore.findBookingMetadataById(10L) }
                         verify(exactly = 1) { performanceRepository.findById(20L) }
                         verify(exactly = 1) { transactionManager.getTransaction(any()) }
+                        verify(exactly = 1) { transactionManager.commit(transactionStatus) }
+                        lockEntered = true
+                    },
+                    onReserve = {
+                        reservationInsideLock = lockEntered
+                        verify(exactly = 2) { transactionManager.getTransaction(any()) }
                     },
                     onUnlock = {
-                        verify(exactly = 1) { transactionManager.commit(transactionStatus) }
+                        verify(exactly = 2) { transactionManager.commit(transactionStatus) }
                         commitCompletedBeforeUnlock = true
                     },
                 )
@@ -240,11 +245,11 @@ class StockContentionExperimentServiceSpec : FunSpec() {
 
             reservationInsideLock shouldBe true
             commitCompletedBeforeUnlock shouldBe true
-            verify(exactly = 1) { transactionManager.commit(transactionStatus) }
+            verify(exactly = 2) { transactionManager.commit(transactionStatus) }
             verify(exactly = 1) { bookingRepository.save(any()) }
         }
 
-        test("Optimistic conflict retry는 공통 조회와 reservation을 시도마다 함께 재실행한다") {
+        test("Optimistic conflict retry는 공통 조회를 반복하지 않고 reservation transaction만 재시도한다") {
             val strategyRegistry = mockk<StockContentionStrategyRegistry>()
             val memberRepository = mockk<MemberRepository>()
             val performanceRepository = mockk<PerformanceRepository>()
@@ -284,12 +289,12 @@ class StockContentionExperimentServiceSpec : FunSpec() {
 
             response.attemptCount shouldBe 3
             response.outcome shouldBe StockContentionOutcome.ACCEPTED
-            verify(exactly = 3) { memberRepository.findById(1L) }
-            verify(exactly = 3) { scheduleStore.findBookingMetadataById(10L) }
-            verify(exactly = 3) { performanceRepository.findById(20L) }
-            verify(exactly = 3) { transactionManager.getTransaction(any()) }
+            verify(exactly = 1) { memberRepository.findById(1L) }
+            verify(exactly = 1) { scheduleStore.findBookingMetadataById(10L) }
+            verify(exactly = 1) { performanceRepository.findById(20L) }
+            verify(exactly = 4) { transactionManager.getTransaction(any()) }
             verify(exactly = 2) { transactionManager.rollback(transactionStatus) }
-            verify(exactly = 1) { transactionManager.commit(transactionStatus) }
+            verify(exactly = 2) { transactionManager.commit(transactionStatus) }
             verify(exactly = 1) { bookingRepository.save(any()) }
         }
     }

--- a/application/frontoffice/src/test/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentServiceSpec.kt
+++ b/application/frontoffice/src/test/kotlin/com/beat/application/frontoffice/booking/booker/experiment/StockContentionExperimentServiceSpec.kt
@@ -184,7 +184,7 @@ class StockContentionExperimentServiceSpec : FunSpec() {
             verify(exactly = 0) { scheduleStore.find(any(), any(), any()) }
         }
 
-        test("Redis lock은 공통 조회가 끝난 뒤 transaction과 reservation을 감싼다") {
+        test("Redis lock 안에서 공통 조회와 reservation transaction이 함께 실행된다") {
             val strategyRegistry = mockk<StockContentionStrategyRegistry>()
             val memberRepository = mockk<MemberRepository>()
             val performanceRepository = mockk<PerformanceRepository>()
@@ -201,13 +201,16 @@ class StockContentionExperimentServiceSpec : FunSpec() {
                 RecordingReservationStrategy(
                     strategy = StockContentionStrategy.REDIS,
                     onLock = {
-                        verify(exactly = 1) { memberRepository.findById(1L) }
-                        verify(exactly = 1) { scheduleStore.findBookingMetadataById(10L) }
-                        verify(exactly = 1) { performanceRepository.findById(20L) }
                         verify(exactly = 0) { transactionManager.getTransaction(any()) }
                         lockEntered = true
                     },
-                    onReserve = { reservationInsideLock = lockEntered },
+                    onReserve = {
+                        reservationInsideLock = lockEntered
+                        verify(exactly = 1) { memberRepository.findById(1L) }
+                        verify(exactly = 1) { scheduleStore.findBookingMetadataById(10L) }
+                        verify(exactly = 1) { performanceRepository.findById(20L) }
+                        verify(exactly = 1) { transactionManager.getTransaction(any()) }
+                    },
                     onUnlock = {
                         verify(exactly = 1) { transactionManager.commit(transactionStatus) }
                         commitCompletedBeforeUnlock = true
@@ -241,7 +244,7 @@ class StockContentionExperimentServiceSpec : FunSpec() {
             verify(exactly = 1) { bookingRepository.save(any()) }
         }
 
-        test("Optimistic conflict retry는 공통 조회를 반복하지 않고 reservation transaction만 재시도한다") {
+        test("Optimistic conflict retry는 공통 조회와 reservation을 시도마다 함께 재실행한다") {
             val strategyRegistry = mockk<StockContentionStrategyRegistry>()
             val memberRepository = mockk<MemberRepository>()
             val performanceRepository = mockk<PerformanceRepository>()
@@ -281,9 +284,9 @@ class StockContentionExperimentServiceSpec : FunSpec() {
 
             response.attemptCount shouldBe 3
             response.outcome shouldBe StockContentionOutcome.ACCEPTED
-            verify(exactly = 1) { memberRepository.findById(1L) }
-            verify(exactly = 1) { scheduleStore.findBookingMetadataById(10L) }
-            verify(exactly = 1) { performanceRepository.findById(20L) }
+            verify(exactly = 3) { memberRepository.findById(1L) }
+            verify(exactly = 3) { scheduleStore.findBookingMetadataById(10L) }
+            verify(exactly = 3) { performanceRepository.findById(20L) }
             verify(exactly = 3) { transactionManager.getTransaction(any()) }
             verify(exactly = 2) { transactionManager.rollback(transactionStatus) }
             verify(exactly = 1) { transactionManager.commit(transactionStatus) }

--- a/apps/api/src/test/kotlin/com/beat/apps/api/booking/experiment/StockContentionConnectionBoundaryIntegrationSpec.kt
+++ b/apps/api/src/test/kotlin/com/beat/apps/api/booking/experiment/StockContentionConnectionBoundaryIntegrationSpec.kt
@@ -1,0 +1,164 @@
+package com.beat.apps.api.booking.experiment
+
+import com.beat.apps.api.ApisApplication
+import com.beat.apps.api.fixture.performanceFixture
+import com.beat.apps.api.fixture.scheduleFixture
+import com.beat.apps.api.fixture.usersFixture
+import com.beat.apps.api.support.BeatTestContainersConfig
+import com.beat.domain.booking.repository.BookingRepository
+import com.beat.domain.member.model.Member
+import com.beat.domain.member.model.SocialType
+import com.beat.domain.member.repository.MemberRepository
+import com.beat.domain.member.vo.SocialIdentity
+import com.beat.domain.performance.repository.PerformanceRepository
+import com.beat.domain.performance.vo.PerformancePeriod
+import com.beat.domain.schedule.model.ScheduleNumber
+import com.beat.domain.schedule.repository.ScheduleRepository
+import com.beat.domain.user.repository.UserRepository
+import com.beat.infrastructure.booking.booker.experiment.StockContentionScheduleVersionPrerequisite
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import javax.sql.DataSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest(
+    classes = [ApisApplication::class],
+    properties =
+        [
+            "booking.experiment.enabled=true",
+            "spring.datasource.hikari.maximum-pool-size=1",
+            "spring.datasource.hikari.connection-timeout=500",
+        ],
+)
+@ActiveProfiles("dev", "test")
+@Import(BeatTestContainersConfig::class)
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class StockContentionConnectionBoundaryIntegrationSpec : FunSpec() {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var dataSource: DataSource
+
+    @Autowired private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired private lateinit var userRepository: UserRepository
+
+    @Autowired private lateinit var memberRepository: MemberRepository
+
+    @Autowired private lateinit var performanceRepository: PerformanceRepository
+
+    @Autowired private lateinit var scheduleRepository: ScheduleRepository
+
+    @Autowired private lateinit var bookingRepository: BookingRepository
+
+    @MockitoBean
+    private lateinit var scheduleVersionPrerequisite: StockContentionScheduleVersionPrerequisite
+
+    init {
+        extension(SpringExtension(SpringTestLifecycleMode.Test))
+
+        test("connection pool이 하나여도 준비 transaction 반환 후 비관적 예매 transaction이 성공한다") {
+            val fixture = createFixture()
+            dataSource.unwrap(HikariDataSource::class.java).maximumPoolSize shouldBe 1
+
+            mockMvc
+                .perform(
+                    post("/api/internal/experiments/stock-contention/PESSIMISTIC/bookings")
+                        .with(authentication(memberAuthentication(fixture.memberId)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """
+                            {
+                              "scheduleId": ${fixture.scheduleId},
+                              "purchaseTicketCount": 1,
+                              "bookerName": "회귀검증예매자",
+                              "bookerPhoneNumber": "010-1234-5678"
+                            }
+                            """
+                                .trimIndent()
+                        )
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.outcome").value("ACCEPTED"))
+                .andExpect(jsonPath("$.bookingId").isNumber)
+
+            checkNotNull(scheduleRepository.findById(fixture.scheduleId))
+                .allocatedTicketCount shouldBe 1
+            bookingRepository.findAll().count { it.scheduleId == fixture.scheduleId } shouldBe 1
+        }
+    }
+
+    private fun createFixture(): Fixture {
+        val databaseNow =
+            checkNotNull(
+                jdbcTemplate.queryForObject("SELECT CURRENT_TIMESTAMP", LocalDateTime::class.java)
+            )
+        val user = userRepository.save(usersFixture())
+        val userId = requireNotNull(user.id)
+        val member =
+            memberRepository.save(
+                Member.create(
+                    nickname = "connection-boundary-$userId",
+                    email = "connection-boundary-$userId@example.com",
+                    userId = userId,
+                    socialIdentity = SocialIdentity.of(SocialType.KAKAO, 8_000_000_000L + userId),
+                )
+            )
+        val performance =
+            performanceRepository.save(
+                performanceFixture(
+                    userId = userId,
+                    ticketPrice = 0,
+                    performancePeriod =
+                        PerformancePeriod.of(
+                            databaseNow.toLocalDate(),
+                            databaseNow.plusDays(2).toLocalDate(),
+                        ),
+                    totalScheduleCount = 1,
+                )
+            )
+        val schedule =
+            scheduleRepository.save(
+                scheduleFixture(
+                    performanceId = requireNotNull(performance.id),
+                    performanceDate = databaseNow.plusDays(1),
+                    bookingCloseAt = databaseNow.plusDays(1).plusHours(2),
+                    totalTicketCount = 2,
+                    scheduleNumber = ScheduleNumber.FIRST,
+                )
+            )
+        return Fixture(
+            memberId = requireNotNull(member.id),
+            scheduleId = requireNotNull(schedule.id),
+        )
+    }
+
+    private fun memberAuthentication(memberId: Long) =
+        UsernamePasswordAuthenticationToken(
+            memberId,
+            null,
+            listOf(SimpleGrantedAuthority("ROLE_MEMBER")),
+        )
+
+    private data class Fixture(val memberId: Long, val scheduleId: Long)
+}

--- a/infrastructure/src/main/resources/application-persistence.yml
+++ b/infrastructure/src/main/resources/application-persistence.yml
@@ -6,6 +6,7 @@ spring:
   jooq:
     sql-dialect: MYSQL
   jpa:
+    open-in-view: false
     properties:
       hibernate:
         dialect: com.beat.infrastructure.config.MysqlCustomDialect

--- a/load-tests/k6/scenarios/stock-contention/README.md
+++ b/load-tests/k6/scenarios/stock-contention/README.md
@@ -70,6 +70,95 @@ profile은 실행 인자로 RPS를 바꾸지 못하도록 `lib/budgets.js`에서
 flash는 k6 open arrival-rate 모델이므로 200 VU가 DB transaction 200개와 같은 의미는
 아닙니다. dropped iteration이 발생하면 결과를 사용하지 않습니다.
 
+## 현재 환경의 변인 통제
+
+이 실험은 cache와 JVM을 매번 강제로 초기화하는 cold-start benchmark가 아니라, 현재 dev의
+steady-state에서 lock strategy만 바꾸는 비교 실험입니다. 통제할 수 있는 것은 고정하고,
+shared RDS·OS cache처럼 안전하게 초기화할 수 없는 것은 같은 방식으로 예열한 뒤 run 전후 값을
+기록합니다.
+
+### 고정하는 조건
+
+- 한 측정 block 동안 동일한 dev Git SHA·Docker image·JVM option·Hikari pool을 유지하고 배포하지 않습니다.
+- 동일한 `cases.json`, endpoint, token, request body, timeout과 versioned workload budget을 사용합니다.
+- warmup/flash schedule은 매 strategy 전에 동일한 stock, sold count, version으로 reset하고 read-back합니다.
+- 동일한 Mac, k6 version, 전원과 네트워크를 사용합니다. Time Machine·대용량 동기화·회의 앱은 중지합니다.
+- strategy별 유효 flash run을 5회 수집하고 문서에 정한 rotation 순서로 실행해 시간·순서 효과를 분산합니다.
+
+### 강제로 초기화하지 않는 상태
+
+- InnoDB buffer pool과 RDS OS page cache
+- JVM JIT, heap과 GC 상태
+- Hikari connection pool
+- Redis 내부 cache와 shared RDS의 소량 외부 트래픽
+
+RDS 재시작, cache flush, `drop_caches`, `TRUNCATE`와 광범위한 `DELETE`는 금지합니다. 이런 조작은
+운영 환경과 다른 상태를 만들거나 다른 서비스에 영향을 줍니다. 대신 모든 strategy에서 동일하게
+warmup한 뒤 60초 quiet period를 두고, 종료 후 최소 90초 동안 baseline 복귀를 확인합니다.
+
+### run 전후 필수 snapshot
+
+DB에서는 동일 connection으로 flash 직전과 drain 직후 아래 누적값을 같은 순서로 기록하고
+`post - pre` delta를 결과에 남깁니다.
+
+```sql
+SHOW GLOBAL STATUS WHERE Variable_name IN (
+  'Innodb_buffer_pool_read_requests',
+  'Innodb_buffer_pool_reads',
+  'Innodb_buffer_pool_read_ahead',
+  'Innodb_buffer_pool_read_ahead_evicted',
+  'Innodb_buffer_pool_pages_dirty',
+  'Innodb_row_lock_waits',
+  'Innodb_row_lock_time',
+  'Threads_connected',
+  'Threads_running',
+  'Questions'
+);
+```
+
+`Innodb_buffer_pool_reads`는 storage까지 간 physical read이고
+`Innodb_buffer_pool_read_requests`는 logical read입니다. `SwapUsage`는 별개의 RDS OS memory
+pressure입니다. shared RDS의 누적값에는 외부 접근이 섞일 수 있으므로 DB delta만으로 strategy의
+우열을 판정하지 않고 같은 UTC 구간의 CloudWatch와 함께 설명합니다.
+
+Grafana Cloud MCP로 run 전 10분 baseline과 실행·cooldown 구간에서 다음을 기록합니다.
+
+- app: process/container/node CPU·memory, JVM heap·GC·allocation, Hikari active/pending
+- RDS: CPU, FreeableMemory, SwapUsage, connection, read/write latency·IOPS, DiskQueueDepth
+- MySQL/Redis: QPS, thread, buffer-pool, row-lock, Redis command rate와 exporter freshness
+- pipeline: Alloy pending/failed, discarded samples, 429와 필수 scrape `up`
+
+### AWS burst credit 통제
+
+현재 k6 발생기는 Mac이므로 발생기에는 AWS CPU credit가 없습니다. 반면 dev application EC2와
+shared `db.t3.micro` RDS는 burstable 계열입니다. RDS db.t3는 AWS가 Unlimited mode로 운영하며,
+EC2는 실제 instance의 credit specification을 실험 전에 AWS Console/CLI로 확인합니다.
+
+```bash
+aws ec2 describe-instance-credit-specifications \
+  --region ap-northeast-2 \
+  --instance-ids <DEV_EC2_INSTANCE_ID>
+```
+
+각 block 전후 동일 instance의 `CPUCreditBalance`, `CPUCreditUsage`,
+`CPUSurplusCreditBalance`, `CPUSurplusCreditsCharged`를 CloudWatch/Grafana MCP로 기록합니다.
+EC2 또는 RDS credit balance가 run 중 0에 도달하거나 surplus balance/charged가 새로 증가하면
+다른 CPU credit regime에서 실행된 것이므로 해당 run을 성능 비교에서 제외합니다. Unlimited는
+credit 소진 뒤에도 실행을 허용하는 과금 방식이지, 실험 변인이 사라진다는 뜻이 아닙니다.
+
+### run 무효화 조건
+
+- `dropped_iterations`, unexpected response, timeout, lock timeout 또는 DB invariant 실패
+- 실행 중 배포·batch·RDS backup·network interruption 발생
+- CPU credit regime 변경 또는 cooldown 뒤 CPU/JVM/Hikari가 baseline으로 복귀하지 않음
+- Hikari acquire timeout이나 지속 pending 발생
+- RDS FreeableMemory·SwapUsage·latency·IOPS·DiskQueueDepth가 사전 baseline에서 지속 이탈
+- Alloy pending/discard/429 때문에 해당 시간대 지표가 유실됨
+
+위 조건을 통과한 run끼리만 비교합니다. 이 방식은 현재 shared dev/RDS에서 strategy의 상대 성능을
+비교하기에는 충분하지만 절대 capacity를 증명하지는 않습니다. 절대 처리 한계가 필요하면 전용 RDS,
+non-burstable application server와 전용 load generator에서 별도 실험합니다.
+
 ## 실행
 
 dev 서버를 한 번 배포한 뒤, 각 strategy마다 합성 warmup/flash schedule을 같은 초기 상태로

--- a/load-tests/k6/scenarios/stock-contention/README.md
+++ b/load-tests/k6/scenarios/stock-contention/README.md
@@ -13,6 +13,10 @@ Conditional Atomic UPDATE 구현을 한 번 배포한 서버에서 비교하는 
 - 요청 timeout은 `35s`로 고정하며 실행 환경에서 덮어쓸 수 없습니다.
 - 서버는 dev profile의 실험 flag 활성화 설정으로 한 번만 배포하고, strategy는 URL 경로로 선택합니다.
 - endpoint는 기존 회원 Bearer 인증과 요청 validation을 그대로 사용합니다.
+- 공통 회원·schedule·performance 조회는 요청당 한 번의 짧은 read-only transaction으로 실행하고
+  connection을 반환합니다. OSIV는 비활성화하며 request 전체에 EntityManager나 connection을 유지하지 않습니다.
+- 각 strategy의 재고 변경과 booking 저장은 하나의 reservation transaction에서 함께 commit 또는 rollback됩니다.
+  Optimistic retry는 공통 조회를 반복하지 않고 reservation transaction만 새로 실행합니다.
 - 실험 endpoint는 `BookingCreatedEvent`를 발행하지 않아 Slack 전송 없이 부하를 측정합니다.
 - 공통 `ACCESS_TOKEN` 환경 변수는 사용하지 않습니다. `cases.json` 최상위의 accessToken 하나를 모든 booking이 공유합니다.
 - `cases.json`은 1,100개 행을 저장하지 않고, k6가 profile별 동일 request를 생성·재사용합니다.


### PR DESCRIPTION
## 문제

PESSIMISTIC warmup에서 요청별 공통 JPA 조회의 connection이 request 종료까지 유지된 상태로 reservation transaction이 두 번째 connection을 요청했습니다. Hikari pool 10개가 `active=10, idle=0, pending=25`로 고갈됐고 30초 timeout이 발생했습니다.

## 변경 내용

- 공통 persistence 설정에서 `spring.jpa.open-in-view=false`로 OSIV를 명시적으로 비활성화했습니다.
- 회원·schedule metadata·performance 공통 조회는 요청당 한 번의 짧은 read-only transaction으로 실행하고 즉시 종료합니다.
- PESSIMISTIC/OPTIMISTIC/ATOMIC/REDIS의 재고 변경과 booking 저장은 기존처럼 하나의 reservation transaction에서 함께 commit/rollback합니다.
- Optimistic retry는 공통 조회를 반복하지 않고 전략별 reservation transaction만 다시 실행합니다.
- Redis lock은 공통 read transaction 종료 후 획득하고 reservation transaction commit 후 해제합니다.
- 실험 README에 위 transaction/connection 경계를 명시했습니다.

## 실험 타당성

- Hikari pool 크기, timeout, RPS, duration을 변경하지 않았으므로 증상을 용량 증설로 숨기지 않습니다.
- 네 전략에 공통인 validation workload는 요청당 정확히 한 번으로 유지합니다.
- strategy별 차이는 lock/CAS/conditional update와 retry 비용에만 남습니다.
- 재고 차감과 booking INSERT의 원자성은 유지됩니다.

## 검증

- `./gradlew :application:frontoffice:test --tests '*StockContentionExperimentServiceSpec' :infrastructure:test --tests '*StockContentionReservationStrategiesSpec'`
- `./gradlew check`

모두 통과했습니다.

`~/.sober/scripts/verify.sh`는 현재 머신에 없어 루트 Gradle `check`로 대체했습니다.

## 배포 후 수용 기준

동일 fixture로 네 전략을 재실행하고 다음을 확인합니다.

- Hikari `pending=0`, timeout 증가 없음
- 한 요청에서 두 connection span이 겹치지 않음
- accepted=100, sold_out=100, dropped=0, unexpected=0
- 네 전략 모두 동일 workload budget과 공통 조회 횟수 유지
